### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ cython
 pyvistaqt
 scikit-learn
 attrs
-pyvista=0.32
+pyvista==0.32
 


### PR DESCRIPTION
Changes made:

* remove unnecessary requirements
* add `pyvista==0.32` as a requirement - there have been some breaking syntax changes since 0.31, so we need 0.32 only.