### PR TITLE
Update GUI

### DIFF
--- a/openep/draw/draw_routines.py
+++ b/openep/draw/draw_routines.py
@@ -181,27 +181,30 @@ def plot_electrograms(times, electrograms, separation=1, names=None, axis=None, 
 
     if axis is None:
         figure, axis = plt.subplots(constrained_layout=True, figsize=(6, 0.4*len(electrograms)))
+    else:
+        figure = axis.get_figure()
 
     # Plot electrograms
-    plt.sca(axis)
+    #plt.sca(axis)
     if electrograms.ndim == 2:  # bipolar voltage
-        plt.plot(times, electrograms.T + separations, label=names, color=colours)
+        axis.plot(times, electrograms.T + separations, label=names, color=colours)
     else:  # unipolar voltages
-        plt.plot(times, electrograms[:, :, 0].T + separations, label=names, color=colours)
-        plt.plot(times, electrograms[:, :, 1].T + separations, label=names, color=colours)
+        axis.plot(times, electrograms[:, :, 0].T + separations, label=names, color=colours)
+        axis.plot(times, electrograms[:, :, 1].T + separations, label=names, color=colours)
 
     # Add names
     if names is not None:
         y_tick_positions = np.arange(electrograms.shape[0]) * separation
-        plt.yticks(y_tick_positions, labels=names)
+        axis.set_yticks(y_tick_positions)
+        axis.set_yticklabels(names)
 
     # Add a horizontal line for each electrogram at its zero voltage position
     for y in separations:
-        plt.axhline(y, color='grey', linestyle='--', linewidth=0.8, alpha=0.6)
+        axis.axhline(y, color='grey', linestyle='--', linewidth=0.8, alpha=0.6)
 
     # Vertical line at time zero (if we know what it is)
     if 0 in times:
-        plt.axvline(0, color="grey", linestyle='--', linewidth=0.8, alpha=0.6)
+        axis.axvline(0, color="grey", linestyle='--', linewidth=0.8, alpha=0.6)
 
     # Remove the border and ticks
     plt.tick_params(axis='both', which='both', length=0)

--- a/openep/draw/draw_routines.py
+++ b/openep/draw/draw_routines.py
@@ -185,7 +185,6 @@ def plot_electrograms(times, electrograms, separation=1, names=None, axis=None, 
         figure = axis.get_figure()
 
     # Plot electrograms
-    #plt.sca(axis)
     if electrograms.ndim == 2:  # bipolar voltage
         axis.plot(times, electrograms.T + separations, label=names, color=colours)
     else:  # unipolar voltages

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -140,13 +140,13 @@ class OpenEpGUI(qtw.QWidget):
     def load_data(self):
         print("Please wait: Loading Data ... ")
         # Loading file from a Dialog Box
-        dlg = qtw.QFileDialog()
-        dlg.setFileMode(qtw.QFileDialog.AnyFile)
+        dialogue.setWindowTitle('Load an OpenEP dataset')
+        dialogue.setDirectory(QtCore.QDir.currentPath())
+        dialogue.setFileMode(QtWidgets.QFileDialog.ExistingFile)
+        dialogue.setNameFilter("MATLAB files (*.mat)")
 
-        if dlg.exec_():
-            self.filenames = dlg.selectedFiles()
-            self.ep_case = openep.load_case(self.filenames[0])
-            self.mesh = self.ep_case.create_mesh()
+            filename = dialogue.selectedFiles()[0]
+            self.case = openep.load_case(filename)
             self.mesh1 = deepcopy(self.mesh)
             self.mesh2 = deepcopy(self.mesh)
             self.volt = self.ep_case.fields.bipolar_voltage

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -18,126 +18,217 @@
 
 
 """
-GUI code for OpenEp
+A GUI for OpenEP-Py.
 """
 import sys
 
-from PyQt5 import QtWidgets, QtCore
+from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import Qt
 from pyvistaqt import QtInteractor
-import numpy as np
-from copy import deepcopy
-import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import (
-    FigureCanvasQTAgg as FigureCanvas
+    FigureCanvasQTAgg as FigureCanvas,
+    NavigationToolbar2QT as NavigationToolbar
 )
+
+import numpy as np
+import matplotlib.pyplot as plt
 
 import openep
 
 
-class OpenEpGUI(QtWidgets.QWidget):
+class DockWidget(QtWidgets.QDockWidget):
+    def __init__(self, title: str):
+        super().__init__(title)
+        self.setTitleBarWidget(QtWidgets.QWidget())
+        self.dockLocationChanged.connect(self.on_dockLocationChanged)
+
+    def on_dockLocationChanged(self):
+        main: QtWidgets.QMainWindow = self.parent()
+        all_dock_widgets = main.findChildren(QtWidgets.QDockWidget)
+
+        for dock_widget in all_dock_widgets:
+            sibling_tabs = main.tabifiedDockWidgets(dock_widget)
+            # If you pull a tab out of a group the other tabs still see it as a sibling while dragging...
+            sibling_tabs = [s for s in sibling_tabs if not s.isFloating()]
+
+            if len(sibling_tabs) != 0:
+                # Hide title bar
+                dock_widget.setTitleBarWidget(QtWidgets.QWidget())
+            else:
+                # Re-enable title bar
+                dock_widget.setTitleBarWidget(None)
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(100, 100)
+
+
+class MplCanvas(FigureCanvas):
+
+    def __init__(self, nrows=1, ncols=1):
+        figure, self.axes = plt.subplots(nrows=nrows, ncols=ncols)
+        super(MplCanvas, self).__init__(figure)
+
+
+class OpenEpGUI(QtWidgets.QMainWindow):
+
     def __init__(self):
+
         super().__init__()
-        self.title = "OpenEP: The open-source solution for electrophysiology data analysis"
-        self.initUI()
-        self.thresholds = False
-        self.minval = 0
-        self.maxval = 2
+        self._initUI()
+        self._add_menu_bar()
+        
         self.egm_point = np.array([0], dtype=int)
 
-    def initUI(self):
-        self.setWindowTitle(self.title)
+        # initial bipolar voltage colourbar limits
+        self._initial_lower_limit_1 = 0
+        self._initial_upper_limit_1 = 2
+        
+        # initial LAT colourbar limits
+        self._initial_lower_limit_2 = 0
+        self._initial_upper_limit_2 = 200
 
-        # # LAYOUTS
-        self.mainLayout = QtWidgets.QVBoxLayout(self)
-        self.menulayout = QtWidgets.QGridLayout(self)
-        self.buttonLayout = QtWidgets.QHBoxLayout(self)
+        self._add_dock_widgets()
 
-        # MenuBar
+    def _initUI(self):
+
+        self.setWindowTitle("OpenEP: The open-source solution for electrophysiology data analysis")
+        self.mainLayout = QtWidgets.QVBoxLayout()
+        self.menulayout = QtWidgets.QGridLayout()
+        self.buttonLayout = QtWidgets.QHBoxLayout()
+    
+    def _add_menu_bar(self):
+
         menubar = QtWidgets.QMenuBar()
         self.menulayout.addWidget(menubar, 0, 0)
         file_menu = menubar.addMenu("File")
-
+        
         self.load_case_act = QtWidgets.QAction("Open File...")
         self.load_case_act.triggered.connect(self.load_data)
         file_menu.addAction(self.load_case_act)
         file_menu.addSeparator()
+        
+    def _add_dock_widgets(self):
 
-        plot_menu = QtWidgets.QMenu("Plots", self)
-        voltage_map_plot_act = QtWidgets.QAction("3-D Voltage Map", self)
-        self.voltage_map_interpolated_plot_act = QtWidgets.QAction(
-            "Interpolated Voltage Plot", self
-        )
-        self.historgram_plot_act = QtWidgets.QAction("Histogram Plot", self)
-        self.egm_plot_act = QtWidgets.QAction("EGM Plot", self)
+        dock_1 = DockWidget("Voltage")
+        dock_2 = DockWidget("LAT")
+        dock_3 = DockWidget("EGMs")
+        dock_4 = DockWidget("Analysis")
 
-        voltage_map_plot_act.triggered.connect(self.plot_3d_map)
-        plot_menu.addAction(voltage_map_plot_act)
+        # Plotter 1 (defaults to bipolar voltage)
+        frame_1 = QtWidgets.QFrame()
+        plotter_1 = QtInteractor(frame_1)
+        plotter_1.background_color = 'white'
+        plotter_1.setMinimumSize(QtCore.QSize(50, 50))
+        self.plotter_1 = plotter_1
+        
+        # Add thresholds to plotter 1
+        self.plotter_1.limitLayout = QtWidgets.QFormLayout(self)
+        
+        self.lower_limit_1 = QtWidgets.QLineEdit("Lower threshold", self.plotter_1)
+        self.lower_limit_1.setStyleSheet("background-color: white; border: 1px solid lightGray;")
+        self.lower_limit_1.setGeometry(200, 10, 50, 40)
+        self.lower_limit_1.setText(str(self._initial_lower_limit_1))
+        self.plotter_1.limitLayout.addRow("Lower threshold", self.lower_limit_1)
+        
+        self.upper_limit_1 = QtWidgets.QLineEdit("Upper threshold", self.plotter_1)
+        self.upper_limit_1.setStyleSheet("background-color: white; border: 1px solid lightGray;")
+        self.upper_limit_1.setGeometry(260, 10, 50, 40)
+        self.upper_limit_1.setText(str(self._initial_upper_limit_1))
+        self.plotter_1.limitLayout.addRow("Upper threshold", self.upper_limit_1)
 
-        self.voltage_map_interpolated_plot_act.triggered.connect(
-            self.plot_interpolated_voltage
-        )
-        plot_menu.addAction(self.voltage_map_interpolated_plot_act)
+        button_set_thresholds_1 = QtWidgets.QPushButton("Set colourbar limits:", self.plotter_1)
+        button_set_thresholds_1.setStyleSheet("background-color: lightGray")
+        button_set_thresholds_1.setGeometry(10, 10, 180, 40)
+        button_set_thresholds_1.clicked.connect(self.update_colourbar_limits_1)
+        self.plotter_1.limitLayout.addRow(button_set_thresholds_1)
+        
+        # Plotter 2 (defaults to LAT)
+        frame_2 = QtWidgets.QFrame()
+        plotter_2= QtInteractor(frame_2)
+        plotter_2.background_color = 'white'
+        plotter_2.setMinimumSize(QtCore.QSize(50, 50))
+        self.plotter_2 = plotter_2
 
-        self.historgram_plot_act.triggered.connect(self.plot_histogram)
-        plot_menu.addAction(self.historgram_plot_act)
+        # Add thresholds to plotter 2
+        self.plotter_2.limitLayout = QtWidgets.QFormLayout(self)        
+        
+        self.lower_limit_2 = QtWidgets.QLineEdit("Lower threshold", self.plotter_2)
+        self.lower_limit_2.setStyleSheet("background-color: white; border: 1px solid lightGray;")
+        self.lower_limit_2.setGeometry(200, 10, 50, 40)
+        self.lower_limit_2.setText(str(self._initial_lower_limit_2))
+        self.plotter_2.limitLayout.addRow("Lower threshold", self.lower_limit_2)
+        
+        self.upper_limit_2 = QtWidgets.QLineEdit("Upper threshold", self.plotter_2)
+        self.upper_limit_2.setStyleSheet("background-color: white; border: 1px solid lightGray;")
+        self.upper_limit_2.setGeometry(260, 10, 50, 40)
+        self.upper_limit_2.setText(str(self._initial_upper_limit_2))
+        self.plotter_2.limitLayout.addRow("Upper threshold", self.upper_limit_2)
 
-        self.egm_plot_act.triggered.connect(self.plot_egm)
-        plot_menu.addAction(self.egm_plot_act)
+        button_set_thresholds_2 = QtWidgets.QPushButton("Set colourbar limits:", self.plotter_2)
+        button_set_thresholds_2.setStyleSheet("background-color: lightGray")
+        button_set_thresholds_2.setGeometry(10, 10, 180, 40)
+        button_set_thresholds_2.clicked.connect(self.update_colourbar_limits_2)
+        self.plotter_2.limitLayout.addRow(button_set_thresholds_2)
 
-        file_menu.addMenu(plot_menu)
+        # MPL canvases
+        # Canvas 1 (EGMs)
+        self.figure_3, self.axis_3 = plt.subplots(ncols=1, nrows=1)
+        self.figure_3.set_facecolor("white")
+        self.canvas_3 = FigureCanvas(self.figure_3)
+        self.axis_3.axis('off')  # hide them until we have data to plot
 
-        file_menu.addSeparator()
+        # Add EGM selections
+        egm_layout = QtWidgets.QFormLayout(self)
+        
+        self.egm_select = QtWidgets.QLineEdit("EGMs", self.canvas_3)
+        self.egm_select.setStyleSheet("background-color: white; border: 1px solid lightGray;")
+        self.egm_select.setGeometry(260, 10, 50, 40)
+        self.egm_select.setText(str(0))
+        egm_layout.addRow("EGMs", self.egm_select)
 
-        self.quit_app_act = QtWidgets.QAction("Quit")
-        self.quit_app_act.triggered.connect(QtWidgets.qApp.quit)
-        file_menu.addAction(self.quit_app_act)
+        button_egm_select = QtWidgets.QPushButton("Select EGMs (indices of points)", self.canvas_3)
+        button_egm_select.setStyleSheet("background-color: lightGray")
+        button_egm_select.setGeometry(10, 10, 240, 40)
+        button_egm_select.clicked.connect(self.plot_electrograms)
+        egm_layout.addRow(button_egm_select)
+        
+        # Create toolbar, passing canvas as first parament, parent (self, the MainWindow) as second.
+        toolbar = NavigationToolbar(self.canvas_3, dock_3)
+        canvas_layout = QtWidgets.QVBoxLayout()
+        canvas_layout.addWidget(self.canvas_3)
+        canvas_layout.addWidget(toolbar)
 
-        menubar.addMenu("Edit")
-        menubar.addMenu("View")
-        menubar.addMenu("Help")
+        # Create a placeholder widget to hold our toolbar and canvas.
+        canvas_widget = QtWidgets.QWidget()
+        canvas_widget.setLayout(canvas_layout)
+        canvas_widget.setStyleSheet("border-width: 0px; border: 0px; background-color:white;")
 
-        # Plot
-        self.plotLayout = QtWidgets.QGridLayout()
-        self.plotLayout.setColumnStretch(0, 5)
-        self.plotLayout.setColumnStretch(1, 5)
+        # Other analysis (e.g. histogram of voltages)
+        content4 = QtWidgets.QWidget()
+        content4.setStyleSheet("background-color:white;")
+        content4.setMinimumSize(QtCore.QSize(50, 50))
 
-        self.frame = QtWidgets.QFrame()
-        self.plotter = QtInteractor(self.frame)
-        self.plotLayout.addWidget(self.plotter.interactor, 0, 0)
+        dock_1.setWidget(self.plotter_1)
+        dock_2.setWidget(self.plotter_2)
+        dock_3.setWidget(canvas_widget)
+        dock_4.setWidget(content4)
+        
+        self.addDockWidget(Qt.LeftDockWidgetArea, dock_1)
+        self.addDockWidget(Qt.LeftDockWidgetArea, dock_2)
+        self.tabifyDockWidget(dock_1, dock_2)
+        self.addDockWidget(Qt.RightDockWidgetArea, dock_3)
+        self.addDockWidget(Qt.LeftDockWidgetArea, dock_4)
+        self.tabifyDockWidget(dock_3, dock_4)
 
-        # # VoltThresholds limit
-        self.limitLayout = QtWidgets.QFormLayout(self)
-        self.lowerlimit = QtWidgets.QLineEdit()
-        self.upperlimit = QtWidgets.QLineEdit()
-        self.lowerlimit.setText(str(0))
-        self.upperlimit.setText(str(2))
-        self.limitLayout.addRow("Voltage Threshold - Lower", self.lowerlimit)
-        self.limitLayout.addRow("Voltage Threshold - Upper", self.upperlimit)
+        self.setDockOptions(self.GroupedDragging | self.AllowTabbedDocks | self.AllowNestedDocks)
+        self.setTabPosition(Qt.AllDockWidgetAreas, QtWidgets.QTabWidget.North)
 
-        button_set_thresholds = QtWidgets.QPushButton("Set Voltage Thresholds", self)
-        button_set_thresholds.setGeometry(200, 150, 100, 40)
-        button_set_thresholds.clicked.connect(self.update_voltage_threshold)
-        self.limitLayout.addRow(button_set_thresholds)
-
-        # selecting the Egm points
-        self.egmselect = QtWidgets.QLineEdit()
-        self.egmselect.setText(str(0))
-        self.limitLayout.addRow("Egm Point", self.egmselect)
-
-        button_egmselect = QtWidgets.QPushButton("Set Egm Point", self)
-        button_egmselect.setGeometry(200, 150, 100, 40)
-        button_egmselect.clicked.connect(self.plot_egm)
-        self.limitLayout.addRow(button_egmselect)
-
-        # Nesting Layouts and setting the main layout
-        self.mainLayout.addLayout(self.menulayout)
-        self.mainLayout.addLayout(self.plotLayout)
-        self.mainLayout.addLayout(self.limitLayout)
-        self.setLayout(self.mainLayout)
-
+        for dock in [dock_1, dock_2, dock_3, dock_4]:
+            dock.setAllowedAreas(Qt.AllDockWidgetAreas)
+        
     def load_data(self):
         print("Please wait: Loading Data ... ")
-        # Loading file from a Dialog Box
+
         dialogue = QtWidgets.QFileDialog()
         dialogue.setWindowTitle('Load an OpenEP dataset')
         dialogue.setDirectory(QtCore.QDir.currentPath())
@@ -145,126 +236,111 @@ class OpenEpGUI(QtWidgets.QWidget):
         dialogue.setNameFilter("MATLAB files (*.mat)")
 
         if dialogue.exec_():
+
             filename = dialogue.selectedFiles()[0]
             self.case = openep.load_case(filename)
-            self.mesh = self.case.create_mesh()
-            self.mesh1 = deepcopy(self.mesh)
-            self.mesh2 = deepcopy(self.mesh)
-            self.volt = self.case.fields.bipolar_voltage
-            self.minval = 0
-            self.maxval = 2
-            self.free_boundaries = openep.mesh.get_free_boundaries(self.mesh)
-            self.add_mesh_kws = {
-                "clim": [self.minval, self.maxval],
+            self.mesh_1 = self.case.create_mesh()
+            self.mesh_2 = self.case.create_mesh()
+            self.free_boundaries = openep.mesh.get_free_boundaries(self.mesh_1)
+
+            self.add_mesh_1_kws = {
+                "clim": [self._initial_lower_limit_1, self._initial_upper_limit_1],
+                "scalar_bar_args": {"label_font_size": 8}
+            }
+            self.add_mesh_2_kws = {
+                "clim": [self._initial_lower_limit_2, self._initial_upper_limit_2],
                 "scalar_bar_args": {"label_font_size": 8}
             }
 
-            # Interpolated voltage data
-            self.voltage_data = openep.case.interpolate_voltage_onto_surface(
+            # Interpolate some fields (e.g. bipolar volage)
+            interpolated_voltage = openep.case.interpolate_voltage_onto_surface(
                 self.case,
                 max_distance=None,
             )
+            self.interpolated_fields = {"bipolar_voltage": interpolated_voltage}
+            
+            # Draw default maps
+            self.draw_map(
+                mesh=self.mesh_1,
+                plotter=self.plotter_1,
+                data=self.case.fields.bipolar_voltage,
+                add_mesh_kws=self.add_mesh_1_kws,
+            )
+            self.draw_map(
+                mesh=self.mesh_2,
+                plotter=self.plotter_2,
+                data=self.case.fields.local_activation_time,
+                add_mesh_kws=self.add_mesh_2_kws,
+            )
 
-    def plot_3d_map(self):
-
-        self.minval = float(self.lowerlimit.text())
-        self.maxval = float(self.upperlimit.text())
-        self.add_mesh_kws["clim"] = [self.minval, self.maxval]
-
-        self.plotter = openep.draw.draw_map(
-            mesh=self.mesh1,
-            field=self.volt,
-            plotter=self.plotter,
-            free_boundaries=False,
-            add_mesh_kws=self.add_mesh_kws,
+            self.axis_3.axis('on')  # make sure we can see the axes now
+            self.plot_electrograms()
+    
+    def update_colourbar_limits_1(self):
+        
+        lower_limit = float(self.lower_limit_1.text())
+        upper_limit = float(self.upper_limit_1.text())
+        self.add_mesh_1_kws["clim"] = [lower_limit, upper_limit]
+        self.draw_map(
+            mesh=self.mesh_1,
+            plotter=self.plotter_1,
+            data=self.case.fields.bipolar_voltage,
+            add_mesh_kws=self.add_mesh_1_kws,
         )
 
-        self.plotter = openep.draw.draw_free_boundaries(
+    def update_colourbar_limits_2(self):
+        
+        lower_limit = float(self.lower_limit_2.text())
+        upper_limit = float(self.upper_limit_2.text())
+        self.add_mesh_2_kws["clim"] = [lower_limit, upper_limit]
+        self.draw_map(
+            mesh=self.mesh_2,
+            plotter=self.plotter_2,
+            data=self.case.fields.local_activation_time,
+            add_mesh_kws=self.add_mesh_2_kws
+        )
+
+    def draw_map(self, mesh, plotter, data, add_mesh_kws):
+
+        plotter = openep.draw.draw_map(
+            mesh=mesh,
+            field=data,
+            plotter=plotter,
+            free_boundaries=False,
+            add_mesh_kws=add_mesh_kws,
+        )
+
+        plotter = openep.draw.draw_free_boundaries(
             self.free_boundaries,
             colour="black",
             width=5,
-            plotter=self.plotter
+            plotter=plotter,
         )
 
-        self.plotter.reset_camera()
+        plotter.reset_camera()
 
-    def plot_interpolated_voltage(self):
+    def plot_electrograms(self):
 
-        self.minval = float(self.lowerlimit.text())
-        self.maxval = float(self.upperlimit.text())
-        self.add_mesh_kws["clim"] = [self.minval, self.maxval]
-
-        # # QDock Widget
-        self.frame1 = QtWidgets.QFrame()
-        self.plotter1 = QtInteractor(self.frame1)
-        self.dock_plot = QtWidgets.QDockWidget("Interpolated Voltage Plot", self)
-        self.dock_plot.setFloating(False)
-        self.dock_plot.setWidget(self.plotter1)
-
-        self.plotLayout.addWidget(self.dock_plot, 0, 1)
-
-        self.plotter1 = openep.draw.draw_map(
-            mesh=self.mesh2,
-            field=self.voltage_data,
-            plotter=self.plotter1,
-            free_boundaries=False,
-            add_mesh_kws=self.add_mesh_kws,
-        )
-
-        self.plotter1 = openep.draw.draw_free_boundaries(
-            self.free_boundaries,
-            colour="black",
-            width=5,
-            plotter=self.plotter1
-        )
-
-        self.plotter1.reset_camera()
-
-    def plot_egm(self):
-        self.egm_point = np.asarray(self.egmselect.text().split(','), dtype=int)
-
-        self.fig, self.ax = plt.subplots(ncols=1, nrows=1)
-        self.fig.set_facecolor("white")
+        self.egm_point = np.asarray(self.egm_select.text().split(','), dtype=int)
 
         self.egm_traces, self.egm_names, self.egm_lat = openep.case.get_electrograms_at_points(
             self.case, indices=self.egm_point
         )
         times = openep.case.get_woi_times(self.case)
         relative_times = openep.case.get_woi_times(self.case, relative=True)
-        self.fig, self.ax = openep.draw.plot_electrograms(
+        
+        _, self.axis_3.axes = openep.draw.plot_electrograms(
             relative_times,
             self.egm_traces[:, times],
             names=self.egm_names,
+            axis=self.axis_3.axes,
         )
-        self.canvas = FigureCanvas(self.fig)
-
-        self.dock_plot1 = QtWidgets.QDockWidget("EGM Plot", self)
-        self.dock_plot1.setFloating(False)
-        self.dock_plot1.setWidget(self.canvas)
-        self.plotLayout.addWidget(self.dock_plot1, 1, 1)
-
-    def plot_histogram(self):
-        self.plotter3 = QtInteractor(self.frame)
-        self.dock_plot2 = QtWidgets.QDockWidget("Histogram Plot", self)
-        self.dock_plot2.setFloating(False)
-        self.dock_plot2.setWidget(self.plotter3)
-
-        self.plotLayout.addWidget(self.dock_plot2, 1, 0)
-        pass
-
-    def update_voltage_threshold(self):
-        self.plot_3d_map()
-        self.plot_interpolated_voltage()
-
-
-def main():
-    # Create an instance of Qapplication
-    app = QtWidgets.QApplication(sys.argv)    
-    # Create an instance of GUI
-    window = OpenEpGUI()
-    window.showMaximized()
-    sys.exit(app.exec_())
+        self.canvas_3.draw()
 
 
 if __name__ == "__main__":
-    main()
+
+    app = QtWidgets.QApplication(sys.argv)
+    main = OpenEpGUI()
+    main.showMaximized()
+    sys.exit(app.exec_())

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -74,54 +74,73 @@ class OpenEpGUI(QtWidgets.QMainWindow):
     def __init__(self):
 
         super().__init__()
-        self._initUI()
-        self._add_menu_bar()
-        
-        self.egm_point = np.array([0], dtype=int)
 
-        # initial bipolar voltage colourbar limits
+        self._init_data()
+        self._init_ui()
+        self._add_menu_bar()
+        self._create_plotter_1_dock()
+        self._create_plotter_2_dock()
+        self._create_canvas_3_dock()
+        self._create_canvas_4_dock()
+        self._add_dock_widgets()
+    
+    def _init_data(self):
+        """
+        Set default values for variables that can later be set by the user.
+        """
+        
+        # Display only the first electrogram
+        self.egm_point = np.array([0], dtype=int)
+        
+        # initial bipolar voltage colourbar limits
         self._initial_lower_limit_1 = 0
         self._initial_upper_limit_1 = 2
-        
-        # initial LAT colourbar limits
+
+        # initial LAT colourbar limits
         self._initial_lower_limit_2 = 0
         self._initial_upper_limit_2 = 200
 
-        self._add_dock_widgets()
+    def _init_ui(self):
+        """
+        Initialise the GUI.
 
-    def _initUI(self):
+        Lots of the layout is handled automatically by QtWidgets.QMainWindow.
+        """
 
         self.setWindowTitle("OpenEP: The open-source solution for electrophysiology data analysis")
-        self.mainLayout = QtWidgets.QVBoxLayout()
-        self.menulayout = QtWidgets.QGridLayout()
-        self.buttonLayout = QtWidgets.QHBoxLayout()
     
     def _add_menu_bar(self):
+        """Add a menu bar to the GUI."""
 
-        menubar = QtWidgets.QMenuBar()
-        self.menulayout.addWidget(menubar, 0, 0)
+        menubar = self.menuBar()
         file_menu = menubar.addMenu("File")
+        menubar.setNativeMenuBar(True)
         
         self.load_case_act = QtWidgets.QAction("Open File...")
         self.load_case_act.triggered.connect(self.load_data)
         file_menu.addAction(self.load_case_act)
         file_menu.addSeparator()
+
+    def _create_plotter_1_dock(self):
+        """
+        Create a dockable pyvista-qt plotter for rendering 3D maps.
         
-    def _add_dock_widgets(self):
+        This can be used for projecting scalar fields onto the 3D surface.
+        Currently, only bipolar voltage is supported.
+        """
 
-        dock_1 = DockWidget("Voltage")
-        dock_2 = DockWidget("LAT")
-        dock_3 = DockWidget("EGMs")
-        dock_4 = DockWidget("Analysis")
-
-        # Plotter 1 (defaults to bipolar voltage)
+        # TODO: add support for changing the scalar field
+        
+        # Plotter 1 defaults to bipolar voltage
+        self.dock_1 = DockWidget("Voltage")
+        
         frame_1 = QtWidgets.QFrame()
         plotter_1 = QtInteractor(frame_1)
         plotter_1.background_color = 'white'
         plotter_1.setMinimumSize(QtCore.QSize(50, 50))
         self.plotter_1 = plotter_1
-        
-        # Add thresholds to plotter 1
+
+        # Add thresholds to plotter 1
         self.plotter_1.limitLayout = QtWidgets.QFormLayout(self)
         
         self.lower_limit_1 = QtWidgets.QLineEdit("Lower threshold", self.plotter_1)
@@ -142,14 +161,28 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         button_set_thresholds_1.clicked.connect(self.update_colourbar_limits_1)
         self.plotter_1.limitLayout.addRow(button_set_thresholds_1)
         
-        # Plotter 2 (defaults to LAT)
+        self.dock_1.setWidget(self.plotter_1)
+
+    def _create_plotter_2_dock(self):
+        """
+        Create a second dockable pyvista-qt plotter for rendering 3D maps.
+        
+        This can be used for displaying alternative scalar fields to `plotter_1`.
+        Currently, only local activation time is supported.
+        """
+
+        # TODO: add support for changing the scalar field
+
+        # Plotter 2 defaults to local activation time
+        self.dock_2 = DockWidget("LAT")
+
         frame_2 = QtWidgets.QFrame()
-        plotter_2= QtInteractor(frame_2)
+        plotter_2 = QtInteractor(frame_2)
         plotter_2.background_color = 'white'
         plotter_2.setMinimumSize(QtCore.QSize(50, 50))
         self.plotter_2 = plotter_2
 
-        # Add thresholds to plotter 2
+        # Add thresholds to plotter 2
         self.plotter_2.limitLayout = QtWidgets.QFormLayout(self)        
         
         self.lower_limit_2 = QtWidgets.QLineEdit("Lower threshold", self.plotter_2)
@@ -169,9 +202,15 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         button_set_thresholds_2.setGeometry(10, 10, 180, 40)
         button_set_thresholds_2.clicked.connect(self.update_colourbar_limits_2)
         self.plotter_2.limitLayout.addRow(button_set_thresholds_2)
+        
+        self.dock_2.setWidget(self.plotter_2)
 
-        # MPL canvases
-        # Canvas 1 (EGMs)
+    def _create_canvas_3_dock(self):
+        """Create a dockable widget for plotting interactive electrograms with matplotlib"""
+
+        # Canvas 3 is for the electrograms
+        self.dock_3 = DockWidget("EGMs")
+
         self.figure_3, self.axis_3 = plt.subplots(ncols=1, nrows=1)
         self.figure_3.set_facecolor("white")
         self.canvas_3 = FigureCanvas(self.figure_3)
@@ -193,7 +232,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         egm_layout.addRow(button_egm_select)
         
         # Create toolbar, passing canvas as first parament, parent (self, the MainWindow) as second.
-        toolbar = NavigationToolbar(self.canvas_3, dock_3)
+        toolbar = NavigationToolbar(self.canvas_3, self.dock_3)
         canvas_layout = QtWidgets.QVBoxLayout()
         canvas_layout.addWidget(self.canvas_3)
         canvas_layout.addWidget(toolbar)
@@ -203,29 +242,38 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         canvas_widget.setLayout(canvas_layout)
         canvas_widget.setStyleSheet("border-width: 0px; border: 0px; background-color:white;")
 
-        # Other analysis (e.g. histogram of voltages)
+        self.dock_3.setWidget(canvas_widget)
+
+    def _create_canvas_4_dock(self):
+        """Create a dockable widget for other matplotlib plots."""
+
+        # TODO: Add matplotlib canvas for plotting results from other analyses
+
+        # Canvas 4 is for plotting other analyses (e.g. histogram of voltages)
+        self.dock_4 = DockWidget("Analysis")
+
         content4 = QtWidgets.QWidget()
         content4.setStyleSheet("background-color:white;")
         content4.setMinimumSize(QtCore.QSize(50, 50))
 
-        dock_1.setWidget(self.plotter_1)
-        dock_2.setWidget(self.plotter_2)
-        dock_3.setWidget(canvas_widget)
-        dock_4.setWidget(content4)
-        
-        self.addDockWidget(Qt.LeftDockWidgetArea, dock_1)
-        self.addDockWidget(Qt.LeftDockWidgetArea, dock_2)
-        self.tabifyDockWidget(dock_1, dock_2)
-        self.addDockWidget(Qt.RightDockWidgetArea, dock_3)
-        self.addDockWidget(Qt.LeftDockWidgetArea, dock_4)
-        self.tabifyDockWidget(dock_3, dock_4)
+        self.dock_4.setWidget(content4)
+
+    def _add_dock_widgets(self):
+        """Add dockable widgets to the main window."""
+
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.dock_1)
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.dock_2)
+        self.tabifyDockWidget(self.dock_1, self.dock_2)
+        self.addDockWidget(Qt.RightDockWidgetArea, self.dock_3)
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.dock_4)
+        self.tabifyDockWidget(self.dock_3, self.dock_4)
 
         self.setDockOptions(self.GroupedDragging | self.AllowTabbedDocks | self.AllowNestedDocks)
         self.setTabPosition(Qt.AllDockWidgetAreas, QtWidgets.QTabWidget.North)
 
-        for dock in [dock_1, dock_2, dock_3, dock_4]:
+        for dock in [self.dock_1, self.dock_2, self.dock_3, self.dock_4]:
             dock.setAllowedAreas(Qt.AllDockWidgetAreas)
-        
+
     def load_data(self):
         print("Please wait: Loading Data ... ")
 
@@ -338,9 +386,17 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         self.canvas_3.draw()
 
 
-if __name__ == "__main__":
+def main():
 
+    # Create an instance of Qapplication
     app = QtWidgets.QApplication(sys.argv)
-    main = OpenEpGUI()
-    main.showMaximized()
+
+    # Create an instance of GUI
+    window = OpenEpGUI()
+    window.showMaximized()
+
     sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -97,16 +97,6 @@ class OpenEpGUI(qtw.QWidget):
         menubar.addMenu("View")
         menubar.addMenu("Help")
 
-        # Label
-        mainLabel1 = qtw.QLabel("OpenEp Tool", self)
-        self.labelLayout.addWidget(mainLabel1)
-        mainLabel2 = qtw.QLabel(
-            "The Open Source solution for electrophysiology data analysis", self
-        )
-        self.labelLayout.addWidget(mainLabel2)
-
-        self.labelLayout.addRow(self.buttonLayout)
-
         # Plot
         self.plotLayout = qtw.QGridLayout()
         self.plotLayout.setColumnStretch(0, 5)

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -83,15 +83,15 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         self._create_canvas_3_dock()
         self._create_canvas_4_dock()
         self._add_dock_widgets()
-    
+
     def _init_data(self):
         """
         Set default values for variables that can later be set by the user.
         """
-        
+
         # Display only the first electrogram
         self.egm_point = np.array([0], dtype=int)
-        
+
         # initial bipolar voltage colourbar limits
         self._initial_lower_limit_1 = 0
         self._initial_upper_limit_1 = 2
@@ -108,14 +108,14 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         """
 
         self.setWindowTitle("OpenEP: The open-source solution for electrophysiology data analysis")
-    
+
     def _add_menu_bar(self):
         """Add a menu bar to the GUI."""
 
         menubar = self.menuBar()
         file_menu = menubar.addMenu("File")
         menubar.setNativeMenuBar(True)
-        
+
         self.load_case_act = QtWidgets.QAction("Open File...")
         self.load_case_act.triggered.connect(self.load_data)
         file_menu.addAction(self.load_case_act)
@@ -124,16 +124,16 @@ class OpenEpGUI(QtWidgets.QMainWindow):
     def _create_plotter_1_dock(self):
         """
         Create a dockable pyvista-qt plotter for rendering 3D maps.
-        
+
         This can be used for projecting scalar fields onto the 3D surface.
         Currently, only bipolar voltage is supported.
         """
 
         # TODO: add support for changing the scalar field
-        
+
         # Plotter 1 defaults to bipolar voltage
         self.dock_1 = DockWidget("Voltage")
-        
+
         frame_1 = QtWidgets.QFrame()
         plotter_1 = QtInteractor(frame_1)
         plotter_1.background_color = 'white'
@@ -142,13 +142,13 @@ class OpenEpGUI(QtWidgets.QMainWindow):
 
         # Add thresholds to plotter 1
         self.plotter_1.limitLayout = QtWidgets.QFormLayout(self)
-        
+
         self.lower_limit_1 = QtWidgets.QLineEdit("Lower threshold", self.plotter_1)
         self.lower_limit_1.setStyleSheet("background-color: white; border: 1px solid lightGray;")
         self.lower_limit_1.setGeometry(200, 10, 50, 40)
         self.lower_limit_1.setText(str(self._initial_lower_limit_1))
         self.plotter_1.limitLayout.addRow("Lower threshold", self.lower_limit_1)
-        
+
         self.upper_limit_1 = QtWidgets.QLineEdit("Upper threshold", self.plotter_1)
         self.upper_limit_1.setStyleSheet("background-color: white; border: 1px solid lightGray;")
         self.upper_limit_1.setGeometry(260, 10, 50, 40)
@@ -160,13 +160,13 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         button_set_thresholds_1.setGeometry(10, 10, 180, 40)
         button_set_thresholds_1.clicked.connect(self.update_colourbar_limits_1)
         self.plotter_1.limitLayout.addRow(button_set_thresholds_1)
-        
+
         self.dock_1.setWidget(self.plotter_1)
 
     def _create_plotter_2_dock(self):
         """
         Create a second dockable pyvista-qt plotter for rendering 3D maps.
-        
+
         This can be used for displaying alternative scalar fields to `plotter_1`.
         Currently, only local activation time is supported.
         """
@@ -183,14 +183,14 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         self.plotter_2 = plotter_2
 
         # Add thresholds to plotter 2
-        self.plotter_2.limitLayout = QtWidgets.QFormLayout(self)        
-        
+        self.plotter_2.limitLayout = QtWidgets.QFormLayout(self)
+
         self.lower_limit_2 = QtWidgets.QLineEdit("Lower threshold", self.plotter_2)
         self.lower_limit_2.setStyleSheet("background-color: white; border: 1px solid lightGray;")
         self.lower_limit_2.setGeometry(200, 10, 50, 40)
         self.lower_limit_2.setText(str(self._initial_lower_limit_2))
         self.plotter_2.limitLayout.addRow("Lower threshold", self.lower_limit_2)
-        
+
         self.upper_limit_2 = QtWidgets.QLineEdit("Upper threshold", self.plotter_2)
         self.upper_limit_2.setStyleSheet("background-color: white; border: 1px solid lightGray;")
         self.upper_limit_2.setGeometry(260, 10, 50, 40)
@@ -202,7 +202,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         button_set_thresholds_2.setGeometry(10, 10, 180, 40)
         button_set_thresholds_2.clicked.connect(self.update_colourbar_limits_2)
         self.plotter_2.limitLayout.addRow(button_set_thresholds_2)
-        
+
         self.dock_2.setWidget(self.plotter_2)
 
     def _create_canvas_3_dock(self):
@@ -218,7 +218,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
 
         # Add EGM selections
         egm_layout = QtWidgets.QFormLayout(self)
-        
+
         self.egm_select = QtWidgets.QLineEdit("EGMs", self.canvas_3)
         self.egm_select.setStyleSheet("background-color: white; border: 1px solid lightGray;")
         self.egm_select.setGeometry(260, 10, 50, 40)
@@ -230,7 +230,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         button_egm_select.setGeometry(10, 10, 240, 40)
         button_egm_select.clicked.connect(self.plot_electrograms)
         egm_layout.addRow(button_egm_select)
-        
+
         # Create toolbar, passing canvas as first parament, parent (self, the MainWindow) as second.
         toolbar = NavigationToolbar(self.canvas_3, self.dock_3)
         canvas_layout = QtWidgets.QVBoxLayout()
@@ -306,7 +306,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
                 max_distance=None,
             )
             self.interpolated_fields = {"bipolar_voltage": interpolated_voltage}
-            
+
             # Draw default maps
             self.draw_map(
                 mesh=self.mesh_1,
@@ -323,9 +323,9 @@ class OpenEpGUI(QtWidgets.QMainWindow):
 
             self.axis_3.axis('on')  # make sure we can see the axes now
             self.plot_electrograms()
-    
+
     def update_colourbar_limits_1(self):
-        
+
         lower_limit = float(self.lower_limit_1.text())
         upper_limit = float(self.upper_limit_1.text())
         self.add_mesh_1_kws["clim"] = [lower_limit, upper_limit]
@@ -337,7 +337,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         )
 
     def update_colourbar_limits_2(self):
-        
+
         lower_limit = float(self.lower_limit_2.text())
         upper_limit = float(self.upper_limit_2.text())
         self.add_mesh_2_kws["clim"] = [lower_limit, upper_limit]
@@ -376,7 +376,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         )
         times = openep.case.get_woi_times(self.case)
         relative_times = openep.case.get_woi_times(self.case, relative=True)
-        
+
         _, self.axis_3.axes = openep.draw.plot_electrograms(
             relative_times,
             self.egm_traces[:, times],

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -37,11 +37,7 @@ import openep
 class OpenEpGUI(qtw.QWidget):
     def __init__(self):
         super().__init__()
-        self.title = "OpenEp Application"
-        self.left = 10
-        self.top = 10
-        self.width = 840
-        self.height = 480
+        self.title = "OpenEP: The open-source solution for electrophysiology data analysis"
         self.initUI()
         self.thresholds = False
         self.minval = 0
@@ -50,7 +46,6 @@ class OpenEpGUI(qtw.QWidget):
 
     def initUI(self):
         self.setWindowTitle(self.title)
-        self.setGeometry(self.left, self.top, self.width, self.height)
 
         # # LAYOUTS
         self.mainLayout = qtw.QVBoxLayout(self)
@@ -276,7 +271,7 @@ def main():
     app = qtw.QApplication(sys.argv)
     # Create an instance of GUI
     window = OpenEpGUI()
-    window.show()
+    window.showMaximized()
     sys.exit(app.exec_())
 
 


### PR DESCRIPTION
Changes made:

* Use dockable widgets for all windows
* Use separate functions for initialising each of the dockable widgets
* Have separate windows for voltage and lat. Separate the colour bar threshold buttons - use one set per window.
* Make the EMG plots interactive (pan, zoom, add title etc., save)
* Don't create a new canvas/plotter each time thresholds/egm indices are selected.
* Maximise screen by default
* Create the menubar using qmainwindow rather than manually with qwidgets
* Make all pyvista plotters and matplotlib canvases have a white background
* Add basic docstrings
* Only allow existing matlab files to be loaded from the File menu (rather than attempt to load any file type)
* make `openep.draw.draw_routines.plot_electrograms` use `axis.plot` rather than `plt.plot` - otherwise when calling from `view_gui` pyplot complains that the plot doesn't belong to `plt`
* rename `qtw` to `QtWidgets` and `ep_case` to `case`
