### PR TITLE
Minor fixes to the GUI

### DIFF
--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -145,6 +145,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
             editor=False,
             menu_bar=False,
             title="Voltage",
+            border=False,
         )
         plotter_1.background_color = 'white'
         plotter_1.setMinimumSize(QtCore.QSize(50, 50))
@@ -197,6 +198,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
             editor=False,
             menu_bar=False,
             title="Voltage",
+            border=False,
         )
         plotter_2.background_color = 'white'
         plotter_2.setMinimumSize(QtCore.QSize(50, 50))

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -24,7 +24,7 @@ import sys
 
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtCore import Qt
-from pyvistaqt import QtInteractor
+from pyvistaqt import BackgroundPlotter
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar
@@ -134,8 +134,18 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         # Plotter 1 defaults to bipolar voltage
         self.dock_1 = DockWidget("Voltage")
 
-        frame_1 = QtWidgets.QFrame()
-        plotter_1 = QtInteractor(frame_1)
+        plotter_1 = BackgroundPlotter(
+            show=False,
+            app=QtWidgets.QApplication.instance(),
+            allow_quit_keypress=False,
+            line_smoothing=False,
+            point_smoothing=False,
+            polygon_smoothing=False,
+            toolbar=False,
+            editor=False,
+            menu_bar=False,
+            title="Voltage",
+        )
         plotter_1.background_color = 'white'
         plotter_1.setMinimumSize(QtCore.QSize(50, 50))
         self.plotter_1 = plotter_1
@@ -176,8 +186,18 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         # Plotter 2 defaults to local activation time
         self.dock_2 = DockWidget("LAT")
 
-        frame_2 = QtWidgets.QFrame()
-        plotter_2 = QtInteractor(frame_2)
+        plotter_2 = BackgroundPlotter(
+            show=False,
+            app=QtWidgets.QApplication.instance(),
+            allow_quit_keypress=False,
+            line_smoothing=False,
+            point_smoothing=False,
+            polygon_smoothing=False,
+            toolbar=False,
+            editor=False,
+            menu_bar=False,
+            title="Voltage",
+        )
         plotter_2.background_color = 'white'
         plotter_2.setMinimumSize(QtCore.QSize(50, 50))
         self.plotter_2 = plotter_2

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -377,12 +377,14 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         times = openep.case.get_woi_times(self.case)
         relative_times = openep.case.get_woi_times(self.case, relative=True)
 
+        self.axis_3.cla()
         _, self.axis_3.axes = openep.draw.plot_electrograms(
             relative_times,
             self.egm_traces[:, times],
             names=self.egm_names,
             axis=self.axis_3.axes,
         )
+        self.axis_3.set_ylim(-0.5, 12.5)
         self.canvas_3.draw()
 
 

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -385,8 +385,6 @@ class OpenEpGUI(QtWidgets.QMainWindow):
             plotter=plotter,
         )
 
-        plotter.reset_camera()
-
     def plot_electrograms(self):
 
         self.egm_point = np.asarray(self.egm_select.text().split(','), dtype=int)


### PR DESCRIPTION
Changes made:

* When new electrograms are plotted, remove the previous ones first (rather than plotting over them)
* Use pyvista-qts `BackgroundPlotter` rather than `QtInteractor`
* Don't reset the camera each time the scalar values of the pyvista plotters change