### PR TITLE
Add basic support for reading and visualising openCARP

### DIFF
--- a/openep/__init__.py
+++ b/openep/__init__.py
@@ -18,5 +18,5 @@
 
 __all__ = ['case', 'mesh', 'draw']
 
-from .io.readers import load_case
+from .io.readers import load_case, load_openCARP
 from . import case, mesh, draw

--- a/openep/data_structures/openCARP.py
+++ b/openep/data_structures/openCARP.py
@@ -1,0 +1,129 @@
+# OpenEP
+# Copyright (c) 2021 OpenEP Collaborators
+#
+# This file is part of OpenEP.
+#
+# OpenEP is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenEP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program (LICENSE.txt).  If not, see <http://www.gnu.org/licenses/>
+
+"""Module containing classes for storing data from openCARP simulations."""
+
+from attr import attrs
+import pyvista
+import numpy as np
+
+__all__ = []
+
+
+@attrs(auto_attribs=True, auto_detect=True)
+class CARPData:
+    """
+    Class for storing information about meshes from openCARP simulations.
+
+    Args:
+        points (np.ndarray): 3D coordinates of points on the mesh.
+        indices (ndarray): Indices of points that make up each face of the mesh
+        unipolar_egm (np.ndarray, optional): Unipolar electrograms for each point.
+    """
+
+    points: np.ndarray
+    indices: np.ndarray
+    unipolar_egm: np.ndarray = None
+
+    def __attrs_post_init__(self):
+
+        self.bipolar_egm = self.bipolar_from_unipolar()
+        self.bipolar_voltage = np.ptp(self.bipolar_egm, axis=1)
+        self.unipolar_voltage = np.ptp(self.unipolar_egm, axis=1)
+
+    def __repr__(self):
+        return f"openCARP mesh with {len(self.unipolar_egm)} points."
+
+    def create_mesh(
+        self,
+        recenter: bool = True,
+    ):
+        """
+        Create a new mesh object from the stored nodes and indices
+
+        Args:
+            recenter: if True, recenter the mesh to the origin
+
+        Returns:
+            mesh (pyvista.Polydata): a mesh created from the points and indices
+        """
+
+        indices = self.indices
+        num_points_per_face = np.full(shape=(len(indices)), fill_value=3, dtype=int)  # all faces have three vertices
+        faces = np.concatenate([num_points_per_face[:, np.newaxis], indices], axis=1)
+
+        mesh = pyvista.PolyData(self.points, faces.ravel())
+
+        if recenter:
+            mesh.translate(
+                -np.asarray(mesh.center)
+            )  # recenter mesh to origin, helps with lighting in default scene
+
+        return mesh
+
+    def bipolar_from_unipolar(self):
+        """
+        Calculate bipolar electrograms from unipolar electrograms for each point on the mesh.
+        
+        Returns
+            all_bipolar_egm (np.ndarray): Bipolar electrograms
+        """
+        
+        all_bipolar_egm = np.full_like(self.unipolar_egm, fill_value=np.NaN)
+
+        for index, egm in enumerate(self.unipolar_egm):
+
+            connected_vertices = self._find_connected_vertices(self.indices, index)
+            bipolar_egm = self._bipolar_from_unipolar(
+                egm=egm,
+                neighbour_egms=self.unipolar_egm[connected_vertices],
+            )
+            all_bipolar_egm[index] = bipolar_egm
+
+        return all_bipolar_egm
+
+    def _find_connected_vertices(self, faces, index):
+        """
+        Find all points connected to a given point by a single edge.
+
+        Args:
+            faces (np.ndarray): faces of a mesh
+            index (int): index of point for which we want to find the neighbouring points
+        """
+
+        connected_faces = [i for i, face in enumerate(faces) if index in face]
+        connected_vertices = np.unique(faces[connected_faces])
+
+        return connected_vertices[connected_vertices != index]
+
+    def _bipolar_from_unipolar(self, egm, neighbour_egms):
+        """
+        Calculate the bipolar electrogram of a given point from a series of unipolar electrograms.
+
+        Args:
+            egm (np.ndarray): unipolar electrogram at a given point
+            neighbour_egms (np.narray): unipolar electrograms at all points
+                neighbouring the given point
+        """
+        
+        difference = neighbour_egms - egm
+        voltage = np.ptp(difference, axis=1)
+        pair_index = np.argmax(voltage)
+        bipolar_electrogram = difference[pair_index]
+
+        return bipolar_electrogram

--- a/openep/data_structures/openCARP.py
+++ b/openep/data_structures/openCARP.py
@@ -79,11 +79,11 @@ class CARPData:
     def bipolar_from_unipolar(self):
         """
         Calculate bipolar electrograms from unipolar electrograms for each point on the mesh.
-        
+
         Returns
             all_bipolar_egm (np.ndarray): Bipolar electrograms
         """
-        
+
         all_bipolar_egm = np.full_like(self.unipolar_egm, fill_value=np.NaN)
 
         for index, egm in enumerate(self.unipolar_egm):
@@ -120,7 +120,7 @@ class CARPData:
             neighbour_egms (np.narray): unipolar electrograms at all points
                 neighbouring the given point
         """
-        
+
         difference = neighbour_egms - egm
         voltage = np.ptp(difference, axis=1)
         pair_index = np.argmax(voltage)

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -53,13 +53,16 @@ and methods of `Case`.
 import os
 import scipy.io
 
+import numpy as np
+
 from .matlab import _load_mat_v73, _load_mat_below_v73
 from ..data_structures.surface import extract_surface_data
 from ..data_structures.electric import extract_electric_data
 from ..data_structures.ablation import extract_ablation_data
 from ..data_structures.case import Case
+from ..data_structures.openCARP import CARPData
 
-__all__ = ["load_case", "load_mat"]
+__all__ = ["load_case", "load_mat", "load_openCARP"]
 
 
 def _check_mat_version_73(filename):
@@ -117,3 +120,26 @@ def load_case(filename, name=None):
         notes = []
 
     return Case(name, points, indices, fields, electric, ablation, notes)
+
+
+def load_openCARP(
+    points,
+    indices,
+    unipolar_egm,
+):
+    """
+    Load data from and OpenCARP simulation.
+
+    Args:
+        points (str): Path to the openCARP points file.
+        indices (str): Path to the openCARP element file. Currently, only triangular meshes are
+            supported.
+        unipolar_egm (str): Path to the openCARP auxiliary grid file containing
+            unipolar electrograms.
+    """
+
+    points_data = np.loadtxt(points, skiprows=1)
+    indices_data = np.loadtxt(indices, skiprows=1, usecols=[1, 2, 3], dtype=int)
+    unipolar_egm_data = np.loadtxt(unipolar_egm)
+
+    return CARPData(points_data, indices_data, unipolar_egm_data)

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -316,7 +316,7 @@ class OpenEpGUI(QtWidgets.QMainWindow):
             elif len(filenames) == 3:
                 self._load_openCARP_and_initialise(filenames)
             else:
-                
+
                 error = QtWidgets.QMessageBox()
                 error.setIcon(QtWidgets.QMessageBox.Critical)
                 error.setText("File selection error")
@@ -329,19 +329,19 @@ class OpenEpGUI(QtWidgets.QMainWindow):
 
     def _load_openCARP_and_initialise(self, filenames):
         """Load data from an openCARP simulation.
-        
+
         """
-        
+
         # TODO: create a new dock widget for the simulation data
         # Allow user to draw either bipolar or unipolar voltages
-        
+
         extensions = [pathlib.Path(f).suffix for f in filenames]
         if (".pts" in extensions) and (".elem" in extensions) and (".dat" in extensions):
             self.carp = openep.load_openCARP(
                 points=filenames[extensions.index(".pts")],
                 indices=filenames[extensions.index(".elem")],
                 unipolar_egm=filenames[extensions.index(".dat")],
-            )                
+            )
 
     def _load_case_and_initialise(self, filename):
         """Load an OpenEP case object.

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -305,8 +305,8 @@ class OpenEpGUI(QtWidgets.QMainWindow):
         dialogue.setWindowTitle('Load an OpenEP dataset')
         dialogue.setDirectory(QtCore.QDir.currentPath())
         dialogue.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
-        dialogue.setNameFilters(["MATLAB files (*.mat)", "openCARP files (*.pts *.elem *.dat)"])
         dialogue.selectNameFilter("MATLAB files (*.mat);;openCARP files (*.pts *.elem *.dat)")
+        dialogue.setNameFilters(["MATLAB files (*.mat)", "openCARP files (*.pts *.elem *.dat)"])
 
         if dialogue.exec_():
 
@@ -315,11 +315,25 @@ class OpenEpGUI(QtWidgets.QMainWindow):
                 self._load_case_and_initialise(filenames[0])
             elif len(filenames) == 3:
                 self._load_openCARP_and_initialise(filenames)
+            else:
+                
+                error = QtWidgets.QMessageBox()
+                error.setIcon(QtWidgets.QMessageBox.Critical)
+                error.setText("File selection error")
+                error.setInformativeText(
+                    "Please select either a single MATLAB file (*.mat), or a single "
+                    "set of openCARP files (one each of *.pts, *.elem, *.dat)."
+                )
+                error.setWindowTitle("Error")
+                error.exec_()
 
     def _load_openCARP_and_initialise(self, filenames):
         """Load data from an openCARP simulation.
         
         """
+        
+        # TODO: create a new dock widget for the simulation data
+        # Allow user to draw either bipolar or unipolar voltages
         
         extensions = [pathlib.Path(f).suffix for f in filenames]
         if (".pts" in extensions) and (".elem" in extensions) and (".dat" in extensions):


### PR DESCRIPTION
Changes made:

* add a `openep.io.readers.load_openCARP` function (callable as `openep.load_openCARP`). This currently requires:
    * a points file (for 3d coordinates)
    * an elements file (for definition of each triangle in the mesh)
    * a data file (.dat, for the unipolar electrograms associated with each point).

* `load_openCARP` creates a `CARPData` object. Creation of this object automatically calculates the bipolar electrograms and voltages from the unipolar electrograms. 

* `CARPData` has a `create_mesh` function, which will create a `pyvista.PolyData` mesh. This mesh can be passed to `openep.draw.draw_map` for visualisation.
 
* openCARP files can be loaded in the GUI, but currently nothing happens when the files are loaded. It would be best to refactor the GUI first as described in #88 before adding visualisation/analysis functionality for these openCARP files.

* An error is raised by the GUI if a user tries to load the wrong file type. File(s) must be either a single MATLAB file (*.mat), or a single set of openCARP files (one each of *.pts, *.elem, *.dat).