### PR TITLE
Fix egm selection

### DIFF
--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -65,7 +65,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         self._active_system = None
 
         self.egm_slider = None
-        self.egm_selection_filter = re.compile('\d')  # noqa: W605
+        self.egm_selection_filter = re.compile('\d+')  # noqa: W605
 
     def _init_ui(self):
         """


### PR DESCRIPTION
Fix the regex for egm selection so that numbers are extracted rather than digits. i.e. previously a selection of `100` would plot three egms - the one at index 1 as well as the one at index 0 twice