### PR TITLE
Add ability to change opacity of the mesh

### DIFF
--- a/openep/draw/draw_routines.py
+++ b/openep/draw/draw_routines.py
@@ -86,7 +86,12 @@ def draw_free_boundaries(
 
         points = free_boundaries.points[boundary[:, 0]]
         points = np.vstack([points, points[:1]])  # we need to close the loop
-        plotter.add_lines(points, color=colours[boundary_index], width=width)
+        plotter.add_lines(
+            points,
+            color=colours[boundary_index],
+            width=width,
+            name=f"free_boundary_{boundary_index:d}",
+        )
 
     return plotter
 
@@ -142,6 +147,8 @@ def draw_map(
         "above_color": "magenta",
         "below_color": "brown",
         "nan_color": "gray",
+        "name": "mesh",
+        "opacity": 1.0,
     }
 
     # combine the default and user-given kwargs

--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -74,8 +74,10 @@ class System:
         plotter_layout = QtWidgets.QVBoxLayout(plotter)
 
         # TODO: We're currently using line edits to set colourbar limits - look into RangeSlider
-        colour_bar_layout, plotter.lower_limit, plotter.upper_limit = self._create_colourbar_layout()
-        plotter_layout.addLayout(colour_bar_layout)
+        plotter.colour_bar_layout, plotter.lower_limit, plotter.upper_limit = self._create_colourbar_layout()
+        plotter.opacity_layout, plotter.opacity = self._create_opacity_layout()
+        control_layout = self._create_control_layout(plotter=plotter)
+        plotter_layout.addLayout(control_layout)
         plotter_layout.addStretch()
 
         # The dock is set to have bold font (so the title stands out)
@@ -127,6 +129,39 @@ class System:
         colour_bar_layout.addStretch()
 
         return colour_bar_layout, lower_limit, upper_limit
+
+    def _create_opacity_layout(self):
+        """Create a layout with widgets for setting the opacity of the mesh."""
+
+        opacity_layout = QtWidgets.QHBoxLayout()
+        opacity_layout.addStretch
+
+        opacity_text = QtWidgets.QLabel("Opacity:")
+        opacity_text.setMinimumWidth(50)
+        opacity_text.setMaximumWidth(120)
+        opacity_text.setStyleSheet('QLabel {border: 0px; background-color: #d8dcd6;}')
+        opacity_layout.addWidget(opacity_text)
+
+        opacity_selector = QtWidgets.QDoubleSpinBox()
+        opacity_selector.setFixedWidth(60)
+        opacity_selector.setRange(0.0, 1.0)
+        opacity_selector.setSingleStep(0.05)
+        opacity_selector.setDecimals(2)
+        opacity_selector.setWrapping(False)
+        opacity_selector.setValue(1)
+        opacity_selector.textFromValue(1)
+        opacity_layout.addWidget(opacity_selector)
+
+        return opacity_layout, opacity_selector
+
+    def _create_control_layout(self, plotter):
+        """Add the colourbar and opacity layout to a single horizontal layout"""
+
+        control_layout = QtWidgets.QHBoxLayout()
+        control_layout.addLayout(plotter.colour_bar_layout)
+        control_layout.addLayout(plotter.opacity_layout)
+
+        return control_layout
 
     def _add_field_menu(self, dock, plotter):
         """Add a Field menu to the menubar. This is used for selecting the scalar field to project onto the surface."""

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -542,6 +542,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         index = len(system.plotters)
         plotter.lower_limit.returnPressed.connect(lambda: self.update_colourbar_limits(system, index=index))
         plotter.upper_limit.returnPressed.connect(lambda: self.update_colourbar_limits(system, index=index))
+        plotter.opacity.valueChanged.connect(lambda: self.update_opacity(system, index=index))
 
         system.docks.append(dock)
         system.plotters.append(plotter)
@@ -596,6 +597,28 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         upper_limit = float(system.plotters[index].upper_limit.text())
         system.add_mesh_kws[index]["clim"] = [lower_limit, upper_limit]
 
+        self.draw_map(
+            system.meshes[index],
+            system.plotters[index],
+            system.plotters[index].active_scalars,
+            system.add_mesh_kws[index],
+            system.free_boundaries[index],
+        )
+
+    def update_opacity(self, system, index):
+        """Update the opacity for a given ploter.
+
+        Args:
+            system (System): system containing the plotter whose opacity
+                will be changed
+            index (int): index of plotter to modify
+        """
+
+        plotter = system.plotters[index]
+        system.add_mesh_kws[index]['opacity'] = plotter.opacity.value()
+
+        # TODO: add a function that adds only the mesh actor, rather than redrawing
+        #       the entire scene every time.
         self.draw_map(
             system.meshes[index],
             system.plotters[index],


### PR DESCRIPTION
Fixes #95 

Add a `QDoubleSpinBox` for setting the opacity of a single mesh. Takes values between 0 a 1, with in increments of 0.05. The map is redrawn after each change in opacity value.