### PR TITLE
Streamline changes to renderer

### DIFF
--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -662,6 +662,9 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
         system.plotters[index].active_scalars_sel = scalars
         system.docks[index].setWindowTitle(system.plotters[index].title)
+
+        # TODO: use pyvista's mesh.point_data and mesh.set_active_scalars instead of
+        # redrawing the whole scene each time
         self.draw_map(
             system.meshes[index],
             system.plotters[index],

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -588,22 +588,20 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             index (int): index of plotter to modify
         """
 
-        if not system.plotters[index].lower_limit.text().strip():
+        plotter = system.plotters[index]
+
+        if not plotter.lower_limit.text().strip():
             return
-        elif not system.plotters[index].upper_limit.text().strip():
+        elif not plotter.upper_limit.text().strip():
             return
 
         lower_limit = float(system.plotters[index].lower_limit.text())
         upper_limit = float(system.plotters[index].upper_limit.text())
         system.add_mesh_kws[index]["clim"] = [lower_limit, upper_limit]
 
-        self.draw_map(
-            system.meshes[index],
-            system.plotters[index],
-            system.plotters[index].active_scalars,
-            system.add_mesh_kws[index],
-            system.free_boundaries[index],
-        )
+        actor = plotter.renderer._actors['mesh']
+        actor_mapper = actor.GetMapper()
+        actor_mapper.SetScalarRange((lower_limit, upper_limit))
 
     def update_opacity(self, system, index):
         """Update the opacity for a given ploter.

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -617,15 +617,9 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         plotter = system.plotters[index]
         system.add_mesh_kws[index]['opacity'] = plotter.opacity.value()
 
-        # TODO: add a function that adds only the mesh actor, rather than redrawing
-        #       the entire scene every time.
-        self.draw_map(
-            system.meshes[index],
-            system.plotters[index],
-            system.plotters[index].active_scalars,
-            system.add_mesh_kws[index],
-            system.free_boundaries[index],
-        )
+        actor = plotter.renderer._actors['mesh']
+        actor_properties = actor.GetProperty()
+        actor_properties.SetOpacity(plotter.opacity.value())
 
     def change_active_system(self, system):
         """


### PR DESCRIPTION
Changes made:

* when changing the colourbar limits, the scalar range of the mapper is changed rather than redrawing the whole scene
* when changing the opacity of the mesh, the opacity of the actor is changed in place rather than redrawing the scene each time

TODO: when changing the field projected onto the mesh, use pyvista's `set_active_scalars` rather than redrawing the scene
