### PR TITLE
Add scalar fields

### DIFF
--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -550,9 +550,36 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         system.add_mesh_kws.append(add_mesh_kws)
         system.free_boundaries.append(free_boundaries)
 
-        for action_name, action in plotter.scalar_field_actions.items():
-            action.triggered.connect(
-                lambda: self.change_active_scalars(system, index=index, scalars=action_name)
+        # We can't put this into a for loop.
+        # For some reason, when iterating over the items in plotter.scalar_field_actions,
+        # all actions are passed the key in the iteration for the scalars argument
+        if 'Bipolar voltage' in plotter.scalar_field_actions:
+            plotter.scalar_field_actions['Bipolar voltage'].triggered.connect(
+                lambda: self.change_active_scalars(system, index=index, scalars='Bipolar voltage')
+            )
+        if 'Unipolar voltage' in plotter.scalar_field_actions:
+            plotter.scalar_field_actions['Unipolar voltage'].triggered.connect(
+                lambda: self.change_active_scalars(system, index=index, scalars='Unipolar voltage')
+            )
+        if 'Clinical bipolar voltage' in plotter.scalar_field_actions:
+            plotter.scalar_field_actions['Clinical bipolar voltage'].triggered.connect(
+                lambda: self.change_active_scalars(system, index=index, scalars='Clinical bipolar voltage')
+            )
+        if 'Clinical unipolar voltage' in plotter.scalar_field_actions:
+            plotter.scalar_field_actions['Clinical unipolar voltage'].triggered.connect(
+                lambda: self.change_active_scalars(system, index=index, scalars='Clinical unipolar voltage')
+            )
+        if 'Clinical LAT' in plotter.scalar_field_actions:
+            plotter.scalar_field_actions['Clinical LAT'].triggered.connect(
+                lambda: self.change_active_scalars(system, index=index, scalars='Clinical LAT')
+            )
+        if 'Clinical force' in plotter.scalar_field_actions:
+            plotter.scalar_field_actions['Clinical force'].triggered.connect(
+                lambda: self.change_active_scalars(system, index=index, scalars='Clinical force')
+            )
+        if 'Clinical impedance' in plotter.scalar_field_actions:
+            plotter.scalar_field_actions['Clinical impedance'].triggered.connect(
+                lambda: self.change_active_scalars(system, index=index, scalars='Clinical impedance')
             )
 
         dock.setWindowTitle(f"{system.name}: {mesh.active_scalars_info.name}")


### PR DESCRIPTION
Fixes #2 

Changes made:

* `openep.draw.draw_map` has previously been modified to use any provided scalar field. In this PR, the option to use the following scalar fields in the GUI has been added:
    - Bipolar voltage (interpolated for OpenEP datasets, calculated from EGMs for openCARP)
    - Unipolar voltage (as above)
    - Clinical bipolar voltage
    - Clinical unipolar voltage
    - Clinical LAT
    - Clinical force
    - Clinical impedance
  
* For the clinical fields, the options are only available if the field is not full of NaNs

* Pyvista's `mesh.set_active_scalars` is used to control which field is currently used. There is a bug in pyvista that changes the active scalars if a title is set for the colourbar (see https://github.com/pyvista/pyvista/issues/1900#issue-1067446986). This is handled by checking the name of the active scalars before adding the mesh, then setting the active scalars to be whatever they were before.