### PR TITLE
Add option to GUI to to export OpenEP data to openCARP

### DIFF
--- a/openep/data_structures/openCARP.py
+++ b/openep/data_structures/openCARP.py
@@ -131,7 +131,7 @@ class CARPData:
             annotations=annotations,
         )
 
-        # We will need to original info if we later want to update bipolar egms/pairs
+        # We will need the original info if we later want to update bipolar egms/pairs
         # based on a different window of interest
         self._unipolar = unipolar
         self._unipolar_pairs = pair_indices


### PR DESCRIPTION
Changes made:

* Add an Export option to the File menu of the GUI for exporting OpenEP datasets
* Currently, can only be used to export mesh data from an OpenEP case into openCARP format (*.pts and *.elem files).
* Uses `openep.io.writeres.export_openCARP`