### PR TITLE
Visualise mapping points in the GUI

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -115,6 +115,11 @@ class Case:
     ablation: Optional[Ablation] = None
     notes: Optional[List] = None
 
+    def __attrs_post_init__(self):
+
+        tmp_mesh = self.create_mesh(recenter=False)
+        self._mesh_center = np.asarray(tmp_mesh.center)
+
     def __repr__(self):
         return f"{self.name}( nodes: {self.points.shape} indices: {self.indices.shape} {self.fields} )"
 

--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -145,14 +145,25 @@ class System:
         return mesh
 
     def _create_default_kws(self):
-        """Create a dictionary of keyword arguments to be passed to openep.draw.draw_map"""
+        """Create a dictionary of keyword arguments to be passed to openep.draw.draw_map and plotter.add_points"""
 
-        return {
+        add_mesh_kws = {
             "clim": [0, 5],
+            "name": "Surface",
+            "opacity": 1,
             "scalar_bar_args": {
                 "title": "Voltage (mV)",
             }
         }
+
+        add_points_kws = {
+            "render_points_as_spheres": True,
+            "point_size": 10,
+            "opacity": 1,
+            "show_scalar_bar": False,
+        }
+
+        return add_mesh_kws, add_points_kws
 
 class SystemManager:
     """Keep track of all systems loaded into the GUI"""

--- a/openep/view/system_ui.py
+++ b/openep/view/system_ui.py
@@ -66,6 +66,11 @@ def add_field_menu(dock, plotter, system_name, scalar_fields):
             menu are selected.
         system_name (str): Name of the system. Will be used in setting the title of the dock widget.
         scalar_fields (dict): Names and values of the scalar fields to be added as options in the Field menu.
+
+    Returns:
+        dock (CustomDockWidget): Dockwidget with a 'Field' menu added to the menubar.
+        plotter (BackgroundPlotter): Plotter with actions for selecting the scalar field stored in a dictionary
+            as the attribute `plotter.scalar_field_actions`.
     """
 
     field_menu = dock.main.menubar.addMenu("Field")
@@ -81,5 +86,33 @@ def add_field_menu(dock, plotter, system_name, scalar_fields):
         field_menu.addAction(action)
         field_group.addAction(action)
         plotter.scalar_field_actions[field_name] = action
+
+    return dock, plotter
+
+def add_show_menu(dock, plotter):
+    """Add a Show menu to the menubar. This is used for showing/hiding the mesh, mapping points, surface-projected mapping points.
+
+    Args:
+        dock (CustomDockWidget): the dockwidget to which the 'Show' menu will be added to the menubar
+        plotter (BackgroundPlotter): The plotter which will have actions added for when specific values from the Show
+            menu are selected.
+
+    Returns:
+        dock (CustomDockWidget): Dockwidget with a 'Show' menu added to the menubar.
+        plotter (BackgroundPlotter): Plotter with actions for showing/hiding actors stored in a dictionary
+            as the attribute `plotter.show_actions`.
+    """
+
+    show_menu = dock.main.menubar.addMenu("Show/Hide")
+
+    plotter.show_actions = {}
+    action_names = ["Surface", "Mapping points", "Surface-projected mapping points"]
+    for action_name in action_names:
+
+        action = QtWidgets.QAction(action_name, dock.main, checkable=True)
+        show = True if action_name=="Surface" else False  # by default only display the mesh
+        action.setChecked(show)
+        show_menu.addAction(action)
+        plotter.show_actions[action_name] = action
 
     return dock, plotter

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -73,6 +73,8 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
         self.setMinimumSize(800, 600)
         self.setWindowTitle("OpenEP: The open-source solution for electrophysiology data analysis")
+        self.setToolTipDuration(-1)
+        self.setAttribute(QtCore.Qt.WA_MacOpaqueSizeGrip, True)
 
     def _create_system_manager_ui(self):
         """Create a dockable widget that for managing systems loaded into the GUI"""        

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -571,7 +571,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
         # Doing add_mesh and setting a title to the colour bar causes pyvista to add
         # the data to the point_data array with the name of the title, and then sets this
-        # new point_data array as the active scalars.
+        # new point_data array as the active scalars. We need to undo this unwanted behaviour.
         mesh.set_active_scalars(active_scalars_name)
 
         # If this is the first 3d viewer for the first system loaded, we need to update the egms etc.

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -495,6 +495,13 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             scalar_fields=system.scalar_fields,
         )
 
+        # Add a Show/Hide menu to the menubar. This is used for showing/hiding the surface mesh, mapping points,
+        # and surface-projected mapping points
+        dock, plotter = openep.view.system_ui.add_show_menu(
+            dock=dock,
+            plotter=plotter,
+        )
+
         mesh = system.create_mesh()
         add_mesh_kws = system._create_default_kws()
         free_boundaries = openep.mesh.get_free_boundaries(mesh)
@@ -562,7 +569,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
         # Doing add_mesh and setting a title to the colour bar causes pyvista to add
         # the data to the point_data array with the name of the title, and then sets this
-        # new point_data array as the active scalars
+        # new point_data array as the active scalars.
         mesh.set_active_scalars(active_scalars_name)
 
         # If this is the first 3d viewer for the first system loaded, we need to update the egms etc.


### PR DESCRIPTION
Fixes #92 

Changes made:
* Added a 'Show/Hide' menu to the menubar of each 3d viewer
* Can selected to show or hide the:
    * mesh
    * mapping points
    * surface-projected mapping points
* By default, only the mesh is visible
* The opacity selector changes the opacity of the mesh only (not that of the mapping points)
* The Field selection is used to colour the mesh only (all points are rendered grey).
