### PR TITLE
Visualise mapping points in the GUI - opencarp

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -255,11 +255,16 @@ class Case:
 
         self.electric.unipolar_egm = unipolar_egm
 
+        # TODO: This assumes that all mapping points are on the surface, and that there is
+        #       one electrogram for each point on the surface.
+        # TODO: Calculate the normals of the surface at these points.
+        self.electric.surface.nearest_point = self.points.copy()
+
         if add_bipolar:
 
             bipolar_egm = Electrogram(
                 egm=bipolar,
-                points=self.points,
+                points=self.points.copy(),
                 voltage=np.ptp(bipolar, axis=1),
                 names=names,
             )


### PR DESCRIPTION
Update to #113 

Changes made:
* Ensure the show/hide menu of the 3d viewers works for opencarp cases
* Previously, there were no surface projected points calculated when loading an opencarp case and unipolar electrograms