### PR TITLE
Set maximum PyQt5 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pyvista>=0.33
 pymeshfix
 trimesh
 shapely
-PyQt5
+PyQt5<5.14
 pyvistaqt>=0.6
 typing_extensions


### PR DESCRIPTION
Changes made:
* PyQt5 version must be less than 5.14.
* With versions >=5.14 the screen flickers red when resizing the 3d viewers.