### PR TITLE
Refresh the 3d viewer more frequently

### DIFF
--- a/openep/view/plotters.py
+++ b/openep/view/plotters.py
@@ -41,6 +41,7 @@ def create_plotter():
         title=None,
         border=False,
         update_app_icon=False,
+        auto_update=100,
     )
     plotter.background_color = '#d8dcd6'
     plotter.setMinimumSize(QtCore.QSize(50, 50))


### PR DESCRIPTION
Changes made:
* In the GUI, the `BackgroundPlotter`s are set to auto-update 100 times per second (rather than the previous default of 5)
* This provides a smoother experience when rotating linked 3d viewers
* The value could be increased further, but it will start to affect performance, especially when multiple 3d viewers are openep