### PR TITLE
Add table to the GUI for displaying info about mapping points

### DIFF
--- a/openep/view/mapping_points.py
+++ b/openep/view/mapping_points.py
@@ -1,0 +1,134 @@
+# OpenEP
+# Copyright (c) 2021 OpenEP Collaborators
+#
+# This file is part of OpenEP.
+#
+# OpenEP is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenEP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program (LICENSE.txt).  If not, see <http://www.gnu.org/licenses/>
+
+"""
+Class and functions for handling and displaying list of mapping points.
+"""
+
+from typing import Optional
+
+from PySide2 import QtCore, QtWidgets
+from PySide2.QtCore import Qt
+
+import numpy as np
+
+from openep.view.custom_widgets import CustomDockWidget
+from openep.view.system_manager import System
+
+class MappingPointsModel(QtCore.QAbstractTableModel):
+    
+    def __init__(
+        self,
+        system,
+    ):
+            
+        super().__init__()
+        self._system = system
+        self._init_headers()
+        self._init_data()
+    
+    @property
+    def system(self):
+        return self._system
+    
+    @system.setter
+    def system(self, system):
+        self._system = system
+        self._init_data()
+
+    def _init_headers(self):
+        
+        self.headers = ["Index", "Tag", "Name", "Voltage", "LAT"]
+
+    def headerData(self, section, orientation, role):
+        if role == QtCore.Qt.DisplayRole :
+            if orientation == QtCore.Qt.Horizontal :
+                return self.headers[section]
+            elif orientation == QtCore.Qt.Vertical :
+                return section
+        return None
+
+    def _init_data(self):
+        """Extract mapping point data from the system.
+        
+        Store data in a 2d array, as required for displaying in a table.
+        """
+        
+        if self._system is None:
+            self._data = None
+            return
+
+        electric = self._system.case.electric
+        has_bipolar = True if electric.bipolar_egm.egm is not None else False
+        
+        if not has_bipolar:
+            self._data = None
+            return
+
+        if not hasattr(electric, '_include'):
+            electric._include = np.full_like(
+                electric.bipolar_egm.voltage,
+                fill_value=True,
+                dtype=bool,
+            )
+
+        activation_time = electric.annotations.local_activation_time - electric.annotations.reference_activation_time
+        self._data = np.concatenate(
+            [
+                np.arange(electric.bipolar_egm.voltage.shape[0], dtype=int)[:, np.newaxis],
+                electric.names[:, np.newaxis],
+                electric.internal_names[:, np.newaxis],
+                electric.bipolar_egm.voltage[:, np.newaxis],
+                activation_time[:, np.newaxis],
+            ],
+            axis=1,
+        )
+        
+        self.layoutChanged.emit()
+
+    def data(self, index, role):
+        
+        if role == Qt.DisplayRole:
+            
+            value = self._data[index.row(), index.column()]
+            return value
+    
+    def rowCount(self, index=None):
+        return 0 if self._data is None else self._data.shape[0]
+
+    def columnCount(self, index=None):
+        return 0 if self._data is None else self._data.shape[1]
+
+class MappingPointsDock(CustomDockWidget):
+    """A dockable widget for handling and viewing the mapping points data."""
+
+    def __init__(self, title: str, system: Optional[System] = None):
+
+        super().__init__(title)
+        
+        self.model = MappingPointsModel(system=system)
+        self.proxy_model = QtCore.QSortFilterProxyModel()
+        self.proxy_model.setSourceModel(self.model)
+        self.table = QtWidgets.QTableView()
+        self.table.setModel(self.proxy_model)
+        self.table.setSortingEnabled(True)
+        self.table.setShowGrid(False)
+        
+        self.main = QtWidgets.QMainWindow()
+        self.main.setCentralWidget(self.table)
+        self.setWidget(self.main)

--- a/openep/view/mapping_points.py
+++ b/openep/view/mapping_points.py
@@ -130,10 +130,6 @@ class SortProxyModel(QtCore.QSortFilterProxyModel):
             if not str(e).startswith("could not convert string to float:"):
                 raise e
             return left_var < right_var
-    
-    #def filterAcceptsRow(self, source_row: int, source_parent: QtCore.QModelIndex) -> bool:
-    #    index = self.sourceModel().index(source_row, 0, source_parent)
-    #    return self.sourceModel()._include[index.row()]
 
 class MappingPointsDock(CustomDockWidget):
     """A dockable widget for handling and viewing the mapping points data."""
@@ -169,7 +165,6 @@ class MappingPointsDock(CustomDockWidget):
         """Create menu for selecting which columns to show when right-clicking on the header"""
 
         header = self.table.horizontalHeader()
-        # header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
         header.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         header.customContextMenuRequested.connect(self._launch_header_context_menu)
         
@@ -185,7 +180,6 @@ class MappingPointsDock(CustomDockWidget):
             )
         
     def _launch_header_context_menu(self, pos):
-        # column_index = self.table.horizontalHeader().logicalIndexAt(pos)
         self.header_menu.exec_(QtGui.QCursor.pos())
 
     def column_visibility(self, show, column_index):

--- a/openep/view/system_manager_ui.py
+++ b/openep/view/system_manager_ui.py
@@ -100,7 +100,7 @@ class SystemManagerDockWidget(CustomDockWidget):
         # We're going to add an additional column to take care of spacing
         self.table_layout.setHorizontalSpacing(0)
         
-        # We use a large number here so the rows do not change size to fill the verical space
+        # We use a large number here so the rows do not change size to fill the vertical space
         self.table_layout.setRowStretch(1e6, 1)
 
         # add a row containing heading labels to the grid

--- a/openep/view/system_manager_ui.py
+++ b/openep/view/system_manager_ui.py
@@ -141,7 +141,7 @@ class SystemManagerDockWidget(CustomDockWidget):
             # This adds a small space between the columns.
             if column < len(heading_names) - 1:
                 self.table_layout.addWidget(heading, row, 2 * column, row_width, column_width:=2)
-                self.table_layout.setColumnMinimumWidth(2 * column + 1, 20 * self._column_stretches[column])
+                self.table_layout.setColumnMinimumWidth(2 * column + 1, 10 * self._column_stretches[column])
                 self.table_layout.setColumnStretch(2 * column, self._column_stretches[column])
             else:
                 self.table_layout.addWidget(heading, row, 2 * column, row_width, column_width:=1, self._alignments[column])
@@ -243,8 +243,6 @@ class SystemManagerDockWidget(CustomDockWidget):
             # This adds a small space between the columns.
             if column < len(widgets) - 1:
                 self.table_layout.addWidget(widget, row_number, 2 * column, row_width, column_width:=2)
-                self.table_layout.setColumnMinimumWidth(2 * column + 1, 20 * self._column_stretches[column])
-                self.table_layout.setColumnStretch(2 * column, self._column_stretches[column])
             else:
                 self.table_layout.addWidget(widget, row_number, 2 * column, row_width, column_width:=1, self._alignments[column])
 

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -37,6 +37,7 @@ import numpy as np
 import openep
 
 import openep.view.custom_widgets
+import openep.view.mapping_points
 import openep.view.canvases
 import openep.view.annotations_ui
 import openep.view.plotters_ui
@@ -69,6 +70,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         self._create_system_manager_ui()
         self._create_egm_canvas_dock()
         self._create_annotate_dock()
+        self._create_mapping_points_dock()
         self._create_analysis_canvas_dock()
         self._add_dock_widgets()
         self._disable_dock_widgets()
@@ -205,6 +207,13 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         # hide the figure until we have data to plot
         self.annotate_dock.deactivate_figure()
     
+    def _create_mapping_points_dock(self):
+        """Create a dockable widget for displaying mapping points info."""
+
+        self.mapping_points = openep.view.mapping_points.MappingPointsDock(
+            title="Mapping points",
+            system=None,
+        )
 
     def _create_analysis_canvas_dock(self):
         """
@@ -256,11 +265,13 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         #self.addDockWidget(Qt.LeftDockWidgetArea, self.egm_dock)
         self.addDockWidget(Qt.LeftDockWidgetArea, self.annotate_dock)
         
+        self.splitDockWidget(self.system_manager_ui, self.mapping_points, Qt.Vertical)
+        
         #self.tabifyDockWidget(self.analysis_dock, self.system_manager_ui)
         #self.tabifyDockWidget(self.egm_dock, self.annotate_dock)
 
         #for dock in [self.analysis_dock, self.system_manager_ui, self.egm_dock,  self.annotate_dock]:
-        for dock in [self.system_manager_ui, self.annotate_dock]:
+        for dock in [self.system_manager_ui, self.annotate_dock, self.mapping_points]:
             dock.setAllowedAreas(Qt.AllDockWidgetAreas)
 
         self.setDockOptions(self.GroupedDragging | self.AllowTabbedDocks | self.AllowNestedDocks)
@@ -788,6 +799,8 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             self.egm_canvas.draw()
             
             self.annotate_dock.deactivate_figure()
+        
+        self.mapping_points.model.system = system
 
     def change_active_scalars(self, system, index, scalars):
         """Change the scalar values that are being projected onto the mesh."""

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -686,8 +686,9 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             self.change_active_system(system)
             self.addDockWidget(Qt.LeftDockWidgetArea, dock)
         else:
-            active_parent = self.system_manager.active_system.plotters[0]
-            self.tabifyDockWidgets(active_parent, dock)
+            active_parent = self.system_manager.active_system.docks[0]
+            self.tabifyDockWidget(active_parent, dock)
+            dock.setTitleBarWidget(QtWidgets.QWidget())
 
         self.highlight_menubars_of_active_plotters()
 

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -187,7 +187,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         self.annotate_dock.canvas.mpl_connect('key_press_event', self.annotation_on_key_press)
         self.annotate_dock.canvas.mpl_connect('scroll_event', self.annotation_on_scroll_wheel)  # this is scrolling with the wheel, not scrollbar
         
-        # We will need to disconnect and reconnect these events through uesr interaction
+        # We will need to disconnect and reconnect these events through user interaction
         self.annotate_dock.cid_button_press_event = self.annotate_dock.canvas.mpl_connect(
             'button_press_event',
             self.annotation_on_button_press,
@@ -790,7 +790,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             self.annotate_dock.deactivate_figure()
 
     def change_active_scalars(self, system, index, scalars):
-        """Cahnge the scalar values that are being projected onto the mesh."""
+        """Change the scalar values that are being projected onto the mesh."""
 
         dock = system.docks[index]
         dock.setWindowTitle(f"{system.name}: {scalars}")

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -246,12 +246,6 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         analysis_canvas_main = QtWidgets.QMainWindow()
         analysis_canvas_main.setCentralWidget(canvas_widget)
 
-        # The dock is set to have bold font (so the title stands out)
-        # But all other widgets should have normal weighted font
-        #main_font = QtGui.QFont()
-        #main_font.setBold(False)
-        #analysis_canvas_main.setFont(main_font)
-
         self.analysis_dock.setWidget(analysis_canvas_main)
 
     def _add_dock_widgets(self):
@@ -259,18 +253,10 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         Add dockable widgets to the main window.
         """
 
-        #self.addDockWidget(Qt.RightDockWidgetArea, self.analysis_dock)
         self.addDockWidget(Qt.RightDockWidgetArea, self.system_manager_ui)
-
-        #self.addDockWidget(Qt.LeftDockWidgetArea, self.egm_dock)
-        self.addDockWidget(Qt.LeftDockWidgetArea, self.annotate_dock)
-        
         self.splitDockWidget(self.system_manager_ui, self.mapping_points, Qt.Vertical)
+        self.splitDockWidget(self.mapping_points, self.annotate_dock, Qt.Vertical)
         
-        #self.tabifyDockWidget(self.analysis_dock, self.system_manager_ui)
-        #self.tabifyDockWidget(self.egm_dock, self.annotate_dock)
-
-        #for dock in [self.analysis_dock, self.system_manager_ui, self.egm_dock,  self.annotate_dock]:
         for dock in [self.system_manager_ui, self.annotate_dock, self.mapping_points]:
             dock.setAllowedAreas(Qt.AllDockWidgetAreas)
 
@@ -675,8 +661,11 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         # If this is the first 3d viewer for the first system loaded, we need to update the egms etc.
         if (system.name == self.system_manager.active_system.name) and (len(system.plotters) == 1):
             self.change_active_system(system)
+            self.addDockWidget(Qt.LeftDockWidgetArea, dock)
+        else:
+            active_parent = self.system_manager.active_system.plotters[0]
+            self.tabifyDockWidgets(active_parent, dock)
 
-        self.addDockWidget(Qt.LeftDockWidgetArea, dock)
         self.highlight_menubars_of_active_plotters()
 
     def update_colourbar_limits(self, system, index):

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -97,7 +97,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
     def _create_system_manager_ui(self):
         """Create a dockable widget that for managing systems loaded into the GUI"""
 
-        self.system_manager_ui = openep.view.system_manager_ui.SystemManagetDockWidget(
+        self.system_manager_ui = openep.view.system_manager_ui.SystemManagerDockWidget(
             title="Systems"
         )
 
@@ -476,8 +476,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
     def update_system_manager_table(self, system):
         """Update the System manager table when a new system is loaded."""
 
-        # Not sure why * 10 works. But if not multiplied by at least 10, there is vertical overlap between rows
-        row_number = len(self.system_manager.systems) * 10
+        row_number = len(self.system_manager.systems)
 
         system.name_widget, *_, active_widget = self.system_manager_ui.update_system_manager_table(
             name=str(system.name),


### PR DESCRIPTION
Changes made:
* Display table of mapping points in a window titled 'Mapping points'.
* Table contains:
  - point index (0 based)
  - point tag (internal name used by clinical mapping system)
  - point name
  - bipolar voltage
  - local activation time
* Can sort by each column
* Can select which columns to show/hide (a context menu appears when right-clicking on the table header)
* Can delete points. Use the left mouse button to highlight points, then right-click to bring up context menu. Select 'delete point(s)'
* The points are moved to the 'Recycle bin'. This is another table, similar to the Mapping Points table, that contains the deleted points. Points can be restored from the recycle bin in the same way they are deleted from the Mapping Points table.