### PR TITLE
Plot the electrogram of the currently selected point

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -282,3 +282,7 @@ class Case:
                 reference_activation_time=np.zeros_like(woi[:, 0], dtype=int)
             )
             self.electric.annotations = annotations
+
+        # whether the mapping points have been rejected (include==False)
+        include = np.full_like(names, fill_value=True, dtype=bool)
+        self.electric.include = include

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -156,6 +156,7 @@ class Electric:
 
     names: np.ndarray
     internal_names: np.ndarray
+    include: np.ndarray
     bipolar_egm: Electrogram
     unipolar_egm: Electrogram
     reference_egm: Electrogram
@@ -183,6 +184,14 @@ def extract_electric_data(electric_data):
 
     names = electric_data['tags'].astype(str)
     internal_names = electric_data['names'].astype(str)
+    if 'include' in electric_data:
+        include = electric_data['include'].astype(bool)
+    else:
+        include = np.full_like(
+            names,
+            fill_value=True,
+            dtype=bool,
+        )
 
     # TODO: check if gain values are stored in electric_data before creating the default values
     bipolar_egm = Electrogram(
@@ -228,6 +237,7 @@ def extract_electric_data(electric_data):
     electric = Electric(
         names=names,
         internal_names=internal_names,
+        include=include,
         bipolar_egm=bipolar_egm,
         unipolar_egm=unipolar_egm,
         reference_egm=reference_egm,
@@ -250,6 +260,7 @@ def empty_electric():
 
     names = None
     internal_names = None
+    include = None
 
     bipolar_egm = Electrogram(
         egm=None,
@@ -291,6 +302,7 @@ def empty_electric():
     electric = Electric(
         names=names,
         internal_names=internal_names,
+        include=include,
         bipolar_egm=bipolar_egm,
         unipolar_egm=unipolar_egm,
         reference_egm=reference_egm,

--- a/openep/view/annotations_ui.py
+++ b/openep/view/annotations_ui.py
@@ -514,7 +514,6 @@ class AnnotationWidget(CustomDockWidget):
             line._original_ydata = signal.copy()
             line._ystart = separation
             self.add_artist(artist=line, label=label, signal=True)
-            self.signal_artists[label] = line
 
         # Set an active artists (has a thicker linewidth than other lines. The gain can be set by scrolling).
         self.active_signal_artist = labels[0]

--- a/openep/view/mapping_points.py
+++ b/openep/view/mapping_points.py
@@ -35,8 +35,8 @@ class MappingPointsModel(QtCore.QAbstractTableModel):
     
     The following data for each mapping point is stored in a 2D Numpy Array:
         - index (0-based)
-        - tag (internal name used by clinical mapping system)
-        - name (name presented to the user of the clinical mapping system)
+        - tag  (physician-visible name of the point applied during the clinical case)
+        - name (internal name used by clinical mapping system)
         - bipolar voltage
         - local activation time
 
@@ -86,7 +86,7 @@ class MappingPointsModel(QtCore.QAbstractTableModel):
         
         if self._system is None:
             self._data = None
-            self._include = np.array([])
+            self.include = np.array([])
             return
 
         electric = self._system.case.electric
@@ -94,17 +94,10 @@ class MappingPointsModel(QtCore.QAbstractTableModel):
         
         if not has_bipolar:
             self._data = None
-            self._include = np.array([])
+            self.include = np.array([])
             return
 
-        # TODO: this should be handled when loading the data set
-        if not hasattr(electric, '_include'):
-            electric._include = self._include = np.full_like(
-                electric.bipolar_egm.voltage,
-                fill_value=True,
-                dtype=bool,
-            )
-
+        self.include = electric.include
         self._index = np.arange(electric.bipolar_egm.voltage.shape[0], dtype=int)
         
         # TODO: should the activation time be absolute, or relative to the window of interest?

--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -64,6 +64,11 @@ class System:
     def _determine_available_fields(self):
         """Create a dictionary of scalar fields that can be used to colour the 3D map."""
 
+        # TODO: Don't distinguish between Clinical and non-clinical data. Use clinical by default. If
+        #       values are interpolated from mapping points onto the surface, then overwrite the
+        #       default clinical values. Add an option to reset the interpolated values to the original
+        #       clinical ones. This can be done by simply reading the file.
+
         if self.type == 'OpenEP':
             self._determine_available_OpenEP_fields()
         elif self.type == 'openCARP':

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -642,9 +642,8 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         Update selected active system.
 
         Make the menubars blue for all 3d viewers of the active system.
-        If the active system has electrograms, plot these in the electrogram viewer.
-        Change the window of interest range slider in the electrogram viewer to reflect
-        those of the active system.
+        If the active system has electrograms, plot these in the annotation viewer.
+        Update the mapping points and recycle bin tables with the electrical data.
         """
 
         self.system_manager.active_system = system


### PR DESCRIPTION
Changes made:
* There is no longer a QComboBox for selecting which electrogram to plot in the annotation viewer
* Instead, the electrogram to plot is determined by the currently-selected point in the mapping points and recycle bin tables
* The name of the point is displayed where the QComboBox was, using a QLabel
* If the point has been deleted (i.e. moved to the recycle bin), this is indicated in the QLabel