### PR TITLE
Use correct mapping point index when adjusting annotations in the GUI

### DIFF
--- a/openep/view/annotations_ui.py
+++ b/openep/view/annotations_ui.py
@@ -52,6 +52,7 @@ class AnnotationWidget(CustomDockWidget):
         super().__init__(title)
         self._init_main_window()
         self._initialise_annotations()
+        self._current_index = None  # index of mapping point currently plotted in the viewer
 
         # TODO: Get the resolution of the screen
         #       We can use this to set the size of the figure and the font size


### PR DESCRIPTION
Changes made:
* Fixed the updating of artists in the annotation viewer. #122 introduced a bug in which the annotation viewer hadn't been updated to account for the removal of the QComboBox. 
* Can no longer press the 'Up' or 'Down' keys in the annotation viewer to change which mapping is has its electrograms displayed. The mapping point must be selected in the tables (mapping points or recycle bin).