### PR TITLE
Enable point picking in the 3d viewer

### DIFF
--- a/openep/view/mapping_points.py
+++ b/openep/view/mapping_points.py
@@ -83,10 +83,11 @@ class MappingPointsModel(QtCore.QAbstractTableModel):
         
         Store data in a 2d array, as required for displaying in a table.
         """
-        
+        self.layoutAboutToBeChanged.emit()
         if self._system is None:
             self._data = None
             self.include = np.array([])
+            self.layoutChanged.emit()
             return
 
         electric = self._system.case.electric

--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -193,6 +193,7 @@ class System:
         """Create a dictionary of keyword arguments for plotting meshes, points, and surface-projected discs."""
 
         add_mesh_kws = {
+            "pickable": False,  # never set to True
             "clim": [0, 5],
             "name": "Surface",
             "opacity": 1,
@@ -202,6 +203,7 @@ class System:
         }
 
         add_points_kws = {
+            "pickable": False,  # only set to True for the primary viewer
             "name": "Mapping points",
             "opacity": 1,
             "show_scalar_bar": False,
@@ -210,6 +212,7 @@ class System:
         }
 
         add_discs_kws = {
+            "pickable": False,  # only set to True for the primary viewer
             "name": "Surface-projected mapping points",
             "opacity": 1,
             "show_scalar_bar": False,

--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -150,6 +150,17 @@ class System:
 
         return mesh
 
+    def create_selected_point_mesh(self, point):
+        """Create a mesh that will be used for highlighting the selected point"""
+
+        point_mesh = pyvista.PolyData(point)
+        point_geometry = pyvista.Sphere(theta_resolution=20, phi_resolution=20)
+
+        factor = 2 if self.type == "OpenEP" else 2000
+        glyphed_mesh = point_mesh.glyph(scale=False, factor=factor, geom=point_geometry)
+
+        return glyphed_mesh
+
     def create_mapping_points_mesh(self):
         """Create a mesh that contains the mapping points."""
 

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -1055,10 +1055,8 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         n_glphys_per_mapping_point = picked_mesh.points.size // n_mapping_points
         current_index = picked_point_id // n_glphys_per_mapping_point
         is_included = system.case.electric.include[current_index]
-        
-        model = self.mapping_points.model if is_included else self.recycle_bin.model
         table = self.mapping_points.table if is_included else self.recycle_bin.table
-        table.setCurrentIndex(model.index(current_index, 0))
+        table.selectRow(current_index)
 
     def annotation_on_button_press(self, event):
         """Update active artist on mouse button press, or set up call backs for moving annotations."""


### PR DESCRIPTION
Changes made:
* enable point picking in the primary 3d viewer of the active system
* press 'p' to select one of the mapping points ( must be a mapping point - not a surface-projected mapping point)
* this will draw that mapping point as a large red sphere
* it will also select the mapping point in the relevant table (mapping points table or recycle bin), and plot the electrogram for this point
* selecting a point in the mapping points or recycle bin tables will highlight this point in the 3d viewer