### PR TITLE
Ensure point-picking works on Mac retina displays

### DIFF
--- a/openep/view/plotters.py
+++ b/openep/view/plotters.py
@@ -51,4 +51,11 @@ def create_plotter():
     plotter.parallel_projection = True
     plotter.setMinimumSize(QtCore.QSize(50, 50))
 
+    # This is a hack to ensure point-picking works correctly on Mac retina displays.
+    # _getPixelRatio was introduced to fix this bug. However, it now seems to be
+    # the **cause** of this bug.
+    # See: https://gitlab.kitware.com/vtk/vtk/-/issues/18195
+    # and https://gitlab.kitware.com/vtk/vtk/-/merge_requests/4201/diffs
+    plotter.iren.interactor._getPixelRatio = lambda _: 1
+
     return plotter


### PR DESCRIPTION
PyVista's `BacgroundPlotter` subclasses `QVTKRenderWindowInteractor`. The point picker of the interactor unnecessarily and incorrectly scales the coordinates of picked points. See: 
* https://gitlab.kitware.com/vtk/vtk/-/issues/18195
* https://gitlab.kitware.com/vtk/vtk/-/merge_requests/4201/diffs

Changes made:
* After creating a `pyvista.BackgroundPlotter`, set the `_getPixelRatio` static method of it's interactor to always return 1. This prevents the scaling of the coordinates of the picked point.