### PR TITLE
Export data in OpenEP format (*.mat)

### DIFF
--- a/openep/__init__.py
+++ b/openep/__init__.py
@@ -19,5 +19,5 @@
 __all__ = ['case', 'mesh', 'draw']
 
 from .io.readers import load_openep_mat, load_opencarp
-from .io.writers import export_openCARP
+from .io.writers import export_openCARP, export_openep_mat
 from . import case, mesh, draw

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -120,9 +120,9 @@ def load_openep_mat(filename, name=None):
         ablation = None
 
     try:
-        notes = data['notes']
+        notes = np.asarray(data['notes']).reshape(-1, 1)
     except KeyError:
-        notes = []
+        notes = np.asarray([""], dtype=str)[:, np.newaxis]
 
     return Case(name, points, indices, fields, electric, ablation, notes)
 

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -164,7 +164,7 @@ def _extract_surface_data(
 
     surface_data['triRep'] = {}
     surface_data['triRep']['X'] = points
-    surface_data['triRep']['Triangulation'] = indices
+    surface_data['triRep']['Triangulation'] = indices + 1  # MATLAB uses 1-based indexing
 
     surface_data['act_bip'] = np.concatenate(
         [

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -168,8 +168,8 @@ def _extract_surface_data(
 
     surface_data['act_bip'] = np.concatenate(
         [
-            fields.bipolar_voltage[:, np.newaxis],
             fields.local_activation_time[:, np.newaxis],
+            fields.bipolar_voltage[:, np.newaxis],
         ],
         axis=1,
     )

--- a/openep/view/system_manager_ui.py
+++ b/openep/view/system_manager_ui.py
@@ -146,7 +146,7 @@ class SystemManagerDockWidget(CustomDockWidget):
             else:
                 self.table_layout.addWidget(heading, row, 2 * column, row_width, column_width:=1, self._alignments[column])
 
-    def create_export_action(self, system_basename, export_name):
+    def create_export_action(self, system_basename):
         """Add an action to the Menubar for exporting a system dataset to a specific format.
 
         Args:
@@ -158,13 +158,15 @@ class SystemManagerDockWidget(CustomDockWidget):
         """
 
         # TODO: the menu should be created separately from the action
+        export_openep_action = QAction("as OpenEP", self)
+        export_openCARP_action = QAction("as openCARP", self)
         export_menu = QtWidgets.QMenu(system_basename, self)
-        export_action = QAction(export_name, self)
-        export_menu.addAction(export_action)
+        export_menu.addAction(export_openep_action)
+        export_menu.addAction(export_openCARP_action)
 
         self.main.export_data_menu.addMenu(export_menu)
 
-        return export_action
+        return export_openep_action, export_openCARP_action
 
     def create_view_action(self, system_basename):
         """Add an action to the Menubar for creating a new 3d viewer of a system.

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -235,15 +235,15 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         self.update_system_manager_table(system)
 
         # We need to dynamically add options for exporting data/creating 3D viewers to the main menubar
-        export_action = self.system_manager_ui.create_export_action(
+        export_openep_action, export_openCARP_action = self.system_manager_ui.create_export_action(
             system_basename=system.basename,
-            export_name="as openCARP",
         )
         view_action = self.system_manager_ui.create_view_action(
             system_basename=system.basename,
         )
 
-        export_action.triggered.connect(lambda: self._export_data_to_openCARP(system))
+        export_openCARP_action.triggered.connect(lambda: self._export_data_to_openCARP(system))
+        export_openep_action.triggered.connect(lambda: self._export_data_to_openep_mat(system))
         view_action.triggered.connect(lambda: self.add_view(system))
 
         self.interpolate_openEP_fields(system=system)
@@ -359,6 +359,28 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
                 # And also create the first 3d viewer
                 self.add_view(system)
+
+    def _export_data_to_openep_mat(self, system):
+        """Export data into an OpenEP .mat format"""
+
+        dialogue = QtWidgets.QFileDialog()
+        dialogue.DontUseNativeDialog = True
+        dialogue.setWindowTitle('Save As')
+        dialogue.setDirectory(QtCore.QDir.currentPath())
+        dialogue.setFileMode(QtWidgets.QFileDialog.AnyFile)
+        dialogue.setNameFilter("MATLAB file (*.mat)")
+
+        filename, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            caption="Save As",
+            directory=QtCore.QDir.currentPath(),
+            filter="MATLAB file (*.mat)",
+        )
+
+        openep.export_openep_mat(
+            case=system.case,
+            filename=filename,
+        )
 
     def _export_data_to_openCARP(self, system):
         """Export mesh data form an OpenEP dataset into openCARP format."""

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,0 +1,49 @@
+# OpenEP
+# Copyright (c) 2021 OpenEP Collaborators
+#
+# This file is part of OpenEP.
+#
+# OpenEP is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenEP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program (LICENSE.txt).  If not, see <http://www.gnu.org/licenses/>
+
+import pytest
+from numpy.testing import assert_allclose
+
+import numpy as np
+
+import openep
+from openep._datasets.openep_datasets import DATASET_2
+
+
+@pytest.fixture()
+def case():
+    return openep.load_openep_mat(DATASET_2)
+
+
+@pytest.fixture()
+def exported_case(case, tmp_path):
+
+    EXPORTED_CASE = tmp_path / "exported_case.mat"
+    openep.export_openep_mat(case, EXPORTED_CASE.as_posix())
+
+    return openep.load_openep_mat(EXPORTED_CASE)
+
+
+def test_openep_mat_export(case, exported_case):
+    """Check the scalar fields of the original and exported data set are equal."""
+
+    assert_allclose(case.fields.bipolar_voltage, exported_case.fields.bipolar_voltage, equal_nan=True)
+    assert_allclose(case.fields.unipolar_voltage, exported_case.fields.unipolar_voltage, equal_nan=True)
+    assert_allclose(case.fields.local_activation_time, exported_case.fields.local_activation_time, equal_nan=True)
+    assert_allclose(case.fields.force, exported_case.fields.force, equal_nan=True)
+    assert_allclose(case.fields.impedance, exported_case.fields.impedance, equal_nan=True)


### PR DESCRIPTION
Fixes #133 

Changes made:
* added a function `openep.io.writers.export_openep_mat` to store data in the OpenEP MATLAB format
* currently, the following fields are exported:
  - `userdata.notes`
  - `userdata.surface`
  - `userdata.electric` (`userdata.electric.impedances` are currently transposed compared to in OpenEP-core)
  - `userdata.surface`
  - `userdata.rf`
*  `userdata.surface.isVertexAtRim` and `userdata.rf_index` cannot be exported as they are not yet read in by `openep.load_openep_mat`
* Account for the 1-based indexing in MATLAB (and so `userdata.surface.triRep.Triangulation` indices are different)
* Added a simple test for writing OpenEP mat files. It checks whether the scalar fields (bipolar voltage, LAT, etc.) are the same in the original data set and in a data set written using  `openep.io.writers.export_openep_mat`. It would be better to check all attributes.
* Added an option to write OpenEP mat files in the GUI: `File > Export > <system filename> > as OpenEP`
