### PR TITLE
Colour deleted points yellow in 3d viewers of the GUI

### DIFF
--- a/openep/view/plotters.py
+++ b/openep/view/plotters.py
@@ -28,7 +28,6 @@ import pyvista
 
 pyvista.set_plot_theme('paraview')
 
-
 def create_plotter():
     """Initialise a BackgroundPlotter"""
 

--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -161,8 +161,13 @@ class System:
 
         return glyphed_mesh
 
-    def create_mapping_points_mesh(self):
-        """Create a mesh that contains the mapping points."""
+    def create_mapping_points_mesh(self, scalars, scalars_name):
+        """Create a mesh that contains the mapping points.
+
+        Args:
+            scalars (np.ndarray): Integer scalar values that will be used to colour the points.
+            scalars_name (str): Name given to the scalars. Can be used to set active scalars of the mesh.
+        """
 
         mapping_points_centered = self.case.electric.bipolar_egm.points - self.case._mesh_center
         mapping_points_mesh = pyvista.PolyData(mapping_points_centered)
@@ -170,6 +175,11 @@ class System:
         
         factor = 1.5 if self.type == "OpenEP" else 1200
         glyphed_mesh = mapping_points_mesh.glyph(scale=False, factor=factor, geom=point_geometry)
+
+        n_mapping_points = mapping_points_centered.size
+        n_glphys_per_mapping_point = glyphed_mesh.points.size // n_mapping_points
+
+        glyphed_mesh.point_data[scalars_name] = scalars.repeat(n_glphys_per_mapping_point)
 
         return glyphed_mesh
 
@@ -219,8 +229,11 @@ class System:
             "name": "Mapping points",
             "opacity": 1,
             "show_scalar_bar": False,
-            "smooth_shading": True,
+            "smooth_shading": False,
             "lighting": True,
+            "cmap": ["yellow", "#FFFFFF"],
+            #"opacity": "Include",  # Do not set opacity using active scalars - even if a point has zero opacity, it is still pickable.
+            "clim": [0, 1],
         }
 
         add_discs_kws = {


### PR DESCRIPTION
Fixes #136 

Changes made:
* When mapping points are deleted, they are displayed as yellow spheres in all relevant 3d viewers
* When they are restored, the colour returns to white
* It is not simple to hide the deleted points. It could be done using a separate mesh for each mapping point, but it is slow to create hundreds or thousands of meshes. The opacity of points can be set using scalar values, but points with zero opacity are still pickable, meaning points that are not visible can still be picked.
* Having two meshes - one for mapping points and one for deleted points - might work, deleting points from relevant mesh and adding them to the other when points are deleted/restored.