### PR TITLE
Show projected mapping points as cylinders in 3d viewers of the GUI

### DIFF
--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -52,7 +52,7 @@ class System:
         self.plotters = []
         self.meshes = []
         self.mapping_points_meshes = []
-        self.surface_projected_discs_meshes = []
+        self.surface_projected_cylinders_meshes = []
         self.free_boundaries = []
         self.add_mesh_kws = []
         self.scalar_fields = None
@@ -183,7 +183,7 @@ class System:
 
         return glyphed_mesh
 
-    def create_surface_discs_mesh(self, mesh):
+    def create_surface_cylinders_mesh(self, mesh):
         """Create a mesh that contains the surface-projected mapping points.
 
         Args:
@@ -204,20 +204,20 @@ class System:
         projected_mapping_points_mesh.point_data["Normals"] = mesh.point_normals[nearest_point_indices]
         projected_mapping_points_mesh.set_active_vectors("Normals", preference="point")
 
-        disc_geometry = pyvista.Disc(inner=0, r_res=1, c_res=360, normal=[1, 0, 0], center=[0, 0, 0])
+        cylinder_geometry = pyvista.Cylinder(height=0.5, resolution=360, direction=[1, 0, 0])
         factor = 1.5 if self.type == "OpenEP" else 1200
 
         glyphed_mesh = projected_mapping_points_mesh.glyph(
             orient="Normals",
             scale=False,
             factor=factor,
-            geom=disc_geometry,
+            geom=cylinder_geometry,
         )
 
         return glyphed_mesh
 
     def _create_default_kws(self):
-        """Create a dictionary of keyword arguments for plotting meshes, points, and surface-projected discs."""
+        """Create a dictionary of keyword arguments for plotting meshes, points, and surface-projected cylinders."""
 
         add_mesh_kws = {
             "pickable": False,  # never set to True
@@ -242,7 +242,7 @@ class System:
             "clim": [0, 1],
         }
 
-        add_discs_kws = {
+        add_cylinders_kws = {
             "pickable": False,  # only set to True for the primary viewer
             "name": "Surface-projected mapping points",
             "opacity": 1,
@@ -252,7 +252,7 @@ class System:
             "color": "#FFFFFF",
         }
 
-        return add_mesh_kws, add_points_kws, add_discs_kws
+        return add_mesh_kws, add_points_kws, add_cylinders_kws
 
 
 class SystemManager:

--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -183,11 +183,13 @@ class System:
 
         return glyphed_mesh
 
-    def create_surface_cylinders_mesh(self, mesh):
+    def create_surface_cylinders_mesh(self, mesh, scalars, scalars_name):
         """Create a mesh that contains the surface-projected mapping points.
 
         Args:
             mesh (pyvista.PolyData): Triangulated surface (from the clinical mapping system)
+            scalars (np.ndarray): Integer scalar values that will be used to colour the cylinders.
+            scalars_name (str): Name given to the scalars. Can be used to set active scalars of the cylinders.
         """
 
         mapping_points_centered = self.case.electric.bipolar_egm.points - self.case._mesh_center
@@ -213,6 +215,11 @@ class System:
             factor=factor,
             geom=cylinder_geometry,
         )
+
+        n_mapping_points = mapping_points_centered.size
+        n_glphys_per_mapping_point = glyphed_mesh.points.size // n_mapping_points
+
+        glyphed_mesh.point_data[scalars_name] = scalars.repeat(n_glphys_per_mapping_point)
 
         return glyphed_mesh
 
@@ -249,7 +256,8 @@ class System:
             "show_scalar_bar": False,
             "smooth_shading": True,
             "lighting": True,
-            "color": "#FFFFFF",
+            "cmap": ["yellow", "#FFFFFF"],
+            "clim": [0, 1],
         }
 
         return add_mesh_kws, add_points_kws, add_cylinders_kws

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -528,7 +528,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             scalars=system.case.electric.include.astype(int),
             scalars_name="Include",
         )
-        projected_discs = system.create_surface_discs_mesh()
+        projected_discs = system.create_surface_discs_mesh(mesh=mesh)
         add_mesh_kws, add_points_kws, add_discs_kws = system._create_default_kws()
         free_boundaries = openep.mesh.get_free_boundaries(mesh)
 

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -528,8 +528,8 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             scalars=system.case.electric.include.astype(int),
             scalars_name="Include",
         )
-        projected_discs = system.create_surface_discs_mesh(mesh=mesh)
-        add_mesh_kws, add_points_kws, add_discs_kws = system._create_default_kws()
+        projected_cylinders = system.create_surface_cylinders_mesh(mesh=mesh)
+        add_mesh_kws, add_points_kws, add_cylinders_kws = system._create_default_kws()
         free_boundaries = openep.mesh.get_free_boundaries(mesh)
 
         is_active_system = True if self.system_manager.active_system.name == system.name else False
@@ -571,13 +571,13 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             )
             
             add_points_kws['pickable'] = is_active_system
-            add_discs_kws['pickable'] = False  # TODO: allow picking of discs too
+            add_cylinders_kws['pickable'] = False  # TODO: allow picking of cylinders too
 
         system.docks.append(dock)
         system.plotters.append(plotter)
         system.meshes.append(mesh)
         system.mapping_points_meshes.append(mapping_points)
-        system.surface_projected_discs_meshes.append(projected_discs)
+        system.surface_projected_cylinders_meshes.append(projected_cylinders)
         system.add_mesh_kws.append(add_mesh_kws)
         system.free_boundaries.append(free_boundaries)
 
@@ -603,10 +603,10 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         )
         plotter.renderer._actors['Mapping points'].SetVisibility(True)
 
-        self.draw_nearest_points_discs(
-            mesh=projected_discs,
+        self.draw_nearest_points_cylinders(
+            mesh=projected_cylinders,
             plotter=plotter,
-            add_discs_kws=add_discs_kws,
+            add_cylinders_kws=add_cylinders_kws,
         )
         plotter.renderer._actors['Surface-projected mapping points'].SetVisibility(False)
 
@@ -747,7 +747,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             plotter = system.plotters[0]
             plotter.pickable_actors = [
                 plotter.renderer._actors['Mapping points'],
-            ]  # TODO: allow picking of projected discs too
+            ]  # TODO: allow picking of projected cylinders too
             system._highlight_actor.SetVisibility(True)
 
         self.system_manager_ui._active_system_button_group.blockSignals(False)
@@ -901,16 +901,16 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
         plotter.add_mesh(mesh, **add_points_kws)
 
-    def draw_nearest_points_discs(self, mesh, plotter, add_discs_kws):
-        """Render the surface-projected mapping points as 2D discs.
+    def draw_nearest_points_cylinders(self, mesh, plotter, add_cylinders_kws):
+        """Render the surface-projected mapping points as 3D cylinders
 
         Args:
             mesh (pyvista.PolyData): mesh to be added to the plotter
             plotter (BackgroundPlotter): plotter to which the mesh will be added
-            add_discs_kws (dict): keyword arguments to pass to `plotter.add_mesh`
+            add_cylinders_kws (dict): keyword arguments to pass to `plotter.add_mesh`
         """
 
-        plotter.add_mesh(mesh, **add_discs_kws)
+        plotter.add_mesh(mesh, **add_cylinders_kws)
 
     def check_available_electrograms(self):
         """Check whether the active case has electrograms.


### PR DESCRIPTION
Fixes #135 

Changes made:
* The surface-projected mapping points are shown as 3d cylinders
* Each cylinder is centered on the location of the projected point, and oriented along the normal to the surface at that point
* As with the mapping points that are shown as spheres, the cylinders are coloured yellow if they have been deleted and white otherwise