### PR TITLE
Highlight selected projected point

### DIFF
--- a/openep/view/system_manager.py
+++ b/openep/view/system_manager.py
@@ -150,11 +150,24 @@ class System:
 
         return mesh
 
-    def create_selected_point_mesh(self, point):
-        """Create a mesh that will be used for highlighting the selected point"""
+    def create_selected_point_mesh(self, point, geometry='sphere'):
+        """
+        Create a mesh that will be used for highlighting the selected point.
+
+        Args:
+            point (np.ndarray): x, y, z, coordinates of the point
+            geometry (str): The geometric mesh to create, can be either
+                'sphere' or 'cylinder'.
+        """
+
+        if geometry.lower() not in ['sphere', 'cylinder']:
+            raise NotImplementedError("Only 'sphere' or 'cylinder' is supported.")
 
         point_mesh = pyvista.PolyData(point)
-        point_geometry = pyvista.Sphere(theta_resolution=20, phi_resolution=20)
+        if geometry.lower() == 'sphere':
+            point_geometry = pyvista.Sphere(theta_resolution=20, phi_resolution=20)
+        elif geometry.lower() == 'cylinder':
+            point_geometry = pyvista.Cylinder(height=0.5, resolution=360, direction=[1, 0, 0])
 
         factor = 2 if self.type == "OpenEP" else 2000
         glyphed_mesh = point_mesh.glyph(scale=False, factor=factor, geom=point_geometry)
@@ -173,7 +186,7 @@ class System:
         mapping_points_mesh = pyvista.PolyData(mapping_points_centered)
         point_geometry = pyvista.Sphere(theta_resolution=8, phi_resolution=8)
         
-        factor = 1.5 if self.type == "OpenEP" else 1200
+        factor = 1.5 if self.type == "OpenEP" else 1500
         glyphed_mesh = mapping_points_mesh.glyph(scale=False, factor=factor, geom=point_geometry)
 
         n_mapping_points = mapping_points_centered.size
@@ -207,7 +220,7 @@ class System:
         projected_mapping_points_mesh.set_active_vectors("Normals", preference="point")
 
         cylinder_geometry = pyvista.Cylinder(height=0.5, resolution=360, direction=[1, 0, 0])
-        factor = 1.5 if self.type == "OpenEP" else 1200
+        factor = 1.5 if self.type == "OpenEP" else 1500
 
         glyphed_mesh = projected_mapping_points_mesh.glyph(
             orient="Normals",
@@ -221,7 +234,7 @@ class System:
 
         glyphed_mesh.point_data[scalars_name] = scalars.repeat(n_glphys_per_mapping_point)
 
-        return glyphed_mesh
+        return glyphed_mesh, projected_mapping_points_mesh
 
     def _create_default_kws(self):
         """Create a dictionary of keyword arguments for plotting meshes, points, and surface-projected cylinders."""

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -1104,17 +1104,17 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
         current_index = self.annotate_dock._current_index
         system = self.system_manager.active_system
-        plotter = system.plotters[0]
+        n_mapping_points = system.case.electric.bipolar_egm.points.size // 3
 
-        plotter.update_coordinates(
-            points=system._highlight_point.field_data["All points"][current_index],
-            mesh=system._highlight_point,
-        )
+        # 3D mapping points
+        mesh = system._highlight_point
+        all_points = mesh.field_data["All points"].reshape(n_mapping_points, mesh.n_points, 3)
+        mesh.points[:] = all_points[current_index]
 
-        plotter.update_coordinates(
-            points=system._highlight_projected_point.field_data["All points"][current_index],
-            mesh=system._highlight_projected_point,
-        )
+        # Projected points
+        mesh = system._highlight_projected_point
+        all_points = mesh.field_data["All points"].reshape(n_mapping_points, mesh.n_points, 3)
+        mesh.points[:] = all_points[current_index]
 
     def make_picked_point_current_index(self, picked_mesh, picked_point_id):
         """Set the user-picked point to be the selected point in the tables"""

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -528,14 +528,12 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             scalars=system.case.electric.include.astype(int),
             scalars_name="Include",
         )
-        projected_cylinders, projected_cylinders_mesh = system.create_surface_cylinders_mesh(
+        projected_cylinders = system.create_surface_cylinders_mesh(
             mesh=mesh,
             scalars=system.case.electric.include.astype(int),
             scalars_name="Include",
         )
-        system.case.electric.surface.nearest_point = projected_cylinders_mesh.points
-        system.case.electric.surface.normals = projected_cylinders_mesh.point_normals
-        
+
         add_mesh_kws, add_points_kws, add_cylinders_kws = system._create_default_kws()
         free_boundaries = openep.mesh.get_free_boundaries(mesh)
 
@@ -1104,20 +1102,19 @@ class OpenEPGUI(QtWidgets.QMainWindow):
     def highlight_mapping_point(self):
         """Show/hide the selected point, and translate it to its new location."""
 
+        current_index = self.annotate_dock._current_index
         system = self.system_manager.active_system
+        plotter = system.plotters[0]
 
-        points = system.case.electric.bipolar_egm.points - system.case._mesh_center
-        new_point_center = points[self.annotate_dock._current_index]
-        current_point_center = system._highlight_point.center
-        translate = current_point_center - new_point_center
-        system._highlight_point.translate(-translate, inplace=True)
+        plotter.update_coordinates(
+            points=system._highlight_point.field_data["All points"][current_index],
+            mesh=system._highlight_point,
+        )
 
-        new_projected_point_center = system.case.electric.surface.nearest_point[self.annotate_dock._current_index]
-        current_projected_point_center = system._highlight_projected_point.center
-        translate_projected = current_projected_point_center - new_projected_point_center
-        system._highlight_projected_point.translate(-translate_projected, inplace=True)
-
-        # TODO: need to change the orientation of the cylinder
+        plotter.update_coordinates(
+            points=system._highlight_projected_point.field_data["All points"][current_index],
+            mesh=system._highlight_projected_point,
+        )
 
     def make_picked_point_current_index(self, picked_mesh, picked_point_id):
         """Set the user-picked point to be the selected point in the tables"""

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -581,7 +581,7 @@ class OpenEPGUI(QtWidgets.QMainWindow):
                 pickable=False,
                 reset_camera=False,
             )
-            highlight_projected_actor.SetVisibility(is_active_system)
+            highlight_projected_actor.SetVisibility(False)
             system._highlight_projected_actor = highlight_projected_actor
             system._highlight_projected_point = highlight_projected_point
 
@@ -694,6 +694,8 @@ class OpenEPGUI(QtWidgets.QMainWindow):
                     actor.SetVisibility(show)
         elif actor_name == "Mapping points":
             plotter.renderer._actors["_picked_point"].SetVisibility(show)
+        elif actor_name == "Surface-projected mapping points":
+            plotter.renderer._actors["_picked_projected_point"].SetVisibility(show)
 
     def link_views_across_plotters(self, system, index):
         """Link or unlink the views of two plotters.


### PR DESCRIPTION
Fixes #142 

Changes made:
* The selected projected point is rendered as a large blue cylinder in the primary viewer of the active system
* It is not shown if projected points are turned off in the show/hide menu