### PR TITLE
Ensure correct types of preferences at start up

### DIFF
--- a/openep/view/preferences.py
+++ b/openep/view/preferences.py
@@ -38,7 +38,7 @@ class PreferencesManager(QtCore.QSettings):
         'QComboBox': ('currentText', 'setCurrentText', str),
         'QSpinBox': ('value', 'setValue', int),
         'QDoubleSpinBox': ('value', 'setValue', float),
-        'QButtonGroup': ('checkedId', 'setId', int),
+        'QButtonGroup': ('checkedId', 'button', int),  # 'button' is not used to set anything
     }
 
     settings_changed = QtCore.Signal()

--- a/openep/view/preferences.py
+++ b/openep/view/preferences.py
@@ -52,10 +52,10 @@ class PreferencesManager(QtCore.QSettings):
     def update_widgets_from_settings(self, map):
         for name, widget in map.items():
             cls = widget.__class__.__name__
-            print(self.widget_mappers.get(cls, (None, None)), cls)
+            #print(self.widget_mappers.get(cls, (None, None)), cls)
             getter, setter, dtype = self.widget_mappers.get(cls, (None, None))
             value = self.settings.value(name, type=dtype)
-            print("load:", getter, setter, value, type(value), dtype)
+            #print("load:", getter, setter, value, type(value), dtype)
             if setter and value is not None:
                 fn = getattr(widget, setter)
                 try:
@@ -67,11 +67,11 @@ class PreferencesManager(QtCore.QSettings):
         for name, widget in map.items():
             cls = widget.__class__.__name__
             getter, setter, dtype = self.widget_mappers.get(cls, (None, None))
-            print("save:", getter, setter)
+            #print("save:", getter, setter)
             if getter:
                 fn = getattr(widget, getter)
                 value = fn()
-                print("-- value:", value, type(value), dtype)
+                #print("-- value:", value, type(value), dtype)
                 if value is not None:
                     self.settings.setValue(name, value)  # Set the settings.
 

--- a/openep/view/preferences_ui.py
+++ b/openep/view/preferences_ui.py
@@ -51,12 +51,6 @@ class PreferencesWidget(CustomDockWidget):
         self.create_annotation_settings()
         self.create_interpolation_settings()
 
-        # TODO:
-        # Add tab for the mapping points tables.
-        # Default columns visible
-        # Default sorting (column name, ascending or descinding)
-        # Interpolate on deleting/restoring mapping points
-
         # Add widget for accepting/rejecting changes to the settings
         self.create_accept_discard_buttons()
 
@@ -203,7 +197,6 @@ class PreferencesWidget(CustomDockWidget):
             "LAT",
         ])
         sort_by.setMinimumWidth(120)
-        # TODO: can use sort_by.setCurrentText('TEXT') to set the default selection
 
         sort_order_text = QtWidgets.QLabel("Order")
         sort_order = QtWidgets.QComboBox()
@@ -256,10 +249,6 @@ class PreferencesWidget(CustomDockWidget):
         """Settings for using the annotation viewer."""
 
         layout = QtWidgets.QVBoxLayout()
-
-        # TODO: set validators for QLineEdit
-        # See: https://zetcode.com/pyqt/qlineedit/
-        # or https://stackoverflow.com/a/13423244/17623640
 
         # TODO: Add legend section
         #       Fontsize

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -126,10 +126,14 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         else:
             self.preferences_store.update_settings_from_widgets(
                 map=self.preferences_ui.map,
-                emit_change=False,  # Don't emit - otherwise self.update_preferences is called
+                emit_change=False,  # Don't emit - otherwise self.update_preferences is called but it doesn't exist
             )
 
         self.preferences = self.preferences_store.extract_preferences()
+
+        # We need to do this to ensure the correct the store has the correct types.
+        # If the preferences were loaded from disk, then all types are currently str.
+        self.preferences_store.update_settings_from_widgets(map=self.preferences_ui.map)
 
     def accept_preferences(self):
         """Copy widget state to the settings manager."""


### PR DESCRIPTION
Changes made:
* By default, when settings are loaded by `QSettings`, all values are of type `str`. Ensure the correct types of preference values are set at start-up