### PR TITLE
Set preferences using values from widgets, not from QSettings

### DIFF
--- a/openep/view/preferences.py
+++ b/openep/view/preferences.py
@@ -22,7 +22,6 @@ Create a preferences manager.
 """
 
 from PySide2 import QtCore
-from scipy.interpolate import RBFInterpolator
 
 __all__ = ["PreferencesManager"]
 
@@ -63,7 +62,7 @@ class PreferencesManager(QtCore.QSettings):
                 except Exception as e:
                     print(e)  # handle type error
 
-    def update_settings_from_widgets(self, map, emit_change=True):
+    def update_settings_from_widgets(self, map):
         for name, widget in map.items():
             cls = widget.__class__.__name__
             getter, setter, dtype = self.widget_mappers.get(cls, (None, None))
@@ -76,89 +75,4 @@ class PreferencesManager(QtCore.QSettings):
                     self.settings.setValue(name, value)  # Set the settings.
 
         # Notify watcher of changed settings.
-        if emit_change:
-            self.settings_changed.emit()
-
-    def extract_preferences(self):
-        """Create dictionary of preferences."""
-
-        data = {}
-
-        # 3D viewers settings
-        # 3D viewers settings: Point selection
-        data['3DViewers/PointSelection/3D'] = bool(self.settings.value('3DViewers/PointSelection/3D'))
-        data['3DViewers/PointSelection/Surface'] = bool(self.settings.value('3DViewers/PointSelection/Surface'))
-        data['3DViewers/PointSelection/Off'] = bool(self.settings.value('3DViewers/PointSelection/Off'))
-
-        point_selection_id = int(self.settings.value('3DViewers/PointSelection'))
-        if point_selection_id == 0:
-            data['3DViewers/PointSelection'] = "3DPoints"
-        elif point_selection_id == 1:
-            data['3DViewers/PointSelection'] = "ProjectedPoints"
-        elif point_selection_id == 2:
-            data['3DViewers/PointSelection'] = "Off"
-
-        # 3D viewers settings: Secondary viewers
-        link_secondary_viewers = bool(self.settings.value('3DViewers/SecondaryViewers/Link'))
-        data['3DViewers/SecondaryViewers/Link'] = link_secondary_viewers
-
-        # Table settings
-        columns = ['Index', 'Tag', 'Name', 'Voltage', 'LAT']
-
-        # Table settings: Mapping points
-        data[f'Tables/MappingPoints/Hide'] = []
-        for column in columns:
-            show = self.settings.value(f'Tables/MappingPoints/Show/{column}')
-            if not show:
-                data[f'Tables/MappingPoints/Hide'].append(column)
-
-        # Table settings: Recycle bin
-        data[f'Tables/RecycleBin/Hide'] = []
-        for column in columns:
-            show = self.settings.value(f'Tables/RecycleBin/Show/{column}')
-            if not show:
-                data[f'Tables/RecycleBin/Hide'].append(column)
-
-        # Table settings: Sorting
-        sort_by = self.settings.value('Tables/SortBy')
-        sort_order_text = self.settings.value('Tables/SortOrder')
-        sort_order = QtCore.Qt.AscendingOrder if sort_order_text == "Ascending" else QtCore.Qt.DescendingOrder
-        data['Tables/SortBy'] = sort_by
-        data['Tables/SortOrder'] = sort_order
-
-        # Table settings: Interpolate
-        interpolate = bool(self.settings.value('Tables/Interpolate'))
-        data['Tables/Interpolate'] = interpolate
-
-        # Annotation settings
-        data['Annotate/Lines/Signals/Linewidth/Active'] = self.settings.value('Annotate/Lines/Signals/Linewidth/Active')
-        data['Annotate/Lines/Signals/Linewidth/Other'] = self.settings.value('Annotate/Lines/Signals/Linewidth/Other')
-        data['Annotate/Lines/Annotations/Linewidth'] = self.settings.value('Annotate/Lines/Annotations/Linewidth')
-        data['Annotate/Lines/Annotations/Markersize'] = self.settings.value('Annotate/Lines/Annotations/Markersize')
-
-        data['Annotate/Gain/Min'] = float(self.settings.value('Annotate/Gain/Min'))
-        data['Annotate/Gain/Max'] = float(self.settings.value('Annotate/Gain/Max'))
-        data['Annotate/Gain/Prefactor'] = float(self.settings.value('Annotate/Gain/Prefactor'))
-
-        data['Annotate/Interpolate'] = bool(self.settings.value('Annotate/Interpolate'))
-
-        # Interpolation settings
-        method_text = self.settings.value('Interpolation/Method')
-
-        if method_text == "RBF":
-
-            method = RBFInterpolator
-            neighbours = int(self.settings.value('Interpolation/RBFParameters/Neighbours'))
-            neighbours = None if neighbours == 0 else neighbours
-            parameters = {
-                "neighbors": neighbours,
-                "smoothing": float(self.settings.value('Interpolation/RBFParameters/Smoothing')),
-                "kernel": self.settings.value('Interpolation/RBFParameters/Kernel'),
-                "epsilon": float(self.settings.value('Interpolation/RBFParameters/Epsilon')),
-                "degree": int(self.settings.value('Interpolation/RBFParameters/Degree')),
-            }
-
-        data['Interpolation/Method'] = method
-        data['Interpolation/Parameters'] = parameters
-
-        return data
+        self.settings_changed.emit()

--- a/openep/view/view_gui.py
+++ b/openep/view/view_gui.py
@@ -123,17 +123,8 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         config = pathlib.Path(self.preferences_store.settings.fileName())
         if config.is_file():
             self.preferences_store.update_widgets_from_settings(map=self.preferences_ui.map)
-        else:
-            self.preferences_store.update_settings_from_widgets(
-                map=self.preferences_ui.map,
-                emit_change=False,  # Don't emit - otherwise self.update_preferences is called but it doesn't exist
-            )
 
-        self.preferences = self.preferences_store.extract_preferences()
-
-        # We need to do this to ensure the correct the store has the correct types.
-        # If the preferences were loaded from disk, then all types are currently str.
-        self.preferences_store.update_settings_from_widgets(map=self.preferences_ui.map)
+        self.preferences = self.preferences_ui.extract_preferences()
 
     def accept_preferences(self):
         """Copy widget state to the settings manager."""
@@ -154,9 +145,9 @@ class OpenEPGUI(QtWidgets.QMainWindow):
         self.preferences_store.update_widgets_from_settings(map=self.preferences_ui.map)
 
     def update_preferences(self):
-        """Update settings used by widgets in the GUI from the settings store."""
+        """Update settings used by widgets in the GUI based on values set in the preferences dock."""
 
-        new_preferences = self.preferences_store.extract_preferences()
+        new_preferences = self.preferences_ui.extract_preferences()
         changed_preferences = {key: value for key, value in new_preferences.items() if value != self.preferences[key]}
         self.preferences = new_preferences
 
@@ -262,14 +253,12 @@ class OpenEPGUI(QtWidgets.QMainWindow):
 
         hide_mapping_points_columns = self.preferences['Tables/MappingPoints/Hide']
         hide_recycle_bin_columns = self.preferences['Tables/RecycleBin/Hide']
-        for column_index, column_name in enumerate(self.mapping_points.model.headers):
+        for column_name in self.mapping_points.model.headers:
 
             hide = True if column_name in hide_mapping_points_columns else False
-            self.mapping_points.table.setColumnHidden(column_index, hide)
             self.mapping_points.header_menu_actions[column_name].setChecked(not hide)
 
             hide = True if column_name in hide_recycle_bin_columns else False
-            self.recycle_bin.table.setColumnHidden(column_index, hide)
             self.recycle_bin.header_menu_actions[column_name].setChecked(not hide)
 
     def _create_annotate_dock(self):
@@ -955,13 +944,13 @@ class OpenEPGUI(QtWidgets.QMainWindow):
             
             hide_mapping_points_columns = self.preferences['Tables/MappingPoints/Hide']
             hide_recycle_bin_columns = self.preferences['Tables/RecycleBin/Hide']
-            for column_index, column_name in enumerate(self.mapping_points.model.headers):
+            for column_name in self.mapping_points.model.headers:
 
                 hide = True if column_name in hide_mapping_points_columns else False
-                self.mapping_points.table.setColumnHidden(column_index, hide)
+                self.mapping_points.header_menu_actions[column_name].setChecked(not hide)
 
                 hide = True if column_name in hide_recycle_bin_columns else False
-                self.recycle_bin.table.setColumnHidden(column_index, hide)
+                self.recycle_bin.header_menu_actions[column_name].setChecked(not hide)
 
             # This also sort the recycle bin table
             sort_by_text = self.preferences['Tables/SortBy']


### PR DESCRIPTION
Fixes #147 

Changes made:
* Get preference value form the preferences dock rather than the preferences store.
* This is necessary because on Windows all values in the store always have type str, whereas on Mac OS and Linux the values take on the correct type if the values in the store are modified. So retrieving the values from the store would need to be handled differently on different operating system.