### PR TITLE
Fix calculation of bipolar electrograms from unipolar

### DIFF
--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -589,7 +589,7 @@ def bipolar_from_unipolar_surface_points(unipolar, indices):
             neighbours=unipolar[connected_vertices],
         )
         bipolar[index] = index_bipolar
-        pair_indices[index] = [index, pair_index]
+        pair_indices[index] = [index, connected_vertices[pair_index]]
 
     return bipolar, pair_indices
 


### PR DESCRIPTION
Changes made:
* Store the correct indices of pairs of unipolar egms that make up each bipolar egm
* Previously, the bipolar egm was calculated correctly, the pairs of unipolar egm that correspond to each bipolar egm were incorrect