### PR TITLE
Fix openep mat file parser

### DIFF
--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -193,6 +193,16 @@ def extract_electric_data(electric_data):
             dtype=bool,
         )
 
+    # Older versions of OpenEP datasets did not have unipolar data or electrode names. Add deafult ones here.
+    if 'electrodeNames_bip' not in electric_data:
+        electric_data['electrodeNames_bip'] = np.full_like(internal_names, fill_value="", dtype=str)
+    if 'egmUni' not in electric_data:
+        num_points, num_samples = electric_data['egm'].shape
+        electric_data['egmUni'] = np.full((num_points, num_samples, 2), fill_value=np.NaN, dtype=float)
+        electric_data['egmUniX'] = np.full((num_points, 3, 2), fill_value=np.NaN, dtype=float)
+        electric_data['voltages']['unipolar'] = np.full(num_points, fill_value=np.NaN, dtype=float)
+        electric_data['electrodeNames_uni'] = np.full_like(internal_names, fill_value="", dtype=str)
+
     # TODO: check if gain values are stored in electric_data before creating the default values
     bipolar_egm = Electrogram(
         egm=electric_data['egm'].astype(float),

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -198,7 +198,7 @@ def extract_electric_data(electric_data):
         electric_data['electrodeNames_bip'] = np.full_like(internal_names, fill_value="", dtype=str)
     if 'egmUni' not in electric_data:
         num_points, num_samples = electric_data['egm'].shape
-        electric_data['egmUni'] = np.full((num_points, num_samples, 2), fill_value=np.NaN, dtype=float)
+        electric_data['egmUni'] = np.full((num_points, num_samples, 2), fill_value=0.0, dtype=float)
         electric_data['egmUniX'] = np.full((num_points, 3, 2), fill_value=np.NaN, dtype=float)
         electric_data['voltages']['unipolar'] = np.full(num_points, fill_value=np.NaN, dtype=float)
         electric_data['electrodeNames_uni'] = np.full_like(internal_names, fill_value="", dtype=str)

--- a/openep/io/matlab.py
+++ b/openep/io/matlab.py
@@ -190,10 +190,14 @@ def _load_mat_v73(filename):
     return data
 
 
-def _decode_empty_strings_array(arr):
-    """"""
-    return np.asarray([item.tobytes().decode('utf-16') for item in arr])
+def _decode_tags(arr):
+    """
+    Convert empty arrays into empty strings. Leave strings unchanged.
 
+    An empty array corresponds to there being no tag for that point.
+    """
+
+    return np.asarray([item if isinstance(item, str) else item.tobytes().decode('utf-16') for item in arr])
 
 def _cast_to_float(arr):
     """Cast a numpy array to float"""
@@ -218,7 +222,7 @@ def _load_mat_below_v73(filename):
         simplify_cells=True,
     )['userdata']
 
-    data['electric']['tags'] = _decode_empty_strings_array(data['electric']['tags'])
+    data['electric']['tags'] = _decode_tags(data['electric']['tags'])
 
     data['electric']['impedances']['time'] = _cast_to_float(data['electric']['impedances']['time'])
     data['electric']['impedances']['value'] = _cast_to_float(data['electric']['impedances']['value'])

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -114,9 +114,9 @@ def load_openep_mat(filename, name=None):
     electric = extract_electric_data(data['electric'])
     ablation = extract_ablation_data(data['rf']) if 'rf' in data else None
 
-    try:
-        notes = np.asarray(data['notes']).reshape(-1, 1)
-    except KeyError:
+    if 'notes' in data:
+        notes = np.asarray([data['notes']])[:, np.newaxis] if isinstance(data['notes'], str) else np.asarray(data['notes']).reshape(-1, 1)
+    else:
         notes = np.asarray([""], dtype=str)[:, np.newaxis]
 
     return Case(name, points, indices, fields, electric, ablation, notes)

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -112,11 +112,7 @@ def load_openep_mat(filename, name=None):
 
     points, indices, fields = extract_surface_data(data['surface'])
     electric = extract_electric_data(data['electric'])
-
-    try:
-        ablation = extract_ablation_data(data['rf'])
-    except KeyError:
-        ablation = None
+    ablation = extract_ablation_data(data['rf']) if 'rf' in data else None
 
     try:
         notes = np.asarray(data['notes']).reshape(-1, 1)


### PR DESCRIPTION
Changes made:
* Correctly decode tags for v7.3
* Handle the case where no unipolar data is present in openep datasets (for old versions of the userdata data structure) - create default egm with values of 0 everywhere
* correctly handle missing ablation data and notes when loading an openep dataset