### PR TITLE
Create scalar field arrays for openCARP datasets

### DIFF
--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -87,7 +87,7 @@ def extract_surface_data(surface_data):
     return points, indices, fields
 
 
-def empty_fields():
+def empty_fields(size=None):
     """Create an empty Fields object with empty numpy arrays.
 
     Returns:
@@ -95,11 +95,18 @@ def empty_fields():
             scalar fields
     """
 
-    local_activation_time = None
-    bipolar_voltage = None
-    unipolar_voltage = None
-    impedance = None
-    force = None
+    if size is not None:    
+        local_activation_time = np.full(size, fill_value=np.NaN, dtype=float)
+        bipolar_voltage = np.full(size, fill_value=np.NaN, dtype=float)
+        unipolar_voltage = np.full(size, fill_value=np.NaN, dtype=float)
+        impedance = np.full(size, fill_value=np.NaN, dtype=float)
+        force = np.full(size, fill_value=np.NaN, dtype=float)
+    else:
+        local_activation_time = None
+        bipolar_voltage = None
+        unipolar_voltage = None
+        impedance = None
+        force = None
 
     fields = Fields(
         bipolar_voltage,

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -126,6 +126,7 @@ def load_opencarp(
     points,
     indices,
     name=None,
+    fill_fields=False,
 ):
     """
     Load data from an OpenCARP simulation.
@@ -136,6 +137,8 @@ def load_opencarp(
             supported.
         name (str, optional): Name of the dataset. If None, the basename of the points file
             will be used as the name.
+        fill_fields (bool, optional): If True, will create scalar fields filled with NaN values
+            (one value per point).
 
     Returns:
         case (Case): an OpenEP Case object that contains the points and indices.
@@ -151,7 +154,8 @@ def load_opencarp(
     points_data = np.loadtxt(points, skiprows=1)
     indices_data = np.loadtxt(indices, skiprows=1, usecols=[1, 2, 3], dtype=int)  # ignore the tag for now
 
-    fields = empty_fields()
+    size = size=points_data.size // 3 if fill_fields else None
+    fields = empty_fields(size)
     electric = empty_electric()
     ablation = empty_ablation()
     notes = []


### PR DESCRIPTION
Changes made:
* Add option to fill scalar field arrays with NaNs when loading openCARP datasets
* set the `fill_fields` of `openep.load_openCARP` to `True` (defaults to `False`)