### PR TITLE
Translate case

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -141,7 +141,7 @@ class Case:
         if self.electric.bipolar_egm.points is not None:
             self.electric.bipolar_egm.points += translate_by
         if self.electric.unipolar_egm.points is not None:
-            self.electric.unipolar_egm.points += translate_by
+            self.electric.unipolar_egm.points += translate_by[:, np.newaxis]
         if self.electric.surface.nearest_point is not None:
             self.electric.surface.nearest_point += translate_by
 

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -80,14 +80,6 @@ def test_mesh_creation_back_faces(mesh, case):
     assert mesh.n_faces == mesh_from_case.n_faces / 2
 
 
-def test_mesh_creation_not_centered(mesh, case):
-
-    mesh_from_case = case.create_mesh(recenter=False)
-
-    assert_allclose(0, mesh.center)
-    not assert_allclose(mesh.center, mesh_from_case.center)
-
-
 def test_get_surface_data(case):
 
     points, indices = case.get_surface_data()


### PR DESCRIPTION
Changes made:
* Remove the `recenter` argument from `openep.data_structures.case.Case.create_mesh`
* Add a `translate` method to `openep.data_structures.case.Case` that takes a 3D translation that will be applied to:
  * `case.points`
  * `case.electric.bipolar_egm.points`
  * `case.electric.unipolar_egm.points`
  * `case.electric.surface.nearest_point`
* Add a `center` method to `openep.data_structures.case.Case` that translates all 3D coordinates so that the center of geometry of `case.points` is at the origin