### PR TITLE
Fix saving files in openep format

### DIFF
--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -211,7 +211,7 @@ def _extract_electric_data(electric: Electric):
     electric_data['electrodeNames_uni'] = electric.unipolar_egm.names.astype(object)
     electric_data['egmUniX'] = electric.unipolar_egm.points
     electric_data['egmUni'] = electric.unipolar_egm.egm
-    electric['egmUniGain'] = electric.unipolar_egm.gain
+    electric_data['egmUniGain'] = electric.unipolar_egm.gain
 
     electric_data['egmRef'] = electric.reference_egm.egm
     electric_data['egmRefGain'] = electric.reference_egm.gain

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -201,18 +201,23 @@ def _extract_electric_data(electric: Electric):
     electric_data = {}
     electric_data['tags'] = electric.names.astype(object)
     electric_data['names'] = electric.internal_names.astype(object)
+    electric_data['include'] = electric.include
 
     electric_data['electrodeNames_bip'] = electric.bipolar_egm.names.astype(object)
     electric_data['egmX'] = electric.bipolar_egm.points
     electric_data['egm'] = electric.bipolar_egm.egm
+    electric_data['egmGain'] = electric.bipolar_egm.gain
 
     electric_data['electrodeNames_uni'] = electric.unipolar_egm.names.astype(object)
     electric_data['egmUniX'] = electric.unipolar_egm.points
     electric_data['egmUni'] = electric.unipolar_egm.egm
+    electric['egmUniGain'] = electric.unipolar_egm.gain
 
     electric_data['egmRef'] = electric.reference_egm.egm
+    electric_data['egmRefGain'] = electric.reference_egm.gain
 
     electric_data['ecg'] = electric.ecg.ecg
+    electric_data['ecgGain'] = electric.ecg.gain
 
     electric_data['egmSurfX'] = electric.surface.nearest_point
     electric_data['barDirection'] = electric.surface.normals


### PR DESCRIPTION
Fixes #161 

Changes made:
* Export the gain and `electric.include` data when saving a dataset in openep format
* When loading an openep dataset, check whether these values exist before creating default values