### PR TITLE
Make FreeBoundaries handle watertight meshes

### DIFF
--- a/openep/mesh/mesh_routines.py
+++ b/openep/mesh/mesh_routines.py
@@ -173,7 +173,7 @@ class FreeBoundary:
 
         """
 
-        if self.n_boundaries:
+        if self.n_boundaries == 0:
             return np.array([])
 
         lengths = [


### PR DESCRIPTION
Changes made:
* `FreeBoundaries` correctly handles water tight meshes, returning empty arrays for the e.g. `split_boundaries` and `calculate_lenghts` methods
* `openep.mesh.mesh_routines.get_free_boundaries` creates correctly handles water tight meshes (previously it would crash when attempting to concatenate the lines of each boundary)