### PR TITLE
Fix writing and loading openCARP datasets

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -255,8 +255,8 @@ class Case:
                 " but the number of points in the mesh is ", len(self.points), " . "
             )
 
-        self.electric.internal_names = np.full(len(unipolar), fill_value="", dtype=str)
         names = np.asarray([f'P{index}' for index in range(len(unipolar))], dtype=str)
+        self.electric.internal_names = names
         self.electric.names = names
 
         bipolar, pair_indices = bipolar_from_unipolar_surface_points(

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -196,7 +196,7 @@ def extract_electric_data(electric_data):
             names,
             fill_value=True,
             dtype=bool,
-        )        
+        )
 
     # Older versions of OpenEP datasets did not have unipolar data or electrode names. Add deafult ones here.
     if 'electrodeNames_bip' not in electric_data:

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -158,7 +158,7 @@ def load_opencarp(
     points_data *= scale_points
     indices_data = np.loadtxt(indices, skiprows=1, usecols=[1, 2, 3], dtype=int)  # ignore the tag for now
 
-    size = size=points_data.size // 3 if fill_fields else None
+    size = size=points_data.size // 3 if fill_fields else 0
     fields = empty_fields(size)
     electric = empty_electric()
     ablation = empty_ablation()


### PR DESCRIPTION
Changes made:
* Fix adding egms to openCARP dataset - `case.electric.internal_names` is now the same as `case.electric.names`, rather than an array of empty strings
* Fix creation of empty Field data - default size is now 0 rather than None. Using None creates a 0d array with a single value, rather than a 1d array with no values.
