### PR TITLE
When exporting to .mat, cast case.indices to be double rather than int

### DIFF
--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -164,7 +164,7 @@ def _extract_surface_data(
 
     surface_data['triRep'] = {}
     surface_data['triRep']['X'] = points
-    surface_data['triRep']['Triangulation'] = indices + 1  # MATLAB uses 1-based indexing
+    surface_data['triRep']['Triangulation'] = indices.astype(float) + 1  # TriRep requires doubles not ints, and MATLAB uses 1-based indexing
 
     surface_data['act_bip'] = np.concatenate(
         [


### PR DESCRIPTION
Changes made:
* When exporting to .mat, cast `case.indices` to be float rather than int.
* This is to be consistent with data exported from MATLAB, and because the `TriRep` MATLAB class requires faces to be doubles rather than ints.