### PR TITLE
Fix reading impedances in openep datasets

### DIFF
--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -242,9 +242,17 @@ def extract_electric_data(electric_data):
         gain=electric_data['egmGain'].astype(float),
     )
 
+    try:
+        impedance_times = electric_data['impedances']['time'].astype(float)
+        impedance_values = electric_data['impedances']['value'].astype(float)
+    except AttributeError as e:
+        # We have a list of arrays, rather than a single array
+        impedance_times = electric_data['impedances']['time']
+        impedance_values = electric_data['impedances']['value']
+
     impedance = Impedance(
-        times=electric_data['impedances']['time'].astype(float),
-        values=electric_data['impedances']['value'].astype(float),
+        times=impedance_times,
+        values=impedance_values,
     )
 
     surface = ElectricSurface(


### PR DESCRIPTION
Changes made:

* Fix reading impedances in openep datasets
* `case.electric.impedances.time` and `case.electric.impedances.value` are not lists of numpy arrays
* We cannot use a single numpy array as it is not guaranteed that each row has the some number of columns