### PR TITLE
Improve performance of LocalSmoothingInterpolator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ attrs
 typing_extensions
 h5py
 numpy
+numba
 scipy<1.8
 scikit-image
 pydicom


### PR DESCRIPTION
Changes made:
* Use numba to speed up local smoothing interpolation
* For a small case (~800 points), time reduced from ~280ms to ~150ms
* Still slower than e.g. `scipy.interpolate.LinearNDInterpolator`