### PR TITLE
Use case.electric.include when interpolating

### DIFF
--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -537,9 +537,9 @@ def interpolate_activation_time_onto_surface(
     points = case.electric.bipolar_egm.points
     local_activation_times = case.electric.annotations.local_activation_time - case.electric.annotations.reference_activation_time
 
-    within_woi = get_mapping_points_within_woi(case, buffer=buffer)
-    points = points[within_woi]
-    local_activation_times = local_activation_times[within_woi]
+    include = case.electric.include
+    points = points[include]
+    local_activation_times = local_activation_times[include]
 
     interpolator = Interpolator(
         points,

--- a/tests/test_case_routines.py
+++ b/tests/test_case_routines.py
@@ -260,7 +260,7 @@ def test_calculate_voltage_from_electrograms_unipolar(real_case):
 
     n_electrograms = 800
     amplitudes = calculate_voltage_from_electrograms(real_case, bipolar=False)
-    assert_allclose((n_electrograms, 2),  amplitudes.shape)
+    assert_allclose((n_electrograms),  amplitudes.shape)
 
 
 def test_calculate_distance(mock_case):


### PR DESCRIPTION
Fixes #160 

Changes made:
* `case.electric.include` is now used to determine which mapping points should be included when interpolating (previously points were used if their local activation time was within the window of interest)
* This has been updated for interpolating both voltages and local activation times
* Separated voltage calculation from voltage interpolation (if required, voltage calculations should be done before interpolating)
* Remove unnecessary copying of data to improve performance
* `openep.case.case_routines.calculate_voltage_from_electrograms` now calculates unipolar voltages based only on the proximal egms (assumed to be `case.electric.unipolar_egm.egm[:, :, 0]`, and the distal to be `case.electric.unipolar_egm.egm[:, :, 1]`). Relevant test updated to reflect this change.