### PR TITLE
Bump scipy min version required

### DIFF
--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -70,8 +70,8 @@ __all__ = ["load_openep_mat", "_load_mat", "load_opencarp", "load_circle_cvi"]
 def _check_mat_version_73(filename):
     """Check if a MATLAB file is of version 7.3"""
 
-    byte_stream, file_opened = scipy.io.matlab.mio._open_file(filename, appendmat=False)
-    major_version, minor_version = scipy.io.matlab.miobase.get_matfile_version(byte_stream)
+    byte_stream, file_opened = scipy.io.matlab._mio._open_file(filename, appendmat=False)
+    major_version, minor_version = scipy.io.matlab._miobase.get_matfile_version(byte_stream)
 
     return major_version == 2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ typing_extensions
 h5py
 numpy
 numba
-scipy<1.8
+scipy>=1.8
 scikit-image
 pydicom
 pandas
@@ -16,4 +16,3 @@ trimesh
 shapely
 meshio
 pynrrd
-


### PR DESCRIPTION
Changes made:
* Set min scipy version to 1.8.
* In 1.8, functions for checking MATLAB file version were moved