### PR TITLE
Make case.electric.include int not bool

### DIFF
--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -537,7 +537,7 @@ def interpolate_activation_time_onto_surface(
     points = case.electric.bipolar_egm.points
     local_activation_times = case.electric.annotations.local_activation_time - case.electric.annotations.reference_activation_time
 
-    include = case.electric.include
+    include = case.electric.include.astype(bool)
     points = points[include]
     local_activation_times = local_activation_times[include]
 
@@ -590,7 +590,7 @@ def interpolate_voltage_onto_surface(
     """
 
     surface_points = case.points
-    include = case.electric.include
+    include = case.electric.include.astype(bool)
 
     if bipolar:
         points = case.electric.bipolar_egm.points[include]

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -190,12 +190,12 @@ def extract_electric_data(electric_data):
 
     # electric.include is a later addition to the openep format
     if 'include' in electric_data:
-        include = electric_data['include'].astype(bool)
+        include = electric_data['include'].astype(int)
     else:
         include = np.full_like(
             names,
             fill_value=True,
-            dtype=bool,
+            dtype=int,
         )
 
     # Older versions of OpenEP datasets did not have unipolar data or electrode names. Add deafult ones here.


### PR DESCRIPTION
Changes made:

* `case.electric.include` is stored as `int`s rather than `bool`s. This is currently necessary for mapping points points in the openep-gui to be coloured by the value of `case.electric.include`. In Pyvista, the clim is ignored if the type of the scalars is `bool` and there is only a single value (e.g. all points are not deleted, or all points are deleted.) There is no issue if the scalars are `int`s
* To ensure correct fancy indexing, `case.electric.include` is now cast to `bool` before e.g. selecting egms to include in interpolation