### PR TITLE
Handle ecgs with multiple channels

### DIFF
--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -226,6 +226,8 @@ def extract_electric_data(electric_data):
 
     # Not all datasets have ecgNames
     electric_data['ecgNames'] = electric_data.get('ecgNames', np.array(['ECG' for _ in range(n_ecg_channels)]))
+    if isinstance(electric_data['ecgNames'], str):
+        electric_data['ecgNames'] = np.array([electric_data['ecgNames']])
 
     # Not all datasets have gain values
     if 'egmGain' not in electric_data:

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -213,9 +213,6 @@ def extract_electric_data(electric_data):
         electric_data['voltages']['unipolar'] = np.full(num_points, fill_value=np.NaN, dtype=float)
         electric_data['electrodeNames_uni'] = np.full_like(internal_names, fill_value="", dtype=str)
 
-    # Not all datasets have ecgNames
-    electric_data['ecgNames'] = electric_data.get('ecgNames', np.array(['ECG']))
-
     # Make ecgs correct shape
     ecg_dims = electric_data['ecg'].ndim
     if ecg_dims == 0:
@@ -226,6 +223,9 @@ def extract_electric_data(electric_data):
         electric_data['ecg'] = electric_data['ecg'].reshape(n_points, n_samples, 1)
     elif ecg_dims == 3:
         n_ecg_channels = electric_data['ecg'].shape[2]
+
+    # Not all datasets have ecgNames
+    electric_data['ecgNames'] = electric_data.get('ecgNames', np.array(['ECG' for _ in range(n_ecg_channels)]))
 
     # Not all datasets have gain values
     if 'egmGain' not in electric_data:

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -209,6 +209,8 @@ def _extract_electric_data(electric: Electric):
     electric_data['names'] = electric.internal_names.astype(object)
     electric_data['include'] = electric.include
 
+    electric_data['sampleFrequencu'] = float(electric.frequency)
+
     electric_data['electrodeNames_bip'] = electric.bipolar_egm.names.astype(object)
     electric_data['egmX'] = electric.bipolar_egm.points
     electric_data['egm'] = electric.bipolar_egm.egm
@@ -224,6 +226,7 @@ def _extract_electric_data(electric: Electric):
 
     electric_data['ecg'] = electric.ecg.ecg
     electric_data['ecgGain'] = electric.ecg.gain
+    electric_data['ecgNames'] = electric.ecg.channel_names.astype(object)
 
     electric_data['egmSurfX'] = electric.surface.nearest_point
     electric_data['barDirection'] = electric.surface.normals


### PR DESCRIPTION
Fixes #179 

Changes made:
* Added an attribute `case.electric.ecg.channel_names`. It is always an array of names, even if only a single channel is present. A default name of `ECG` is used if the single channel has no name.
* `case.electric.ecg.ecg` now takes shape `n_mapping_points x n_samples x n_channels`
* `case.electric.ecg.gain` now takes shape `n_mapping_points x n_channels`
* Added an attribute `case.electric.frequency` for storing the sample frequency (defaults to 1000 Hz)