### PR TITLE
Store all annotations as indices

### DIFF
--- a/examples/openep_caseroutines.py
+++ b/examples/openep_caseroutines.py
@@ -22,6 +22,7 @@ import openep
 from openep._datasets.openep_datasets import DATASET_2
 
 case = openep.load_openep_mat(DATASET_2)
+openep.case.get_woi_times(case)
 mesh = case.create_mesh()
 
 # determine the window of interest for each point

--- a/openep/case/__init__.py
+++ b/openep/case/__init__.py
@@ -2,7 +2,6 @@ __all__ = ['case_routines']
 
 from .case_routines import (
     get_mapping_points_within_woi,
-    get_woi_times,
     get_electrograms_at_points,
     calculate_voltage_from_electrograms,
     calculate_distance,

--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -33,8 +33,6 @@ Extracting data from a Case
 
 .. autofunction:: get_electrograms_at_points
 
-.. autofunction:: get_woi_times
-
 .. _analysing:
 
 Analyses
@@ -71,7 +69,6 @@ import scipy.interpolate
 __all__ = [
     'get_mapping_points_within_woi',
     'get_electrograms_at_points',
-    'get_woi_times',
     'calculate_voltage_from_electrograms',
     'calculate_distance',
     'calculate_points_within_distance',

--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -246,54 +246,6 @@ def get_electrograms_at_points(
     return electrograms
 
 
-def get_woi_times(case, buffer=50, relative=False):
-    """
-    Extracts the times within the window of interest.
-
-    Args:
-        case (Case): openep case object
-        buffer (float): times within the window of interest plus/minus this buffer
-            time will be considered to be within the woi.
-        relative (bool): if True, the time of the reference annotation will be
-            subtracted from the returned times.
-
-    Returns:
-        times (ndarray): times within the window of interest
-        
-    Warning
-    -------
-    This returns the sample indices that cover the window of interest for the
-    **first** electrogram only. get_sample_indices_within_woi can be used to
-    obtain a two-dimensional boolean array in which value of True indicate
-    that the specific sample is within the specific electrogram's window of
-    interest.
-    """
-    
-    # TODO: remove this function as it does not take into account the fact
-    #       that different electrograms may have different windows of interest
-    #       and different reference annotations
-
-    # TODO: This is sample rather than time
-    #       Should take into account sample frequency to get actual time
-    times = np.arange(case.electric.bipolar_egm.egm.shape[1])
-
-    # TODO: woi and reference times might be different for each mapping point
-    woi = case.electric.annotations.window_of_interest[0]
-    ref_annotation = case.electric.annotations.reference_activation_time[0]
-
-    start_time, stop_time = woi + ref_annotation + [-buffer, buffer]
-
-    keep_times = np.logical_and(
-        times >= start_time,
-        times <= stop_time,
-    )
-
-    if relative:
-        times -= ref_annotation
-
-    return times[keep_times]
-
-
 def get_sample_indices_within_woi(case, buffer=50, indices=None):
     """
     Determine which samples are within the window of interest for each electrogram.

--- a/tests/test_case_routines.py
+++ b/tests/test_case_routines.py
@@ -28,7 +28,6 @@ from openep.case.case_routines import (
     _get_window_of_interest,
     get_mapping_points_within_woi,
     get_electrograms_at_points,
-    get_woi_times,
     calculate_voltage_from_electrograms,
     calculate_distance,
     calculate_points_within_distance,
@@ -224,25 +223,6 @@ def test_get_electrograms_at_points_invalid_type(mock_case):
             mock_case,
             egm_type="other",
         )
-
-
-def test_get_woi_times(mock_case):
-
-    times = get_woi_times(mock_case)
-    assert_allclose(np.arange(20), times)
-
-
-def test_get_woi_times_no_buffer(mock_case):
-
-    times = get_woi_times(mock_case, buffer=0)
-    assert_allclose(np.arange(10, 20), times)
-
-
-def test_get_woi_times_no_buffer_relative(mock_case):
-
-    times = get_woi_times(mock_case, buffer=0, relative=True)
-    assert_allclose(np.arange(5, 15), times)
-
 
 def test_calculate_voltage_from_electrograms(mock_case):
 


### PR DESCRIPTION
Changes made:

* All annotations are stored as indices:
  - `case.electric.annotations._window_of_interest_indices`
  - `case.electric.annotations._local_activation_time_indices`
  - `case.electric.annotations._reference_activation_time_indices`
 * But are accessible as times (defined as properties in the `Annotations` class):
   - `case.electric.annotations.window_of_interest`
   - `case.electric.annotations.local_activation_time`
   - `case.electric.annotations.reference_activation_time`