### PR TITLE
Set missing attributes to None rather than empty numpy arrays

### DIFF
--- a/examples/bipolar_from_unipolar.py
+++ b/examples/bipolar_from_unipolar.py
@@ -20,8 +20,12 @@ import numpy as np
 import openep
 
 carp = openep.load_opencarp(
-    points="/home/ps21/github/openep-misc/examples/data/pig21_endo_coarse.pts",
-    indices="/home/ps21/github/openep-misc/examples/data/pig21_endo_coarse.elem",
+    points="/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse.pts",
+    indices="/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse.elem",
+    scale=1000,
 )
-unipolar = np.loadtxt("/home/ps21/github/openep-misc/examples/data/pig21_endo_coarse_phie.dat")
+unipolar = np.loadtxt("/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse_phie.dat")
 carp.add_unipolar_electrograms(unipolar=unipolar)
+
+openep.export_openep_mat(carp, 'test-export.mat')
+new_carp = openep.load_openep_mat('test-export.mat')

--- a/openep/data_structures/ablation.py
+++ b/openep/data_structures/ablation.py
@@ -36,11 +36,11 @@ class AblationForce:
         points (np.ndarray): array of shape Nx3
 
     """
-    times: np.ndarray
-    force: np.ndarray
-    axial_angle: np.ndarray
-    lateral_angle: np.ndarray
-    points: np.ndarray
+    times: np.ndarray = None
+    force: np.ndarray = None
+    axial_angle: np.ndarray = None
+    lateral_angle: np.ndarray = None
+    points: np.ndarray = None
 
     def __repr__(self):
         return f"Ablation forces with {len(self.times)} sites."
@@ -61,11 +61,16 @@ class Ablation:
             and the 3D coordinates of the ablation site.
     """
 
-    times: np.ndarray
-    power: np.ndarray
-    impedance: np.ndarray
-    temperature: np.ndarray
-    force: AblationForce
+    times: np.ndarray = None
+    power: np.ndarray = None
+    impedance: np.ndarray = None
+    temperature: np.ndarray = None
+    force: AblationForce = None
+
+    def __attrs_post_init__(self):
+
+        if self.force is None:
+            self.force = AblationForce()
 
     def __repr__(self):
         n_sites = {len(self.times)} if self.times is not None else 0
@@ -85,7 +90,7 @@ def extract_ablation_data(ablation_data):
     """
 
     if isinstance(ablation_data, np.ndarray) or ablation_data['originaldata']['ablparams']['time'].size == 0:
-        return empty_ablation()
+        return Ablation()
 
     times = ablation_data['originaldata']['ablparams']['time'].astype(float)
     power = ablation_data['originaldata']['ablparams']['power'].astype(float)

--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -222,7 +222,6 @@ class Case:
         unipolar,
         add_bipolar=True,
         add_reference=True,
-        add_ecg=True,
         add_annotations=True,
     ):
         """Add unipolar electrograms into the Case object.
@@ -240,8 +239,6 @@ class Case:
                 electrograms and returned.
             add_reference (bool): If True, reference electrograms will be created. All signals will
                 have values of 0 at every time point.
-            add_ecg (bool): If True, ecgs will be created. All signals will have values of 0 at every
-                time point.
             add_annotations (bool): If True, default annotations of the electrograms will
                 be created and returned. The window of interest will be set to
                 cover the entire period of the electrogram traces, and the reference
@@ -304,14 +301,6 @@ class Case:
                 gain=np.ones(len(unipolar), dtype=float),
             )
             self.electric.reference_egm = reference_egm
-
-        if add_ecg:
-
-            ecg = ECG(
-                ecg=np.zeros_like(bipolar),
-                gain=np.ones(len(unipolar), dtype=float),
-            )
-            self.electric.ecg = ecg
 
         if add_annotations:
 

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -37,7 +37,7 @@ class Electrogram:
         names (np.ndarray): Names of the associated electrodes.
     """
 
-    egm: np.ndarray
+    egm: np.ndarray = None
     points: np.ndarray = None
     voltage: np.ndarray = None
     gain: np.ndarray = None
@@ -63,8 +63,8 @@ class ECG:
         gain (np.ndarray): gain to apply to each signal
     """
 
-    ecg: np.ndarray
-    channel_names: np.ndarray
+    ecg: np.ndarray = None
+    channel_names: np.ndarray = None
     gain: np.ndarray = None
 
     def __attrs_post_init__(self):
@@ -229,9 +229,9 @@ class Electric:
 
         if self.bipolar_egm.egm is None or self.bipolar_egm.egm.shape[1] == 0:
             self._time_indices = np.array([], dtype=float)
-
-        n_samples = self.bipolar_egm.egm.shape[1]
-        self._time_indices = np.arange(n_samples)
+        else:
+            n_samples = self.bipolar_egm.egm.shape[1]
+            self._time_indices = np.arange(n_samples)
 
     @property
     def times(self):

--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -95,6 +95,9 @@ def extract_surface_data(surface_data):
     except KeyError as e:
         thickness = None
 
+    if isinstance(thickness, np.ndarray) and thickness.size == 0:
+        thickness = None
+
     fields = Fields(
         bipolar_voltage,
         unipolar_voltage,

--- a/openep/io/_circle_cvi.py
+++ b/openep/io/_circle_cvi.py
@@ -20,7 +20,7 @@
 Create meshes from Circle CVI workspaces --- :mod:`openep.io.readers._circle_cvi`
 =================================================================================
 
-This module contains functions for creating an OpenEP dataset (mesh only)
+This module contains functions for creating a PyVista PolyData mesh
 from a Circle CVI workspace and a stack of dicoms.
 
 """

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -128,7 +128,6 @@ def load_opencarp(
     points,
     indices,
     name=None,
-    fill_fields=False,
     scale_points=1,
 ):
     """
@@ -140,8 +139,6 @@ def load_opencarp(
             supported.
         name (str, optional): Name of the dataset. If None, the basename of the points file
             will be used as the name.
-        fill_fields (bool, optional): If True, will create scalar fields filled with NaN values
-            (one value per point).
         scale_points (float, optional): Scale the point positions by this number. Useful to scaling
             the units to be in mm rather than micrometre.
 
@@ -150,7 +147,7 @@ def load_opencarp(
 
     Note
     ----
-    All other attributes of the Case object will be empty numpy arrays.
+    All other attributes of the Case object will be set to None.
 
     """
 

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -59,9 +59,9 @@ import numpy as np
 
 from . import _circle_cvi
 from .matlab import _load_mat_v73, _load_mat_below_v73
-from ..data_structures.surface import extract_surface_data, empty_fields
-from ..data_structures.electric import extract_electric_data, empty_electric
-from ..data_structures.ablation import extract_ablation_data, empty_ablation
+from ..data_structures.surface import extract_surface_data, Fields
+from ..data_structures.electric import extract_electric_data, Electric
+from ..data_structures.ablation import extract_ablation_data, Ablation
 from ..data_structures.case import Case
 
 __all__ = ["load_openep_mat", "_load_mat", "load_opencarp", "load_circle_cvi"]
@@ -160,11 +160,11 @@ def load_opencarp(
     points_data *= scale_points
     indices_data = np.loadtxt(indices, skiprows=1, usecols=[1, 2, 3], dtype=int)  # ignore the tag for now
 
-    size = size=points_data.size // 3 if fill_fields else 0
-    fields = empty_fields(size)
-    electric = empty_electric()
-    ablation = empty_ablation()
-    notes = np.asarray([])
+    # Create empty data structures for pass to Case
+    fields = Fields()
+    electric = Electric()
+    ablation = Ablation()
+    notes = np.asarray([], dtype=object)
 
     return Case(name, points_data, indices_data, fields, electric, ablation, notes)
 

--- a/openep/load-kodex-data.py
+++ b/openep/load-kodex-data.py
@@ -1,0 +1,22 @@
+import numpy as np
+import openep
+from openep._datasets.openep_datasets import DATASET_2
+
+case = openep.load_opencarp(
+    '../openep-misc/examples/data/pig21_endo_coarse.pts',
+    '../openep-misc/examples/data/pig21_endo_coarse.elem'
+)
+egms = np.loadtxt('../openep-misc/examples/data/pig21_endo_coarse_phie.dat')
+case.add_unipolar_electrograms(
+    egms,
+)
+openep.export_openep_mat(case, 'test-export.mat')
+case = openep.load_openep_mat('test-export.mat')
+
+
+#case = openep.load_openep_mat('../openep-misc/examples/data/pig21_endo_coarse.mat')
+#case = openep.load_openep_mat('../testdata.mat')
+
+#openep.export_openep_mat(case, "../testdata-exported.mat")
+#new_case = openep.load_openep_mat('../testdata-exported.mat')
+#print(case)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -42,8 +42,53 @@ def exported_case(case, tmp_path):
 def test_openep_mat_export(case, exported_case):
     """Check the scalar fields of the original and exported data set are equal."""
 
+    assert np.all(case.notes == exported_case.notes)
+
+    assert_allclose(case.points, exported_case.points)
+    assert_allclose(case.indices, exported_case.indices)
+
     assert_allclose(case.fields.bipolar_voltage, exported_case.fields.bipolar_voltage, equal_nan=True)
     assert_allclose(case.fields.unipolar_voltage, exported_case.fields.unipolar_voltage, equal_nan=True)
     assert_allclose(case.fields.local_activation_time, exported_case.fields.local_activation_time, equal_nan=True)
     assert_allclose(case.fields.force, exported_case.fields.force, equal_nan=True)
     assert_allclose(case.fields.impedance, exported_case.fields.impedance, equal_nan=True)
+
+    assert np.all(case.electric.names == exported_case.electric.names)
+    assert np.all(case.electric.internal_names == exported_case.electric.internal_names)
+
+    assert_allclose(case.electric.bipolar_egm.egm, exported_case.electric.bipolar_egm.egm)
+    assert_allclose(case.electric.bipolar_egm.points, exported_case.electric.bipolar_egm.points)
+    assert_allclose(case.electric.bipolar_egm.voltage, exported_case.electric.bipolar_egm.voltage)
+    assert_allclose(case.electric.bipolar_egm.gain, exported_case.electric.bipolar_egm.gain)
+    assert np.all(case.electric.bipolar_egm.names == exported_case.electric.bipolar_egm.names)
+
+    assert_allclose(case.electric.unipolar_egm.egm, exported_case.electric.unipolar_egm.egm)
+    assert_allclose(case.electric.unipolar_egm.points, exported_case.electric.unipolar_egm.points)
+    assert_allclose(case.electric.unipolar_egm.voltage, exported_case.electric.unipolar_egm.voltage)
+    assert_allclose(case.electric.unipolar_egm.gain, exported_case.electric.unipolar_egm.gain)
+    assert np.all(case.electric.unipolar_egm.names == exported_case.electric.unipolar_egm.names)
+
+    assert_allclose(case.electric.reference_egm.egm, exported_case.electric.reference_egm.egm)
+    assert_allclose(case.electric.reference_egm.gain, exported_case.electric.reference_egm.gain)
+    assert exported_case.electric.reference_egm.points is None
+    assert exported_case.electric.reference_egm.voltage is None
+    assert exported_case.electric.reference_egm.names is None
+
+    assert_allclose(case.electric.ecg.ecg, exported_case.electric.ecg.ecg)
+    assert_allclose(case.electric.ecg.gain, exported_case.electric.ecg.gain)
+    assert np.all(case.electric.ecg.channel_names == exported_case.electric.ecg.channel_names)
+
+    assert_allclose(case.electric.annotations.reference_activation_time, case.electric.annotations.reference_activation_time)
+    assert_allclose(case.electric.annotations.local_activation_time, case.electric.annotations.local_activation_time)
+    assert_allclose(case.electric.annotations.window_of_interest, case.electric.annotations.window_of_interest)
+
+    assert_allclose(case.ablation.times, exported_case.ablation.times)
+    assert_allclose(case.ablation.power, exported_case.ablation.power)
+    assert_allclose(case.ablation.impedance, exported_case.ablation.impedance)
+    assert_allclose(case.ablation.temperature, exported_case.ablation.temperature)
+
+    assert_allclose(case.ablation.force.times, exported_case.ablation.force.times)
+    assert_allclose(case.ablation.force.points, exported_case.ablation.force.points)
+    assert_allclose(case.ablation.force.force, exported_case.ablation.force.force)
+    assert_allclose(case.ablation.force.axial_angle, exported_case.ablation.force.axial_angle)
+    assert_allclose(case.ablation.force.lateral_angle, exported_case.ablation.force.lateral_angle)


### PR DESCRIPTION
Changes made:

* When loading a dataset, if it is missing any attribute it is now set to be None rather than an empty array
* When exporting a dataset in openep format, any attributes that are None are set the be empty 1D arrays (as scipy cannot write None to .mat files)
* If any field in `case.fields` is missing, set it to None. Previously the field would be populated with NaN values - one per point in the mesh. However, this makes the dataset significantly larger, especially if all fields are missing (e.g. when loading openCarp datasets)