### PR TITLE
Remove 'buffer' argument from interpolation function

### DIFF
--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -453,15 +453,11 @@ class Interpolator:
 
 def interpolate_activation_time_onto_surface(
         case,
-        buffer=50,
         method=scipy.interpolate.RBFInterpolator,
         method_kws=None,
         max_distance=None,
 ):
     """Interpolate local activation times onto the points of a mesh.
-
-    Only mapping points within the window of interest, plus the buffer time,
-    are used for the interpolation.
 
     Args:
         case (openep.case.Case): case from which the activation time will be interpolated


### PR DESCRIPTION
Changes made:
* The window of interest is not used in determining which mapping points to include in the interpolation. Thus the 'buffer' argument to the interpolation methods is not used and has now been removed.