### PR TITLE
Fix importing and exporting openep datasets

### DIFF
--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -18,6 +18,7 @@
 
 """Module containing classes for storing surface data of a mesh."""
 
+from threading import local
 from attr import attrs
 import numpy as np
 
@@ -83,12 +84,24 @@ def extract_surface_data(surface_data):
     else:
         local_activation_time, bipolar_voltage = surface_data['act_bip'].T.astype(float)
 
+    if all(np.isnan(local_activation_time)):
+        local_activation_time = None
+    if all(np.isnan(bipolar_voltage)):
+        bipolar_voltage = None
+
     if surface_data['uni_imp_frc'].size == 0:
         unipolar_voltage = None
         impedance = None
         force = None
     else:
         unipolar_voltage, impedance, force = surface_data['uni_imp_frc'].T.astype(float)
+
+    if all(np.isnan(unipolar_voltage)):
+        unipolar_voltage = None
+    if all(np.isnan(impedance)):
+        impedance = None
+    if all(np.isnan(force)):
+        force = None
 
     try:
         thickness = surface_data['thickness'].astype(float)

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -173,7 +173,14 @@ def _extract_surface_data(
     triangulation = indices.astype(float) + 1 if indices is not None else empty_int_array
     surface_data['triRep']['Triangulation'] = triangulation
 
-    try:
+    if fields.local_activation_time is None and fields.bipolar_voltage is None:
+        surface_data['act_bip'] = empty_float_array
+    elif fields.local_activation_time is None:
+        fields.local_activation_time = np.full_like(fields.bipolar_voltage, fill_value=np.NaN)
+    elif fields.bipolar_voltage is None:
+        fields.bipolar_voltage = np.full_like(fields.local_activation_time, fill_value=np.NaN)
+
+    if 'act_bip' not in surface_data:
         surface_data['act_bip'] = np.concatenate(
             [
                 fields.local_activation_time[:, np.newaxis],
@@ -181,10 +188,18 @@ def _extract_surface_data(
             ],
             axis=1,
         )
-    except TypeError as e:
-        surface_data['act_bip'] = empty_float_array
 
-    try:
+    if fields.unipolar_voltage is None and fields.impedance is None and fields.force is None:
+        surface_data['uni_imp_frc'] = empty_float_array
+    else:
+        if fields.unipolar_voltage is None:
+            fields.unipolar_voltage = np.full(points.size // 3, fill_value=np.NaN)
+        if fields.impedance is None:
+            fields.impedance = np.full(points.size // 3, fill_value=np.NaN)
+        if fields.force is None:
+            fields.force = np.full(points.size // 3, fill_value=np.NaN)
+
+    if 'uni_imp_frc' not in surface_data:
         surface_data['uni_imp_frc'] = np.concatenate(
             [
                 fields.unipolar_voltage[:, np.newaxis],
@@ -193,8 +208,6 @@ def _extract_surface_data(
             ],
             axis=1,
         )
-    except TypeError as e:
-        surface_data['uni_imp_frc'] = empty_float_array
 
     surface_data['thickness'] = fields.thickness if fields.thickness is not None else empty_float_array
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -50,11 +50,13 @@ def test_openep_mat_export(case, exported_case):
     assert_allclose(case.fields.bipolar_voltage, exported_case.fields.bipolar_voltage, equal_nan=True)
     assert_allclose(case.fields.unipolar_voltage, exported_case.fields.unipolar_voltage, equal_nan=True)
     assert_allclose(case.fields.local_activation_time, exported_case.fields.local_activation_time, equal_nan=True)
-    assert_allclose(case.fields.force, exported_case.fields.force, equal_nan=True)
-    assert_allclose(case.fields.impedance, exported_case.fields.impedance, equal_nan=True)
+    assert exported_case.fields.force is None
+    assert exported_case.fields.impedance is None
+    assert exported_case.fields.thickness is None
 
     assert np.all(case.electric.names == exported_case.electric.names)
     assert np.all(case.electric.internal_names == exported_case.electric.internal_names)
+    assert_allclose(case.electric.include, exported_case.electric.include)
 
     assert_allclose(case.electric.bipolar_egm.egm, exported_case.electric.bipolar_egm.egm)
     assert_allclose(case.electric.bipolar_egm.points, exported_case.electric.bipolar_egm.points)


### PR DESCRIPTION
Changes made:
* If any of the `case.fields` have arrays in which all values are equal to NaN, set this field to be None
* Updated the exporting of datasets to handle cases where some fields are None
* Updated the exporting tests