### PR TITLE
Use python 3.9 for running tests and building docs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,10 +24,10 @@ jobs:
     - uses: actions/checkout@v2
     # Setup Python using a existing action "actions/setup-python@v2" from Github's library of actions
     # Arguments are provided to this action using the key-values under "with"
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     # Install the requirements for this library plus those for running out tests (flake8 and coverage)
     - name: Install dependencies
       run: |
@@ -61,10 +61,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: 3.9
    install:
    - requirements: docs/requirements.txt
    - requirements: requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ autodoc_mock_imports = [
     'h5py',
     'numpy',
     'scipy',
+    'pandas',
     'matplotlib',
     'pyvista',
     'pymeshfix',
@@ -74,11 +75,6 @@ autodoc_member_order = 'bysource'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if not on_rtd:  # only set the theme if we're building docs locally
     html_theme = 'sphinx_rtd_theme'
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
 
 html_use_smartypants = True
 html_last_updated_fmt = '%b %d, %Y'

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -7,7 +7,7 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set SOURCEDIR=source
+set SOURCEDIR=.
 set BUILDDIR=build
 
 if "%1" == "" goto help

--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -90,7 +90,6 @@ from ..case.case_routines import bipolar_from_unipolar_surface_points
 __all__ = []
 
 
-@attrs(auto_attribs=True, auto_detect=True)
 class Case:
     """
     The fundamental OpenEP object.
@@ -109,13 +108,25 @@ class Case:
         notes (list, optional): Notes associated with the dataset.
 
     """
-    name: str
-    points: np.ndarray
-    indices: np.ndarray
-    fields: Fields
-    electric: Electric
-    ablation: Optional[Ablation] = None
-    notes: Optional[List] = None
+
+    def __init__(
+        self,
+        name: str,
+        points: np.ndarray,
+        indices: np.ndarray,
+        fields: Fields,
+        electric: Electric,
+        ablation: Optional[Ablation] = None,
+        notes: Optional[List] = None,
+    ):
+
+        self.name = name
+        self.points = points
+        self.indices = indices
+        self.fields = fields
+        self.ablation = ablation
+        self.electric = electric
+        self.notes = notes
 
     def __repr__(self):
         return f"{self.name}( nodes: {self.points.shape} indices: {self.indices.shape} {self.fields} )"

--- a/openep/mesh/mesh_routines.py
+++ b/openep/mesh/mesh_routines.py
@@ -34,7 +34,7 @@ Calculating the mesh surface area and volume
 
 .. autofunction:: calculate_field_area
 
-.. autofunction:: calculate_per_triangle_field
+.. autofunction:: point_data_to_cell_data
 
 .. _distances:
 
@@ -105,7 +105,6 @@ def _create_trimesh(pyvista_mesh):
     return trimesh.Trimesh(vertices, faces, process=False)
 
 
-@attrs(auto_attribs=True, auto_detect=True)
 class FreeBoundary:
     """
     Class for storing information on the free boundaries of a mesh.
@@ -121,13 +120,20 @@ class FreeBoundary:
             were identified.
     """
 
-    points: np.ndarray
-    lines: np.ndarray
-    n_boundaries: int
-    n_points_per_boundary: np.ndarray
-    original_lines: np.ndarray
+    def __init__(
+        self,
+        points: np.ndarray,
+        lines: np.ndarray,
+        n_boundaries: int,
+        n_points_per_boundary: np.ndarray,
+        original_lines: np.ndarray
+    ):
 
-    def __attrs_post_init__(self):
+        self.points = points
+        self.lines = lines
+        self.n_boundaries = n_boundaries
+        self.n_points_per_boundary = n_points_per_boundary
+        self.original_lines = original_lines
 
         if self.n_boundaries == 0:
             self._start_indices = None
@@ -147,7 +153,7 @@ class FreeBoundary:
 
         self._boundary_meshes = None
 
-    def separate_boundaries(self, original_lines=False):
+    def separate_boundaries(self, original_lines: bool = False):
         """
         Creates a list of numpy arrays where each array contains the indices of
         node pairs in a single free boundary.
@@ -158,10 +164,10 @@ class FreeBoundary:
                 If False, `FreeBoundary.lines` will be used.
 
         Returns:
-            boundaries (list): a list of numpy arrays - one array per free boundary.
-            Each array is of shape Nx2, where N is the number of lines in a given boundary.
-            Each array contains the indices of pairs of nodes that make up each line in the
-            boundary.
+            separate_boundaries (list): a list of numpy arrays - one array per free boundary.
+                Each array is of shape Nx2, where N is the number of lines in a given boundary.
+                Each array contains the indices of pairs of nodes that make up each line in the
+                boundary.
 
         """
 
@@ -203,7 +209,7 @@ class FreeBoundary:
             points (ndarray): Nx3 array of cartesian coordinates of points along the line.
 
         Returns:
-            length (float): length of the line
+            total_distance (float): length of the line
         """
 
         distance_between_neighbours = np.sqrt(np.sum(np.square(points[:, 0, :] - points[:, 1, :]), axis=1))


### PR DESCRIPTION
Changes made:
* Use python 3.9 for running tests and building docs
* Swtich `FreeBoundary` and `Case` classes from attrs classes to regular classes. For some reason sphinx-build would complain about not being able to infer the types of arguments in methods belonging to these attrs classes