### PR TITLE
Read/write opencarp fibre files

### DIFF
--- a/openep/io/matlab.py
+++ b/openep/io/matlab.py
@@ -124,6 +124,9 @@ def _mat_v73_transform_arrays(data):
         if key == 'userdata/electric/electrodeNames_uni':
             data[key] = data[key].reshape(2, -1).T
 
+        if 'userdata/surface/fibres' in key:
+            data[key] = data[key].reshape(3, -1).T
+
     return data
 
 
@@ -135,7 +138,7 @@ def _mat_v73_flat_to_nested(data):
     ['userdata']['electric].
 
     Args:
-        data ([type]): [description]
+        data (dict): Data loaded from a v7.3 .mat file.
     """
 
     nested_dict = lambda: defaultdict(nested_dict)  # noqa: E731
@@ -163,7 +166,7 @@ def _mat_v73_flat_to_nested(data):
             nested_data[key1][key2][key3][key4] = data[key]
 
         else:
-            raise ValueError(f"Need more leaves! {key}")
+            raise ValueError(f"Cannot make nested key from: {key}")
 
     return nested_data
 

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -159,8 +159,16 @@ def load_opencarp(
     points_data *= scale_points
     indices_data = np.loadtxt(indices, skiprows=1, usecols=[1, 2, 3], dtype=int)  # ignore the tag for now
 
+    longitudinal_fibres = None
+    transverse_fibres = None
+    if fibres is not None:
+        fibres_data = np.loadtxt(fibres, skiprows=1, dtype=float)
+        longitudinal_fibres = fibres_data[:, :3]
+        if fibres_data.shape[1] == 6:
+            transverse_fibres = fibres_data[:, 3:]
+
     # Create empty data structures for pass to Case
-    fields = Fields()
+    fields = Fields(longitudinal_fibres=longitudinal_fibres, transverse_fibres=transverse_fibres)
     electric = Electric()
     ablation = Ablation()
     notes = np.asarray([], dtype=object)

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -127,6 +127,7 @@ def load_openep_mat(filename, name=None):
 def load_opencarp(
     points,
     indices,
+    fibres=None,
     name=None,
     scale_points=1,
 ):
@@ -137,13 +138,14 @@ def load_opencarp(
         points (str): Path to the openCARP points file.
         indices (str): Path to the openCARP element file. Currently, only triangular meshes are
             supported.
+        fibres (str, optional): Path to the openCARP fibres file.
         name (str, optional): Name of the dataset. If None, the basename of the points file
             will be used as the name.
         scale_points (float, optional): Scale the point positions by this number. Useful to scaling
             the units to be in mm rather than micrometre.
 
     Returns:
-        case (Case): an OpenEP Case object that contains the points and indices.
+        case (Case): an OpenEP Case object that contains the points, indices and fibres.
 
     Note
     ----


### PR DESCRIPTION
Changes made:

* Added new fields `case.fields.longitudinal_fibres` and `case.fields.transverse_fibres`
* When exported as .mat, stored in `userdata.surface.fibres.longitudinal` and `userdata.surface.fibres.transverse`
* When case is exported as openCARP, fibres are written to .lon
* Added option to pass .lon file when import openCARP files