### PR TITLE
Separate landmark-only points from points with electrical data

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -169,11 +169,11 @@ class Case:
 
         self.points += translate_by
         if self.electric.bipolar_egm.points is not None:
-            self.electric.bipolar_egm.points += translate_by
+            self.electric.bipolar_egm._points += translate_by
         if self.electric.unipolar_egm.points is not None:
-            self.electric.unipolar_egm.points += translate_by[:, np.newaxis]
+            self.electric.unipolar_egm._points += translate_by[:, np.newaxis]
         if self.electric.surface.nearest_point is not None:
-            self.electric.surface.nearest_point += translate_by
+            self.electric.surface._nearest_point += translate_by
 
     def create_mesh(
         self,

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -447,6 +447,13 @@ class Electric:
     def include(self):
         return self._include[self._is_electrical]
 
+    @include.setter
+    def include(self, include):
+        if isinstance(include, np.ndarray) and include.size == self.n_points:
+            self._include[self._is_electrical] = include
+        else:
+            self._include = include
+
     @property
     def times(self):
         return self._time_indices * 1000 / self.frequency  # time in ms

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -390,6 +390,7 @@ class Electric:
         self._internal_names = internal_names
         self._include = include
         self._is_electrical = is_electrical
+        self._is_electrical_indices = np.nonzero(is_electrical)[0].ravel()
         self.bipolar_egm = bipolar_egm
         self.unipolar_egm = unipolar_egm
         self.reference_egm = reference_egm

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -251,8 +251,11 @@ class ElectricSurface:
         self._normals = normals
         self._is_electrical = is_electrical
 
+        if self._nearest_point is None:
+            self._nearest_point = np.full((is_electrical.size, 3), fill_value=np.NaN, dtype=float)
+
         if self._normals is None and self._nearest_point is not None:
-            self._normals = np.ones_like(self._nearest_point, dtype=float)
+            self._normals = np.full_like(self._nearest_point, fill_value=np.NaN, dtype=float)
         
     @property
     def nearest_point(self):

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -247,40 +247,40 @@ def _extract_electric_data(electric: Electric):
     empty_int_array = np.array([], dtype=int)
 
     electric_data = {}
-    electric_data['tags'] = electric.names.astype(object) if electric.names is not None else empty_object_array
-    electric_data['names'] = electric.internal_names.astype(object) if electric.internal_names is not None else empty_object_array
-    electric_data['include'] = electric.include if electric.include is not None else empty_int_array
+    electric_data['tags'] = electric._names.astype(object) if electric._names is not None else empty_object_array
+    electric_data['names'] = electric._internal_names.astype(object) if electric._internal_names is not None else empty_object_array
+    electric_data['include'] = electric._include if electric._include is not None else empty_int_array
 
     electric_data['sampleFrequencu'] = float(electric.frequency)
 
-    electric_data['electrodeNames_bip'] = electric.bipolar_egm.names.astype(object) if electric.bipolar_egm.names is not None else empty_object_array
-    electric_data['egmX'] = electric.bipolar_egm.points if electric.bipolar_egm.points is not None else empty_float_array
-    electric_data['egm'] = electric.bipolar_egm.egm if electric.bipolar_egm.egm is not None else empty_float_array
-    electric_data['egmGain'] = electric.bipolar_egm.gain if electric.bipolar_egm.gain is not None else empty_float_array
+    electric_data['electrodeNames_bip'] = electric.bipolar_egm._names.astype(object) if electric.bipolar_egm._names is not None else empty_object_array
+    electric_data['egmX'] = electric.bipolar_egm._points if electric.bipolar_egm._points is not None else empty_float_array
+    electric_data['egm'] = electric.bipolar_egm._egm if electric.bipolar_egm._egm is not None else empty_float_array
+    electric_data['egmGain'] = electric.bipolar_egm._gain if electric.bipolar_egm._gain is not None else empty_float_array
 
-    electric_data['electrodeNames_uni'] = electric.unipolar_egm.names.astype(object) if electric.unipolar_egm.names is not None else empty_object_array
-    electric_data['egmUniX'] = electric.unipolar_egm.points if electric.unipolar_egm.points is not None else empty_float_array
-    electric_data['egmUni'] = electric.unipolar_egm.egm if electric.unipolar_egm.egm is not None else empty_float_array
-    electric_data['egmUniGain'] = electric.unipolar_egm.gain if electric.unipolar_egm.gain is not None else empty_float_array
+    electric_data['electrodeNames_uni'] = electric.unipolar_egm._names.astype(object) if electric.unipolar_egm._names is not None else empty_object_array
+    electric_data['egmUniX'] = electric.unipolar_egm._points if electric.unipolar_egm._points is not None else empty_float_array
+    electric_data['egmUni'] = electric.unipolar_egm._egm if electric.unipolar_egm._egm is not None else empty_float_array
+    electric_data['egmUniGain'] = electric.unipolar_egm._gain if electric.unipolar_egm._gain is not None else empty_float_array
 
-    electric_data['egmRef'] = electric.reference_egm.egm if electric.reference_egm.egm is not None else empty_float_array
-    electric_data['egmRefGain'] = electric.reference_egm.gain if electric.reference_egm.gain is not None else empty_float_array
+    electric_data['egmRef'] = electric.reference_egm._egm if electric.reference_egm._egm is not None else empty_float_array
+    electric_data['egmRefGain'] = electric.reference_egm._gain if electric.reference_egm._gain is not None else empty_float_array
 
-    electric_data['ecg'] = electric.ecg.ecg if electric.ecg.ecg is not None else empty_float_array
-    electric_data['ecgGain'] = electric.ecg.gain if electric.ecg.gain is not None else empty_float_array
+    electric_data['ecg'] = electric.ecg._ecg if electric.ecg._ecg is not None else empty_float_array
+    electric_data['ecgGain'] = electric.ecg._gain if electric.ecg._gain is not None else empty_float_array
     electric_data['ecgNames'] = electric.ecg.channel_names.astype(object) if electric.ecg.channel_names is not None else empty_object_array
 
-    electric_data['egmSurfX'] = electric.surface.nearest_point if electric.surface.nearest_point is not None else empty_float_array
-    electric_data['barDirection'] = electric.surface.normals if electric.surface.normals is not None else empty_float_array
+    electric_data['egmSurfX'] = electric.surface._nearest_point if electric.surface._nearest_point is not None else empty_float_array
+    electric_data['barDirection'] = electric.surface._normals if electric.surface._normals is not None else empty_float_array
 
     electric_data['annotations'] = {}
-    electric_data['annotations']['woi'] = electric.annotations.window_of_interest
-    electric_data['annotations']['referenceAnnot'] = electric.annotations.reference_activation_time
-    electric_data['annotations']['mapAnnot'] = electric.annotations.local_activation_time
+    electric_data['annotations']['woi'] = electric.annotations._window_of_interest_indices
+    electric_data['annotations']['referenceAnnot'] = electric.annotations._reference_activation_time_indices
+    electric_data['annotations']['mapAnnot'] = electric.annotations._local_activation_time_indices
 
     electric_data['voltages'] = {}
-    electric_data['voltages']['bipolar'] = electric.bipolar_egm.voltage if electric.bipolar_egm.voltage is not None else empty_float_array
-    electric_data['voltages']['unipolar'] = electric.unipolar_egm.voltage if electric.unipolar_egm.voltage is not None else empty_float_array
+    electric_data['voltages']['bipolar'] = electric.bipolar_egm._voltage if electric.bipolar_egm._voltage is not None else empty_float_array
+    electric_data['voltages']['unipolar'] = electric.unipolar_egm._voltage if electric.unipolar_egm._voltage is not None else empty_float_array
 
     electric_data['impedances'] = {}
     electric_data['impedances']['time'] = electric.impedance.times if electric.impedance.times is not None else empty_float_array


### PR DESCRIPTION
Changes made:
* Added a new class `openep.data_structures.electric.LandmarkPoints` for storing data (coordinates, tags) of landmark points (either landmark-only points or landmark points with electrical data - there's no need to distinguish.)
* Landmark-only points are removed from all other data, e.g. `case.electric.bipolar_egm.egm`, `case.electric.include` etc. contain only data for mapping points with electrical signals
* The full original data is stored in the same attribute but with a leading underscore, e.g. `case.electric.bipolar_egm._egm`, `case.electric._include`
* Properties are then used along with a flag (`case.electric._is_electrical`) to filter the points with electrical data. The flag is True is a mapping point has electrical signals and False otherwise
* Using properties means that the filtered arrays are not views of the underlying data (as they are creating via fancy indexing of the full arrays). This means that the values for individual points cannot be changed. However, property setters have been written to set the value of all points with electrical data at once, e.g.
```py
case.electric.include = include
```
will set `case.electric._include[case.electric._is_electrical] = include`
* Updated other functions (such as `case.translate` and `openep.export_openep_mat`) to handle the new structure of `case.electric`