### PR TITLE
Fix reading and writing opencarp files

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -134,8 +134,10 @@ class Case:
     def remove_unreferenced_points(self):
         """Remove surface points not reference in the triangulation."""
 
-        # Determine which points are referenced and remove
         referenced_indices = np.unique(self.indices.ravel())
+        n_points = self.points.size // 3
+
+        # Remove the unreferenced points
         self.points = self.points[referenced_indices]
 
         # Renumber indices to takes into account changed number of points.
@@ -144,7 +146,7 @@ class Case:
 
         # Remove unused point data from the fields
         for field in self.fields:
-            if self.fields[field] is None:
+            if self.fields[field] is None or self.fields[field].size != n_points:
                 continue
             self.fields[field] = self.fields[field][referenced_indices]
 

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -251,7 +251,7 @@ class ElectricSurface:
         self._normals = normals
         self._is_electrical = is_electrical
 
-        if self._nearest_point is None:
+        if self._nearest_point is None and self._is_electrical is not None:
             self._nearest_point = np.full((is_electrical.size, 3), fill_value=np.NaN, dtype=float)
 
         if self._normals is None and self._nearest_point is not None:

--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -180,7 +180,7 @@ def empty_fields(n_points=0, n_cells=0):
     impedance = np.full(n_points, fill_value=np.NaN, dtype=float)
     force = np.full(n_points, fill_value=np.NaN, dtype=float)
     thickness = np.full(n_points, fill_value=np.NaN, dtype=float)
-    region = np.full(n_cells, fill_value=0, dtype=int)
+    cell_region = np.full(n_cells, fill_value=0, dtype=int)
     longitudinal_fibres = np.full((n_cells, 3), fill_value=np.NaN)
     transverse_fibres = np.full((n_cells, 3), fill_value=np.NaN)
 
@@ -191,7 +191,7 @@ def empty_fields(n_points=0, n_cells=0):
         impedance,
         force,
         thickness,
-        region,
+        cell_region,
         longitudinal_fibres,
         transverse_fibres,
     )

--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -47,7 +47,7 @@ class Fields:
     impedance: np.ndarray = None
     force: np.ndarray = None
     thickness: np.ndarray = None
-    region: np.ndarray = None
+    cell_region: np.ndarray = None
     longitudinal_fibres: np.ndarray = None
     transverse_fibres: np.ndarray = None
 
@@ -126,12 +126,12 @@ def extract_surface_data(surface_data):
 
     # This is defined on a per-cell bases
     try:
-        region = surface_data['region'].astype(int)
+        cell_region = surface_data['cell_region'].astype(int)
     except KeyError as e:
-        region = None
+        cell_region = None
 
-    if isinstance(region, np.ndarray) and region.size == 0:
-        region = None
+    if isinstance(cell_region, np.ndarray) and cell_region.size == 0:
+        cell_region = None
 
     # Fibre orientation are vectors defined on a per-cell basis
     try:
@@ -158,7 +158,7 @@ def extract_surface_data(surface_data):
         impedance=impedance,
         force=force,
         thickness=thickness,
-        region=region,
+        cell_region=cell_region,
         longitudinal_fibres=longitudinal_fibres,
         transverse_fibres=transverse_fibres,
     )

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -157,7 +157,8 @@ def load_opencarp(
 
     points_data = np.loadtxt(points, skiprows=1)
     points_data *= scale_points
-    indices_data = np.loadtxt(indices, skiprows=1, usecols=[1, 2, 3], dtype=int)  # ignore the tag for now
+    indices_data = np.loadtxt(indices, skiprows=1, usecols=[1, 2, 3], dtype=int)
+    cell_region = np.loadtxt(indices, skiprows=1, usecols=4, dtype=int)
 
     longitudinal_fibres = None
     transverse_fibres = None
@@ -168,7 +169,11 @@ def load_opencarp(
             transverse_fibres = fibres_data[:, 3:]
 
     # Create empty data structures for pass to Case
-    fields = Fields(longitudinal_fibres=longitudinal_fibres, transverse_fibres=transverse_fibres)
+    fields = Fields(
+        cell_region=cell_region,
+        longitudinal_fibres=longitudinal_fibres,
+        transverse_fibres=transverse_fibres,
+    )
     electric = Electric()
     ablation = Ablation()
     notes = np.asarray([], dtype=object)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -53,7 +53,9 @@ def test_openep_mat_export(case, exported_case):
     assert exported_case.fields.force is None
     assert exported_case.fields.impedance is None
     assert exported_case.fields.thickness is None
-    assert exported_case.fields.region is None
+    assert exported_case.fields.cell_region is None
+    assert exported_case.longitudinal_fibres is None
+    assert exported_case.transverse_fibres is None
 
     assert np.all(case.electric.names == exported_case.electric.names)
     assert np.all(case.electric.internal_names == exported_case.electric.internal_names)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -54,8 +54,8 @@ def test_openep_mat_export(case, exported_case):
     assert exported_case.fields.impedance is None
     assert exported_case.fields.thickness is None
     assert exported_case.fields.cell_region is None
-    assert exported_case.longitudinal_fibres is None
-    assert exported_case.transverse_fibres is None
+    assert exported_case.fields.longitudinal_fibres is None
+    assert exported_case.fields.transverse_fibres is None
 
     assert np.all(case.electric.names == exported_case.electric.names)
     assert np.all(case.electric.internal_names == exported_case.electric.internal_names)


### PR DESCRIPTION
Changes made:
* correctly import/export the cell region id, as well as fibres
* add option to export only longitudinal fibres (ignoring transverse). This is controlled by the argument `export_transverse_fibres` to the function `openep.export_opencarp`
* don't remove cell data in the function `openep.case.remove_unreferenced_points`