### PR TITLE
Electrogram class assigns voltage to NaNs

### DIFF
--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -84,6 +84,12 @@ class Electrogram:
         if egm is not None and gain is None:
             gain = np.ones(egm.shape[0])
 
+        if egm is not None and voltage is None:
+            voltage = np.full(egm.shape[0], fill_value=np.NaN)
+
+        if egm is not None and is_electrical is None:
+            is_electrical = np.ones(egm.shape[0], fill_value=True, dtype=bool)
+
         self._egm = egm
         self._points = points
         self._voltage = voltage

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -270,12 +270,6 @@ def _extract_electric_data(electric: Electric):
     empty_float_array = np.array([], dtype=float)
     empty_int_array = np.array([], dtype=int)
 
-    # Voltages are added when loading a dataset if egms are present but voltages are not
-    # These should be removed before saving
-    for egm in [electric.bipolar_egm, electric.unipolar_egm, electric.reference_egm]:
-        if all(np.isnan(egm.voltage)):
-            egm.voltage = None
-
     electric_data = {}
     electric_data['tags'] = electric._names.astype(object) if electric._names is not None else empty_object_array
     electric_data['names'] = electric._internal_names.astype(object) if electric._internal_names is not None else empty_object_array
@@ -311,6 +305,12 @@ def _extract_electric_data(electric: Electric):
     electric_data['voltages'] = {}
     electric_data['voltages']['bipolar'] = electric.bipolar_egm._voltage if electric.bipolar_egm._voltage is not None else empty_float_array
     electric_data['voltages']['unipolar'] = electric.unipolar_egm._voltage if electric.unipolar_egm._voltage is not None else empty_float_array
+
+    # Voltages are added when loading a dataset if egms are present but voltages are not
+    # These should be removed before saving
+    for channel, voltage in electric_data['voltages'].items():
+        if all(np.isnan(voltage)):
+            electric_data['voltages'][channel] = empty_float_array
 
     electric_data['impedances'] = {}
     electric_data['impedances']['time'] = electric.impedance.times if electric.impedance.times is not None else empty_float_array

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -270,6 +270,12 @@ def _extract_electric_data(electric: Electric):
     empty_float_array = np.array([], dtype=float)
     empty_int_array = np.array([], dtype=int)
 
+    # Voltages are added when loading a dataset if egms are present but voltages are not
+    # These should be removed before saving
+    for egm in [electric.bipolar_egm, electric.unipolar_egm, electric.reference_egm]:
+        if all(np.isnan(egm.voltage)):
+            egm.voltage = None
+
     electric_data = {}
     electric_data['tags'] = electric._names.astype(object) if electric._names is not None else empty_object_array
     electric_data['names'] = electric._internal_names.astype(object) if electric._internal_names is not None else empty_object_array

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -76,7 +76,7 @@ def test_openep_mat_export(case, exported_case):
     assert_allclose(case.electric.reference_egm.egm, exported_case.electric.reference_egm.egm)
     assert_allclose(case.electric.reference_egm.gain, exported_case.electric.reference_egm.gain)
     assert exported_case.electric.reference_egm.points is None
-    assert exported_case.electric.reference_egm.voltage is None
+    assert_allclose(case.electric.reference_egm.voltage, exported_case.electric.reference_egm.voltage, equal_nan=True)
     assert exported_case.electric.reference_egm.names is None
 
     assert_allclose(case.electric.ecg.ecg, exported_case.electric.ecg.ecg)


### PR DESCRIPTION
Changse made:
* When instantiating `openep._data_structures.Electrogram`, voltage values are assigned to be NaN if necessary
* This is done when egms are present but voltages are not, and ensures the setter for `Electrogram.voltage` works correctly
* These NaN values are not exported when saving to file