### PR TITLE
Add function to create a new landmark point

### DIFF
--- a/examples/bipolar_from_unipolar.py
+++ b/examples/bipolar_from_unipolar.py
@@ -20,10 +20,11 @@ import numpy as np
 import openep
 
 carp = openep.load_opencarp(
-    points="/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse.pts",
-    indices="/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse.elem",
-    scale=1000,
+    points="/home/ps21/github/openep-misc/examples/data/pig21_endo_coarse.pts",
+    indices="/home/ps21/github/openep-misc/examples/data/pig21_endo_coarse.elem",
+    scale_points=1000,
 )
+carp.add_landmark('a', 'b', point=np.array([0, 0, 0]))
 unipolar = np.loadtxt("/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse_phie.dat")
 carp.add_unipolar_electrograms(unipolar=unipolar)
 

--- a/examples/openep_caseroutines.py
+++ b/examples/openep_caseroutines.py
@@ -21,7 +21,16 @@ import matplotlib.pyplot as plt
 import openep
 from openep._datasets.openep_datasets import DATASET_2
 
+case = openep.load_openep_mat(
+    '/home/ps21/Downloads/2021-08-05_13-21-51_PL_L465_15_RA_LAT_WT_Abl - RA_Map_Remap1_1_1_1_1_1_1_1.mat'
+)
+case.add_landmark('a', 'b', point=np.array([0, 0, 0]))
+
 case = openep.load_openep_mat(DATASET_2)
+case.add_landmark('a', 'b', point=np.array([0, 0, 0]))
+openep.export_openep_mat(case, 'test-add-landmark.mat')
+case2 = openep.load_openep_mat('test-add-landmark.mat')
+
 openep.case.get_woi_times(case)
 mesh = case.create_mesh()
 

--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -164,18 +164,30 @@ class Case:
         * case.electric.bipolar_egm.points
         * case.electric.unipolar_egm.points
         * case.electric.surface.nearest_point
+        * case.electric.landmark_points.points
 
         Args:
             translate_by (np.ndarray): 3D coordinates by which to translate the case
         """
 
         self.points += translate_by
-        if self.electric.bipolar_egm.points is not None:
+        if self.electric.bipolar_egm._points is not None:
             self.electric.bipolar_egm._points += translate_by
-        if self.electric.unipolar_egm.points is not None:
+        elif self.electric.landmark_points._points is not None:
+            self.electric.landmark_points._points += translate_by
+        if self.electric.unipolar_egm._points is not None:
             self.electric.unipolar_egm._points += translate_by[:, np.newaxis]
-        if self.electric.surface.nearest_point is not None:
+        if self.electric.surface._nearest_point is not None:
             self.electric.surface._nearest_point += translate_by
+
+    def add_landmark(
+        self,
+        tag: str,
+        name: str,
+        point: np.ndarray,
+    ):
+        """Add a landmark to a case."""
+        self.electric.add_landmark(tag, name, point)
 
     def create_mesh(
         self,

--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -510,6 +510,11 @@ class Electric:
         # We need to add rows to **all** all signals
         # Not necessary for openep-py, but it is for openep-matlab
 
+        if name == '':
+            raise ValueError("name cannot be an empty string.")
+        if internal_name == '':
+            raise ValueError("internal_name cannot be an empty string.")
+
         if isinstance(internal_name, str):
             internal_name = np.array([internal_name], dtype=str)
         if isinstance(name, str):

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -77,7 +77,7 @@ def test_openep_mat_export(case, exported_case):
     assert_allclose(case.electric.reference_egm.gain, exported_case.electric.reference_egm.gain)
     assert exported_case.electric.reference_egm.points is None
     assert_allclose(case.electric.reference_egm.voltage, exported_case.electric.reference_egm.voltage, equal_nan=True)
-    assert exported_case.electric.reference_egm.names is None
+    assert all(exported_case.electric.reference_egm.names == '')
 
     assert_allclose(case.electric.ecg.ecg, exported_case.electric.ecg.ecg)
     assert_allclose(case.electric.ecg.gain, exported_case.electric.ecg.gain)


### PR DESCRIPTION
Changes made:

* Added a method `Case.add_landmark`
* This is a wrapper around a method `Electric.add_landmark`, which takes a `name`, `internal_name`, and `point` (3D coordinate) to add a landmark to the dataset
* The `name` and the `internal` name must not be empty strings
* If there is no bipolar egm data, then data a new instance of `EGM` is created with:
   - the `point` passed to `add_landmark`
   - `egm` set to be a single row with a single NaN value
   - `names` set to be an array with a single string `' '` (with a single space, not empty)
* otherwise, `case.electric.bipolar_egm` is updated in place
* For other signals (`reference_egm`, `unipolar_egm`, `ecg`, `annotation`), data is not created if the signal is not present, but arrays are modified inplace if they are present
* `case.electric.names`, `case.electric.tags`, `case.electric.include`, `case.electric._is_electrical`, `case.electric._is_landmark` are updated inplace if they exist or created if they do not
* `case.electric.landmark_points` are re-created based on data in `case.electric.bipolar_egm`