### PR TITLE
Fix arguments to case.add_landmark

### DIFF
--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -182,12 +182,12 @@ class Case:
 
     def add_landmark(
         self,
-        tag: str,
         name: str,
+        internal_name: str,
         point: np.ndarray,
     ):
         """Add a landmark to a case."""
-        self.electric.add_landmark(tag, name, point)
+        self.electric.add_landmark(name, internal_name, point)
 
     def create_mesh(
         self,


### PR DESCRIPTION
Changes made:

* `case.add_landmark` now takes the arguments `name` and `internal_name` rather than `tag` and `name`, to be consistent with the usage in both `case.electric.add_landmark` and `case.electric` in general