### PR TITLE
Add a pacing site field to case.fields

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,6 +53,7 @@ jobs:
         file: ./coverage.xml
         fail_ci_if_error: true
         verbose: true
+        version: "v0.1.15"
   
   build_docs:
     if: "github.repository == 'openep/openep-py'"

--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -366,6 +366,9 @@ def calculate_points_within_distance(origin, destination, max_distance, return_d
         and each test_point.
     """
 
+    origin = origin[np.newaxis, :] if origin.ndim == 1 else origin
+    destination = destination[np.newaxis, :] if destination.ndim == 1 else destination
+
     distances = calculate_distance(origin, destination)
     within_max_distance = distances <= max_distance
 

--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -38,6 +38,7 @@ class Fields:
         region (np.ndarray): array of shape N_cells
         longitudinal_fibres (np.ndarray): array of shape N_cells x 3
         transverse_fibres (np.ndarray): array of shape N_cells x 3
+        pacing_site (np.ndarray): array of shape N_points
     """
 
     bipolar_voltage: np.ndarray = None
@@ -49,6 +50,7 @@ class Fields:
     cell_region: np.ndarray = None
     longitudinal_fibres: np.ndarray = None
     transverse_fibres: np.ndarray = None
+    pacing_site: np.ndarray = None
 
     def __repr__(self):
         return f"fields: {tuple(self.__dict__.keys())}"
@@ -149,6 +151,14 @@ def extract_surface_data(surface_data):
     if isinstance(transverse_fibres, np.ndarray) and transverse_fibres.size == 0:
         transverse_fibres = None
 
+    # Pacing site point ids (-1 is not pacing site)
+    try:
+        pacing_site = surface_data['pacing_site'].astype(int)
+    except KeyError as e:
+        pacing_site = None
+
+    if isinstance(pacing_site, np.ndarray) and pacing_site.size == 0:
+        pacing_site = None
 
     fields = Fields(
         bipolar_voltage=bipolar_voltage,
@@ -160,6 +170,7 @@ def extract_surface_data(surface_data):
         cell_region=cell_region,
         longitudinal_fibres=longitudinal_fibres,
         transverse_fibres=transverse_fibres,
+        pacing_site=pacing_site,
     )
 
     return points, indices, fields
@@ -182,6 +193,7 @@ def empty_fields(n_points=0, n_cells=0):
     cell_region = np.full(n_cells, fill_value=0, dtype=int)
     longitudinal_fibres = np.full((n_cells, 3), fill_value=np.NaN)
     transverse_fibres = np.full((n_cells, 3), fill_value=np.NaN)
+    pacing_site = np.full(n_points, fill_value=-1, dtype=int)
 
     fields = Fields(
         bipolar_voltage,
@@ -193,6 +205,7 @@ def empty_fields(n_points=0, n_cells=0):
         cell_region,
         longitudinal_fibres,
         transverse_fibres,
+        pacing_site,
     )
 
     return fields

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -242,6 +242,7 @@ def _extract_surface_data(
     surface_data['fibres'] = {}
     surface_data['longitudinal'] = fields.longitudinal_fibres if fields.longitudinal_fibres is not None else empty_float_array
     surface_data['transverse'] = fields.transverse_fibres if fields.transverse_fibres is not None else empty_float_array
+    surface_data['pacing_site'] = fields.pacing_site if fields.pacing_site is not None else empty_int_array
 
     # Remove arrays that are full of NaNs
     for field_name, field in surface_data.items():


### PR DESCRIPTION
Changes made:
* Add `case.fields.pacing_site` array. Equal to -1 if the point does not belong to a pacing site, otherwise equal to the index of the pacing site

Also specify the CodeCov action version as a workaround to the coverage report not being updated. As suggested here: https://github.com/codecov/codecov-action/issues/598#issuecomment-1030074427