### PR TITLE
Fix naming of electrodes when adding unipolar egms to an openarp case

### DIFF
--- a/examples/check-landmark-points.py
+++ b/examples/check-landmark-points.py
@@ -32,9 +32,9 @@ carp = openep.load_opencarp(
     indices="/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse.elem",
     scale_points=1e-3,
 )
-carp.add_landmark('a', 'b', point=np.array([0, 0, 0]))
 unipolar = np.loadtxt("/Users/paul/github/openep-misc/examples/data/pig21_endo_coarse_phie.dat")
 carp.add_unipolar_electrograms(unipolar=unipolar)
+carp.add_landmark('a', 'b', point=np.array([0, 0, 0]))
 
 openep.export_openep_mat(carp, 'test-add-landmark-carp.mat')
 carp_with_landmark = openep.load_openep_mat('test-add-landmark-carp.mat')

--- a/openep/data_structures/case.py
+++ b/openep/data_structures/case.py
@@ -365,7 +365,7 @@ class Case:
             egm=np.concatenate([unipolar_A[:, :, np.newaxis], unipolar_B[:, :, np.newaxis]], axis=2),
             points=np.concatenate([points_A[:, :, np.newaxis], points_B[:, :, np.newaxis]], axis=2),
             voltage=np.ptp(unipolar[pair_indices], axis=2)[:, 0],  # axis=2 because of the shape of unipolar[pairs_indices]
-            names=np.asarray(['_'.join(pair) for pair in names[pair_indices]]),
+            names=names[pair_indices],
             gain=np.zeros((len(unipolar), 2)),
         )
 


### PR DESCRIPTION
Changes made:
* `case.electric.unipolar_egm.names` is now of shape `(n_egms, 2)` - one name per electrode