### PR TITLE
Add support for vtk import/export

### DIFF
--- a/openep/__init__.py
+++ b/openep/__init__.py
@@ -18,8 +18,8 @@
 
 __all__ = ['case', 'mesh', 'draw']
 
-from .io.readers import load_openep_mat, load_opencarp, load_circle_cvi
-from .io.writers import export_openCARP, export_openep_mat
+from .io.readers import load_openep_mat, load_opencarp, load_circle_cvi, load_vtk
+from .io.writers import export_openCARP, export_openep_mat, export_vtk
 from .converters.pyvista_converters import from_pyvista, to_pyvista
 from . import case, mesh, draw
 from .case import interpolators

--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -83,6 +83,26 @@ class Fields:
 
         return fields
 
+    @classmethod
+    def from_pyvista(cls, mesh):
+        """Create a Fields object from a pyvista.PolyData mesh.
+
+        Args:
+            mesh (pyvista.PolyData): mesh from which Fields will be created.
+        """
+
+        fields = cls()
+        for point_data in mesh.point_data:
+            if point_data not in fields:
+                continue
+            fields[point_data] = np.asarray(mesh.point_data[point_data])
+        for cell_data in mesh.cell_data:
+            if cell_data not in fields:
+                continue
+            fields[cell_data] = np.asarray(mesh.cell_data[cell_data])
+
+        return fields
+
 
 def extract_surface_data(surface_data):
     """Extract surface data from a dictionary.

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -60,7 +60,11 @@ from openep.data_structures.case import Case
 from openep.data_structures.surface import Fields
 from openep.data_structures.electric import Electric
 
-__all__ = ["export_openCARP", "export_openep_mat"]
+__all__ = [
+    "export_openCARP",
+    "export_openep_mat",
+    "export_vtk",
+]
 
 
 def export_openCARP(
@@ -196,6 +200,31 @@ def export_openep_mat(
         do_compression=True,
         oned_as='column',
     )
+
+
+def export_vtk(
+    case: Case,
+    filename: str,
+):
+    """Export data in vtk format.
+
+    Saves all field data.
+
+    Args:
+        case (Case): dataset to be exported
+        filename (str): name of file to be written
+    """
+
+    mesh = case.create_mesh()
+    for field in case.fields:
+        if case.fields[field] is None:
+            continue
+        if len(case.fields[field]) == mesh.n_points:
+            mesh.point_data[field] = case.fields[field]
+        elif len(case.fields[field]) == mesh.n_cells:
+            mesh.cell_data[field] = case.fields[field]
+
+    mesh.save(filename)
 
 
 def _extract_surface_data(


### PR DESCRIPTION
Changes made:
* Added a function `openep.io.writers.export_vtk`. Takes a `Case` and a filename as input. Write the surface data to file in vtk format. Stores any fields that are not None
* Added a function `openep.io.readers.load_vtk`. Takes a filename and name as input. Loads the vtk file using pyvista. Extracts point and cell data from the mesh to populate the `Fields` of a case. Uses a newly-added class method `openep.data_structures.surface.Fields.from_pyvista` that extracts point and cell data from a `pyvista.PolyData`