### PR TITLE
Fix loading .mat file with missing unipolar electrode names

### DIFF
--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -782,7 +782,9 @@ def extract_electric_data(electric_data):
         electric_data['egmUni'] = electric_data['egmUni'].astype(float)
         electric_data['egmUniX'] = electric_data['egmUniX'].astype(float)
         electric_data['voltages']['unipolar'] = electric_data['voltages']['unipolar'].astype(float)
-        electric_data['electrodeNames_uni'] = electric_data['electrodeNames_uni'].astype(str)
+    if 'electrodeNames_uni' not in electric_data:
+            electric_data['electrodeNames_uni'] = np.full((len(electric_data['egmUni']), 2), fill_value="", dtype=str)
+    electric_data['electrodeNames_uni'] = electric_data['electrodeNames_uni'].astype(str)
 
     # Make ecgs correct shape
     ecg_dims = electric_data['ecg'].ndim


### PR DESCRIPTION
Changes made:
* When loading an openep dataset (.mat file), add unipolar electrode names if if unipolar egms exist but the names are missing