### PR TITLE
Fix reading .mat files when there is not unipolar egm data

### DIFF
--- a/openep/data_structures/electric.py
+++ b/openep/data_structures/electric.py
@@ -796,8 +796,9 @@ def extract_electric_data(electric_data):
         electric_data['voltages']['unipolar'] = electric_data['voltages']['unipolar'].astype(float)
     if 'electrodeNames_uni' not in electric_data:
             electric_data['electrodeNames_uni'] = np.full((len(electric_data['egmUni']), 2), fill_value="", dtype=str)
-    electric_data['electrodeNames_uni'][:, 0] = _decode_string_arrays(electric_data['electrodeNames_uni'][:, 0])
-    electric_data['electrodeNames_uni'][:, 1] = _decode_string_arrays(electric_data['electrodeNames_uni'][:, 1])
+    if electric_data['electrodeNames_uni'].ndim == 2:
+        electric_data['electrodeNames_uni'][:, 0] = _decode_string_arrays(electric_data['electrodeNames_uni'][:, 0])
+        electric_data['electrodeNames_uni'][:, 1] = _decode_string_arrays(electric_data['electrodeNames_uni'][:, 1])
     electric_data['electrodeNames_uni'] =  electric_data['electrodeNames_uni'].astype(str)
 
     # Make ecgs correct shape


### PR DESCRIPTION
Changes made:
* When loading an openep dataset (.mat file), use an empty (1 dimensional) array for unipolar egm electroade names if there are no egms present