### PR TITLE
Add tutorial notebooks

### DIFF
--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -7,8 +7,7 @@ dependencies:
   - ipywidgets=7.6.5
   - ipygany=0.5
   - jupyter_core=4.9.1
-  - matplotlib=3.5.1
-  
+  - matploblib=3.5.1  
   - pip:
-    - git+https://github.com/openep/openep-py@docs
+    - git+https://github.com/openep/openep-py@dev
 

--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -1,0 +1,14 @@
+name: openep-tutorials
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9.7
+  - pip=21.3.1
+  - ipywidgets=7.6.5
+  - ipygany=0.5
+  - jupyter_core=4.9.1
+  - matploblib=3.5.1
+  
+  - pip:
+    - git+https://github.com/openep/openep-py@dev
+

--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -10,4 +10,3 @@ dependencies:
   - matplotlib=3.5.1
   - pip:
     - git+https://github.com/openep/openep-py@dev
-

--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - ipywidgets=7.6.5
   - ipygany=0.5
   - jupyter_core=4.9.1
-  - matploblib=3.5.1
+  - matplotlib=3.5.1
   
   - pip:
-    - git+https://github.com/openep/openep-py@dev
+    - git+https://github.com/openep/openep-py@docs
 

--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - ipywidgets=7.6.5
   - ipygany=0.5
   - jupyter_core=4.9.1
-  - matploblib=3.5.1  
+  - matplotlib=3.5.1
   - pip:
     - git+https://github.com/openep/openep-py@dev
 

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyvista\n",
+    "import openep\n",
+    "from openep._datasets.openep_datasets import DATASET_2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pyvista.set_jupyter_backend('ipygany')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case = openep.load_openep_mat(DATASET_2)\n",
+    "mesh = case.create_mesh()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6744fdd25dde41c89a29d35577d8e60a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Scene(background_color='#4c4c4c', camera={'position': [71.80763645292058, -4.5938635470794225, 216.89163645292…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mesh.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/Caskroom/miniconda/base/envs/openep/lib/python3.9/site-packages/traittypes/traittypes.py:97: UserWarning: Given trait value dtype \"float64\" does not match required type \"float64\". A coerced copy has been created.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0669abce1e3f498980abac59637cc77b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(VBox(children=(HTML(value='<h3></h3>'), Dropdown(description='Colormap:', options={'BrBG':…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plotter = openep.draw.draw_map(mesh, field=case.fields.bipolar_voltage, add_mesh_kws={'cmap': 'Plasma'})\n",
+    "plotter.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.7 ('openep')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "1498aee3a2eb102c855ec1dded6b9c2b4c71150cc8d698a3bd601de65c8dfbf1"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pyvista\n",
     "import openep\n",
     "from openep._datasets.openep_datasets import DATASET_2"
    ]
@@ -17,16 +16,296 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set the backend used for plotting\n",
+    "import pyvista\n",
     "pyvista.set_jupyter_backend('ipygany')"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load a case\n",
+    "We will load a .mat file that was created using OpenEP MATLAB and then take a look at the data stored in the case"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/usr/local/Caskroom/miniconda/base/envs/openep-tutorials/lib/python3.9/site-packages/openep/_datasets/OpenEP-MATLAB/openep_dataset_2.mat'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "DATASET_2  # DATASET_2 is simply a path to a .mat file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "case = openep.load_openep_mat(DATASET_2)\n",
+    "case = openep.load_openep_mat(DATASET_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Look at the surface data\n",
+    "The nodes and triangle data are stored in `case.points` and `case.indices` respectively"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 46.451, -98.879, 155.286],\n",
+       "       [ 38.777, -94.997, 121.448],\n",
+       "       [ 37.268, -69.189, 141.284],\n",
+       "       ...,\n",
+       "       [-62.585, -77.163, 133.982],\n",
+       "       [-63.766, -76.47 , 119.425],\n",
+       "       [-64.5  , -75.396, 119.241]])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "case.points  # the x, y, z coordinate of each node in the surface mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 5343,  7474,  7523],\n",
+       "       [ 7976,  4159,  4138],\n",
+       "       [ 7953,  5780, 12295],\n",
+       "       ...,\n",
+       "       [10283, 10270, 14360],\n",
+       "       [10283, 14360, 14361],\n",
+       "       [14380,  6871, 14364]])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "case.indices  # the indices of nodes in each triagle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Scalar data associated with the mesh are stored in `case.fields`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "fields: ('bipolar_voltage', 'unipolar_voltage', 'local_activation_time', 'impedance', 'force', 'thickness', 'cell_region', 'longitudinal_fibres', 'transverse_fibres', 'pacing_site')"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "case.fields"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([    nan, 1.07604, 1.71656, ..., 0.32316, 0.16372, 0.19536])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "case.fields.bipolar_voltage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualising the surface mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = case.create_mesh()  # creates a pyvista.PolyData mesh from case.points and case.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openep.draw.draw_map(\n",
+    "    mesh=mesh,\n",
+    "    \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Electrical data\n",
+    "The bipolar electrograms, unipolar electrograms, reference electrograms, and ecgs are all stored in `case.electric`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Electric data for 800 mapping points."
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "case.electric  # we see there are 800 mapping points in this case"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Electrograms with 800 mapping points."
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "case.electric.bipolar_egm  # this is an Electrogram object, containing information about bipolar egms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['__class__',\n",
+       " '__delattr__',\n",
+       " '__dict__',\n",
+       " '__dir__',\n",
+       " '__doc__',\n",
+       " '__eq__',\n",
+       " '__format__',\n",
+       " '__ge__',\n",
+       " '__getattribute__',\n",
+       " '__gt__',\n",
+       " '__hash__',\n",
+       " '__init__',\n",
+       " '__init_subclass__',\n",
+       " '__le__',\n",
+       " '__lt__',\n",
+       " '__module__',\n",
+       " '__ne__',\n",
+       " '__new__',\n",
+       " '__reduce__',\n",
+       " '__reduce_ex__',\n",
+       " '__repr__',\n",
+       " '__setattr__',\n",
+       " '__sizeof__',\n",
+       " '__str__',\n",
+       " '__subclasshook__',\n",
+       " '__weakref__',\n",
+       " '_egm',\n",
+       " '_gain',\n",
+       " '_is_electrical',\n",
+       " '_names',\n",
+       " '_points',\n",
+       " '_voltage',\n",
+       " 'copy',\n",
+       " 'egm',\n",
+       " 'gain',\n",
+       " 'n_points',\n",
+       " 'n_samples',\n",
+       " 'names',\n",
+       " 'points',\n",
+       " 'voltage']"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dir(case.electric.bipolar_egm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "mesh = case.create_mesh()"
    ]
   },
@@ -38,7 +317,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6744fdd25dde41c89a29d35577d8e60a",
+       "model_id": "793a1063721448e687109dd17073b8fa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -63,14 +342,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/Caskroom/miniconda/base/envs/openep/lib/python3.9/site-packages/traittypes/traittypes.py:97: UserWarning: Given trait value dtype \"float64\" does not match required type \"float64\". A coerced copy has been created.\n",
+      "/usr/local/Caskroom/miniconda/base/envs/openep-tutorials/lib/python3.9/site-packages/traittypes/traittypes.py:97: UserWarning: Given trait value dtype \"float64\" does not match required type \"float64\". A coerced copy has been created.\n",
       "  warnings.warn(\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0669abce1e3f498980abac59637cc77b",
+       "model_id": "98b1a90f7977464c911da87f6c059a66",
        "version_major": 2,
        "version_minor": 0
       },
@@ -97,7 +376,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('openep')",
+   "display_name": "Python 3.9.13 ('openep-tutorials')",
    "language": "python",
    "name": "python3"
   },
@@ -115,7 +394,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "1498aee3a2eb102c855ec1dded6b9c2b4c71150cc8d698a3bd601de65c8dfbf1"
+    "hash": "0a4359d27a983cff32fcf095f4547555a5a1033eff1494389832674483dda890"
    }
   }
  },

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -2,10 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pathlib\n",
+    "\n",
+    "import numpy as np\n",
+    "import scipy.stats\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
     "import openep\n",
     "from openep._datasets.openep_datasets import DATASET_2"
    ]
@@ -31,11 +37,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "case = openep.load_openep_mat(DATASET_2)"
+    "case = openep.load_openep_mat(DATASET_2)\n"
    ]
   },
   {
@@ -47,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {
     "scrolled": true
    },
@@ -56,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/data/KCL/Paul/miniconda3/envs/openep-tutorials/lib/python3.9/site-packages/openep/_datasets/OpenEP-MATLAB/openep_dataset_2.mat\n"
+      "c:\\Anaconda3\\envs\\openep-tutorials\\lib\\site-packages\\openep\\_datasets\\OpenEP-MATLAB\\openep_dataset_2.mat\n"
      ]
     }
    ],
@@ -73,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -97,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +118,7 @@
        "       [-64.5  , -75.396, 119.241]])"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -123,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -138,13 +144,13 @@
        "       [14380,  6871, 14364]])"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "case.indices  # the indices of nodes in each triagle"
+    "case.indices  # the indices of nodes in each triangle"
    ]
   },
   {
@@ -156,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -165,7 +171,7 @@
        "fields: ('bipolar_voltage', 'unipolar_voltage', 'local_activation_time', 'impedance', 'force', 'thickness', 'cell_region', 'longitudinal_fibres', 'transverse_fibres', 'pacing_site')"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +191,7 @@
        "array([    nan, 1.07604, 1.71656, ..., 0.32316, 0.16372, 0.19536])"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -203,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,13 +218,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tr><th>Header</th><th>Data Arrays</th></tr><tr><td>\n",
+       "\n",
        "<table>\n",
        "<tr><th>PolyData</th><th>Information</th></tr>\n",
        "<tr><td>N Cells</td><td>16942</td></tr>\n",
@@ -226,29 +232,21 @@
        "<tr><td>X Bounds</td><td>-7.584e+01, 6.374e+01</td></tr>\n",
        "<tr><td>Y Bounds</td><td>-1.300e+02, -3.585e+01</td></tr>\n",
        "<tr><td>Z Bounds</td><td>7.937e+01, 1.712e+02</td></tr>\n",
-       "<tr><td>N Arrays</td><td>2</td></tr>\n",
+       "<tr><td>N Arrays</td><td>0</td></tr>\n",
        "</table>\n",
-       "\n",
-       "</td><td>\n",
-       "<table>\n",
-       "<tr><th>Name</th><th>Field</th><th>Type</th><th>N Comp</th><th>Min</th><th>Max</th></tr>\n",
-       "<tr><td><b>Data</b></td><td>Points</td><td>float64</td><td>1</td><td>3.600e-02</td><td>4.614e+00</td></tr>\n",
-       "<tr><td>Normals</td><td>Points</td><td>float32</td><td>3</td><td>-1.000e+00</td><td>1.000e+00</td></tr>\n",
-       "</table>\n",
-       "\n",
-       "</td></tr> </table>"
+       "\n"
       ],
       "text/plain": [
-       "PolyData (0x7ff36d10de80)\n",
+       "PolyData (0x299a04e1220)\n",
        "  N Cells:\t16942\n",
        "  N Points:\t14383\n",
        "  X Bounds:\t-7.584e+01, 6.374e+01\n",
        "  Y Bounds:\t-1.300e+02, -3.585e+01\n",
        "  Z Bounds:\t7.937e+01, 1.712e+02\n",
-       "  N Arrays:\t2"
+       "  N Arrays:\t0"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -259,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,13 +270,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Anaconda3\\envs\\openep-tutorials\\lib\\site-packages\\traittypes\\traittypes.py:97: UserWarning: Given trait value dtype \"float64\" does not match required type \"float64\". A coerced copy has been created.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a0de72c38b594e28bd05fcb088049b72",
+       "model_id": "4c7dcfdccaf044fcbfcb0d3ee0ffcd0b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -295,30 +301,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1498a7df83724fb5871bf3b733c83415",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "AppLayout(children=(VBox(children=(HTML(value='<h3>Data</h3>'), Dropdown(description='Colormap:', options={'Br…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "mesh.plot()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -328,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -337,7 +319,7 @@
        "Electric data for 800 mapping points."
       ]
      },
-     "execution_count": 9,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -357,7 +339,7 @@
        "Electrograms with 800 mapping points."
       ]
      },
-     "execution_count": 10,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,71 +350,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['__class__',\n",
-       " '__delattr__',\n",
-       " '__dict__',\n",
-       " '__dir__',\n",
-       " '__doc__',\n",
-       " '__eq__',\n",
-       " '__format__',\n",
-       " '__ge__',\n",
-       " '__getattribute__',\n",
-       " '__gt__',\n",
-       " '__hash__',\n",
-       " '__init__',\n",
-       " '__init_subclass__',\n",
-       " '__le__',\n",
-       " '__lt__',\n",
-       " '__module__',\n",
-       " '__ne__',\n",
-       " '__new__',\n",
-       " '__reduce__',\n",
-       " '__reduce_ex__',\n",
-       " '__repr__',\n",
-       " '__setattr__',\n",
-       " '__sizeof__',\n",
-       " '__str__',\n",
-       " '__subclasshook__',\n",
-       " '__weakref__',\n",
-       " '_egm',\n",
-       " '_gain',\n",
-       " '_is_electrical',\n",
-       " '_names',\n",
-       " '_points',\n",
-       " '_voltage',\n",
-       " 'copy',\n",
-       " 'egm',\n",
-       " 'gain',\n",
-       " 'n_points',\n",
-       " 'n_samples',\n",
-       " 'names',\n",
-       " 'points',\n",
-       " 'voltage']"
+       "array([[ 0.018,  0.012, -0.006, ..., -0.015, -0.018, -0.27 ],\n",
+       "       [ 0.042,  0.036,  0.03 , ...,  0.006,  0.003, -0.165],\n",
+       "       [ 0.024,  0.018,  0.   , ...,  0.003,  0.015, -0.243],\n",
+       "       ...,\n",
+       "       [ 0.036,  0.033,  0.036, ...,  0.003,  0.   , -0.174],\n",
+       "       [ 0.003,  0.033,  0.039, ...,  0.   , -0.003, -0.12 ],\n",
+       "       [ 0.021,  0.009,  0.   , ..., -0.003,  0.018, -0.162]])"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "dir(case.electric.bipolar_egm)"
+    "case.electric.bipolar_egm.egm  # the signals, shape (n_points, n_samples)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAACDCAYAAADBExzWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAABUJ0lEQVR4nO3deXxU9b34/9c5Z/bMZN8hCQHCvrqAiCJqRanr1Vpbl2qvW1ul5apXe2+/98q993dxaatdtNr2qnWt2rrWBcUFFAHZIewBQhKy7zOT2c/5/P6YZJIhEyAQEpDP8/HgATlzMnw+53zmzPt8Pp/zeStCCIEkSZIkSZI0JNShLoAkSZIkSdKpTAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSdJx8bftbWyu9w91MSTphKfIROGSJEnSQFtR2cH5L+0FIPzvU4a4NJJ0YpM9Y5I0iF4sbaXod9tZX+sb6qJI0nG1uUH2iEnSkZLBmCQNon/+RxU13gg/fLdqqIvyjSSE4NlNLXxS7hnqokg9GHIARpIOyTTUBZCkU5EvYgx1Eb5RXtvWxoulrdw0OY07PziARVNoumcidrO83xwqSo9/e4IGKTZtyMoiSSc6GYxJ0hAwZEfBgLrxnUoAPtoX7REL6YIVVR1cNNI1lMU6pQX17kbeFtRlMHacCSHwhAySrfI4n4zkbaMkDQE5anP8bW8KDHURTmltAT3hv6Xj42cf15Dx622sk/NRT0oyGJOkIRCRXWPHXVlLaKiLcEp7c2d77N/tMhg77p5a3wzA/3xZP8QlkY6GDMYkaQjIOWMDxx9OfCzLWoKDXBKpp53N3ce/LSiDscGytSHA3UuqafVHhrooUj/IYEw6LiKGkE9QHUJHSAZjA6XBl/hLZ0Odn1e3tQ5yaaRE5DDl8dVzudBKd5g/bmjmzg8ODGGJpP6SwZg04Fr8EcY9tZNZz+1Bl8NxMT0DMF0elgFT1R5OuL0toHPTO1XypuAE0BaQNx/HU0eC3uG3drmHoCTS0ZLBmDTglu7zUtEeZkOdn9JGOYm6y11L5J3q8VDh7j03rOeyCl7ZCznoDk7s0i6HKY+rZn/i4ysT7Jw8ZDAmDbhdzd0BWFW7nETd5eWtbUNdhJPW/rYQIT1xUFXe2ruNjcu0xv7dKofIBt3BHeJymPL48gQTfzb299FrLJ14+hWMPfTQQ5x55pm4XC6ys7O56qqr2LVrV9w+QggWLVpEfn4+druduXPnsm3btoTvt3jxYjRN4+GHH+5XoWtra7n++usZO3YsqqqycOHCXvvMnTsXRVF6/bn00ksP+d5vvvkmF198MZmZmSiKwqZNm3rtU1dXx0033URubi5JSUmcdtpp/P3vf+9XHb7JNvZIDPzVgcF9zPr17W2c98IeqhL0lgyEZl+Et3a29/tpSHmHevS+quqg5A87ueSV8oSvb0yQiHpMencwJntljo47qNPcx3y8w9EPau8NHcd/MnkwYuANnZrn2tNHvd/d3Z5wu3Ti6Vcwtnz5cu666y5Wr17N0qVLiUQizJs3j46Ojtg+jz76KI899hhPPPEEa9euJTc3l4suugiPp3d6kueee47777+fZ599tl+FDgaDZGVl8Ytf/IKpU6cm3OfNN9+ktrY29mfr1q1omsa11157yPfu6Ohg9uzZhwwQb7rpJnbt2sW7775LaWkpV199Nddddx0bN27sVz0Gwom4RMKOpu6nqL6qiraNWm+Yz3qkqPnF57WYF2/h/bLueQ3VnjA//EcVzkdKMS/ewtl/KSPQz6cOb3i7kpUHfPzrJ7XHWIvEvvtmBd99s4KHv2ro1+81+XpfLOVcpiPz/JYWAL6s6uj1WkfI4MvK+O02k0JxqiX280AOUwYjBtsaA7ScAk+qzf7LHgp+t6PPgGzVgQ5WHehI2I4P/tjubD626QpCCP6yuYUHl9clvOaFdcHw3+0g7VfbsD20hW2d0yMaOyKsru7dbo6lHG0Bnb9ua2XZfu9h9//Nmkbm/3Ufv17dQLDzoBzqxuzVba1c8OJeShPk9XxrZzvX/n0/td7evV19tfG3dh59MLa2xseHe+LnnX1a7uHLSi/727pvdoUQvLWzHfvDW1iwpDq2PRgxaPZFCOkG7qDeZ73bAzpPr2/mopf3cu3f9x/xNV83BIuW1/FC5/XhZKeIY7hlb2xsJDs7m+XLlzNnzhyEEOTn57Nw4UIeeOABIBo45eTk8Mgjj3DnnXfGfnf58uXccMMNlJeXM2LECP76178yZ86cfpdh7ty5TJs2jd/85jeH3O83v/kN//mf/0ltbS1JSUmHfd/9+/dTXFzMxo0bmTZtWtxrTqeTp556iptuuim2LSMjg0cffZRbb72133U4Ws2+CNP+vJvvTkhl/mgXhoiuPO6yqNR6w7QFDKo9YarcIXxhg7KW6N9Tc2xkJ5nJtGu4rCrPbmohJ8lMfUeYM/IdnJHnwKRCjSdCilUl12kmxarismj4Igab6/28V+ahxR/BEDDMZea0PDuZdhPtQZ1frW6MK+d9Z2XFts0tSuLv14wg87Fob+kwl5n9C8bzj93tXP33il51nJJt4+EL8rCbVOo7wqyp8bG+1k9a52reG+r8JJlVpuTYyHWa+e2aptjv+h6YTI03jE1TyEoysaHOz+oDPv6+o43ythBOi8p1E1I5a3gSmQ6N3c1BLJqKzaTgNKtUuMN8tt+LN6iTbNOwm1T+uKE59v6/v3gYigJ2k4LDrNLQEaEjbKAqoBvgDulUtIUJRAwq3dE5dD39bEYmz21uoSTdynmFSZw/wklxqoUvKjv4VrGLWm+Y0oYADrOKP2xgUhUOuEPYTCqaGh2aeHlrK6k2jUBEYDerdIR0zKpCrtPMuYVJnJZrp8mvs6Kqg2FOE2l2E7oQfFXZQb0vwvlFTiZk2jBrCq2BCC1+HZOqcKQihiCsC7KSTGQ5TFg0hRpPmNaAji9sEIgI/BGDNTU+hIDxmTam5tgYlWbFG9LZ2xqizhsh1aaRZFaxmhQ0RUFTwaQqBCOCez+pif1//3NeLhcWO1my18Pu5iCf7vfQeFCgm2bT+MvlBVz5t/0APHf5cG6cnB57vaEjwivbWnmptJVaT4TpuXbMGtx5WgY1nghra3w4zCpmTSHNphHWBXvbQizd56G+s4fHYVa4eUo6cwqTcFk09rYGURWFPa1Brh2fyrQcG56QQWlDgGpPGEMIdBE9XhFDoBvRz2qzP0JQF1g0BVUBq6aSnWRiYqaNVJtGUDf4orKD8rYQFk2hoi1EyBC0B3SGJ5sJRAS6EBSlWBjuMqN1njt3MHr8S9KtuCwaI1It5DpN7GoOsrbGx7paH2XNIcyawph0KxOzrNjNKmFdENIFvojB419HP0v3npXFHdPTaQno7GwKoijw9PpmVld393pfPNLFvrYg5xQk8dt5w3hlWys/+qD7i9lmUmj4l+70VPvbQpQ2+KnxRmLXmv2dUxrynWYafBF8YYOx6VZCuuDNne3s6lyqZGy6lV+cm82141NRFZj5bBmb6uODvbOGOfjsxlE4HikFop/Rl68qZNbwJE7/v93UeCNMy7ExuyCJB87Oxhsy+NXqRr6s9BKMCPJcZhbNyeHB5fWsqYnWc0Kmle1N8culXDraxcY6P4UpFi4Y4aQoxcLcoiTcIYPfrmnipdLeT/PaTQo/nJrO7IIkluz1oCjR4/ePMjevbmuL7bfqh6NZUdWBpiicU5DEjGfLALBqCovPz6PBF2Zsho3zi5KY+ufduBMMVSrA2ltLmJpjp84bZn97CENAZXuo8xqo0dgRIaAbOEwqVZ4wFW0hFAWWVUSD2MnZNuaNdLGiqoOve5zza8en8OzlBdz3SW3cdXHnj8cS0gXnvbA3borA+Awr105I5fpJqYxKi/Zc72gKcMYzZYQOeqKpINlMcaqFjrDBeYVJnJnvwKQq/KPMTW6SiXS7xiflXj4pjwbEt01L58E5OezvrFdYF+xqDhLSBQIYmWoh2aqhKLC7Ocj/bWwhzaZxxdhkfGGDZIvGg3NyYp+foXBMwdiePXsoKSmhtLSUSZMmsW/fPkaNGsWGDRuYPn16bL8rr7yS1NRUnn/++di2H/zgB+Tk5PDLX/6S++67j8bGxrjXj9SRBmOTJ09m1qxZ/OlPfzqi9z1UMHbJJZdgMpl44YUXSE1N5fXXX+e2225j8+bNjBo1qtd7GYaBYXR/UBRFQdM0dD3+bkFVVVRVJRKJvxPta/vTG1v5l6W1aCL+y0jv7PDUMI5su6KBEAm3K8JARRx2u0DBUFRUYaD02G6gIBQ1roz/Pjub/++rRoSiYhI6628r4fLX9lPtCaOjUpRq4UBb/MX1RK/TobbrqKAoJ915OlnqZNFUTstPYlWVFwVBvtPEG9eOYOZzexGKSqpZ8If5w/i6xsfr29qp8+knfJ2+Secp32mixhthfkkyNpOJPS1+SnsMLR+vOhWmmKlsD8dtH5VmYW/nHMNv+nm6oiSZdztHHgazTv8+O5vFXzUcsk52k0IocoR1HaTztPSGkcwaHu2o6es7V9M0FEVJuB1A1/WE2xXl8EHeUeemFEJwzz33cM455zBp0iQgOpcKICcnJ27fnJwcKiq6ez3cbjdvvPEGK1euBODGG29k9uzZ/P73vyc5Ofloi9SnNWvWsHXrVp555pkBeb/XXnuN6667joyMDEwmEw6Hg7feeithIAZQVlbG7t27Yz8XFhYydepUtm7dSmVlZWz7mDFjGDt2LOvWraOxsbt3aerUqRQWFrJixYq44d7vzJhB5pUFLPvkY1p9QQIRgQLsTZmMbrIyo2Mj2UkmVEXBooJjwrnsa/QwvHkzjb4IAjCbTFRkz8DT2sj0yF72t4XITTLjwUpZ6hT8TTXM1A7gDup4QgatajIF409jjKjF0laF06zijwhqtAz+Up/FyGAlBaKZcRlWar1h1oWyKVPyOM0oJ4to2dd/CcOVAqqUTM42drP4L1uZFDKYBDx800WMH5HPhx9+iNsfYuUBH/vbQ6y1jKcwM5lZvo24rCpdc7mHnXYebq+f+m2rsWgKmXYTpc1h/hqaSCYeZhh7Y8fLp9hoyp7OOFMLZ6gHqPGEafLplAUdlFpLuDi5nXTfAUK6IBARhJzZjJs0hbS2vQSbawkbgk31fsqUXMqUPL6TUoMt2EYwYiAAb/pozGl5DG/ejCniR1HAZdFoSBvH07sEFxrbMNH9Yf1CHcel4zKZ6tlIrTdMky9Ce9DgI3UKdkLMFTtJtmhEDIFmMrHMMhWTv5UrHJVEDEGVO4wXGzPPmcNYrYWm8h20BXQiBuj2VPY6x1K2ezeT1HqKUy2EDYHblkWdcyQjAvvJDDVR6w3TETZocQxDZI6g2LMTU6AtVkZv2mgCzhzSajeiRbrvitszJxC2p5JWtRoMnaBu0B4wKE+dTE6qk5KWdZhUhYghUBUYd9YFWEWIPRtW0uzX8YYMFFWjYdhM6hsamKOWYxjRu1jdZKchZzomTy1GbVnssf1GXKzVRjNRbWC2o4k8pxmnWeWM8cWsMVJwV+6kQDSTHFDZtGIPo4WDMiWPksBeXnprEwDTgVKlgHpTFvPVvYx0RD8Hu1uCrFFH0aIk8z3rTjKsxMofGH4aDoed1KqvyU0ykWbXqHaH+dI6jX2NHsZ7t5Jmj15KazoM3hGTY20vyazitKhgcVCfPY1kfwPp7ftQlc4nPpPSsBVPxV9bjq09ugxHR9hgZySN5cFhTOEAM51uUm0a/rBBcn4xeSNKCO7fjKe1GU2Fak+E1pSRGMm5ZNZvQov40I3ovK0q1zh2BBxMaV9PuPMLJNNhInXcDPJTnVj2rcQTMmgL6BiAt+gsrEaIA6WrY8OBiqqx3DKNPNycrZRjUsFhUglodsyjzqSl7gBjwxU0+XXK20Kx8zRa1FMi6jg/zcnnbi8VuzMoVQuZbFRysWhGU6KBNBmFOPNHktKwjYC7BbtZxWVR0fLGUKmkkV67ESXsJ8thIifJxJeimGfK6PV5unDuXK6bmsODz7xBrTcCrTAeaBo2k+217cwxdkIzjAZyXVamnfst/nvJztg1Is9poigrlc+V8ewp389kURV77551Ot/ZzOyCJDwhg22hFFZGhjM2VIG3qbsHt+sacWNGLfNzI4QNwbpaP43OYiyZ+VRsXIldBGJtbI06iiaSE14j/Fi42NhCklnltFw7+9tDvKlPYkSSQVbDlti+ETQ+1qaQiYdZYi9Xm1LRaafNsPKFNp7hooWZWjUCsGgKblMy+51jmWZqoCBcQ9gAb0gnmJRD9qgJJDXvQXXXUd8RYV9biDIll3OnT2RiYDf7q+vZ3x5CF7DXUsRN507g408/x0mA9V/CxcAadRSv3ziNbSs/JdUC+1pDbGsK8EFkDP5ItE4AmXYTs4Y7uPmay1i9v5U3l3xKeVuIiVk2zCYTpamn425uJKlhO4LoaAoWB8vUcZg99ZSEKgh3ttWu83Rpehs5gWocJhVVVWizZrGBAor85YxUWgjpAqtJRaQX8rtyJ6cZ5Wz5qpy2ZPMhv3NnzpxJdnZ2bJpWl7lz52K32/nwww/paf78+fj9flyuw+fIPeqesbvuuov333+fFStWMHz4cABWrlzJ7NmzqampIS8vL7bv7bffTlVVFUuWLAHg6aef5sknn6S0tDS2z+TJk1mwYAF33HFHv8pxJD1jd955JytXroz7/15++eW4YdMPP/yQc889N/bzoXrGFixYwJo1a1i8eDGZmZm8/fbbPP7443z55ZdMnjy51/9/vHrGDo7ShRCx94a+o/SDt5tMJoQQCbcfXPa+tieqk24IHvyygS+qfPxpfh5/2tDMnzZEx/cT3WUtODODRy8q6HXnoRsCi9nUrzpVdxg0doQpcmlsbQigqQpn5juwW829yr6tMUBxuh2nWTlsnZyPlGKg8Ot5w/nx9NS4//NQ5+l/vqznze0tlLeFYgmUhaKy7+7x5Di6p24GIwYOq5mOkIFZMeK6zY/mPB3cxo5X2+u5HQ59np5Y28jPP6vj1asLuWp8xmHr5Hyk+3P79W3jGJFsIsncfVwUReHJ9a3869IDKAgmZtl48pJhzHlxH0JRybEDIvpU5ag0KzdPzWDhWdkII/p/hnXBVa/vR9VU3v/+SIwjbGOH2t7si2BSDJyW7qTN/f08KapKIBTBonXX9VjOU0V7iGEuMyb18NeIDTVeZv9lDwDeByb32fZu/aCGv5a28NuL8rj9tAwWr6iP9or06J3wPjCZj/e5eaG0naABp+dYuXVqOllJpqOu07paP3d/UEFJmoV/npbBzGEOHNboF+m9H1fxh3XRYbOzhjn45KYS/m9TCwuXRIOrf56Wxu8uHo7JZGJPS4APd7cxLdfOWcMcKIqCyWSi0RvixS3NTM2xc16RE0MILObe146en6eIbrC1McDjqxuYNzqVG6ek92pLXXXa3uDFHTA4I99BY0eEuz6q5Z+nZ/Cd16OB4fYfjaUg2Rz9DBuCqvYAw13mWA9L13l6fFUd//55Xez9u3qR8pNU9t49nhWVXpZVdDCzwMWYdAtFyfH9L0d6Le+5vet8lLcG2dUS5JxCF6l2M7b/7Z4znWHXeOd7ozgjP6nX+dvcGOQ/Pq/js3I335+Ywp8uLTjk91ZX26v3BHFZVKwmNWHZ9c4pAEk2S7++c+e/up/l5e08c/lwrpuQFneeBrNn7KiCsQULFvD222/zxRdfUFxcHNt+pMOUM2bMYN26dahq95eQYRiceeaZfP311/0qy+GCMZ/PR15eHv/93//Nz372s9h2j8dDfX13Dq9hw4Zht9tjP/cVjO3du5fRo0ezdetWJk6cGNv+rW99i9GjR/P000/3q/ynkrAuYnM4AL4/MZVPyrvn/Gy9cwxjM2xDVbwjYl4cvZt76cpCrpuY2u/fH/abbTR01vfVfyrkmvH9f4+TXdcxtJsU3Pf3vnnpa3+A8L9PSbjPk+uaWPhxtGfizHw7j12Uz7nPR7/YHr4gl3vPyj7WYp9yvqz0kp1kOuRnsuvcZNo1av9lIutqfcx6bk/cPn2ds+Ol2hPmf1fU809jU7hoZLRH4u1d7Vz7RnR0puXeibis2qHeYsgs3efBFza4cmzKEe2vG4IXS1u5/f34NQxL0i1s/9G441HEPp37/B5WV/tQleh83aGcf9Uf3/n7ft7Z7eaJS4Zx52kZQ1aOfg1TCiFYsGABb731FsuWLYsLxACKi4vJzc1l6dKlsWAsFAqxfPlyHnnkEQBKS0tZt24dy5YtIz29e1JtW1sbc+bMYevWrbFhz4Hw+uuvEwwGufHGG+O2u1yuI+o6PJjPFx2q6RlIQjQCPviOV4pn1hRK0i2xBM4RQ/DU/OH895f13Dcr64QPxABeuaqQFVUdfGf8kV0sD9bzzifRqtmnEn9k4J4m7fnQgd2kxj3NJ1NPHZ1zC52HfD3cY9J1V67VyVk2Uqwq7X2sezUYhrnM/GH+8Lht5xc5yXaYmDHMfsIGYkAseDxSmqpwy9T0XsGYyzL4dXz16iI+3ufhxklpJ00gBuC0RB/aGuqVCfoVjN1111288sorvPPOO7hcrtgcsZSUFOx2O4qisHDhQhYvXkxJSQklJSUsXrwYh8PB9ddfD8AzzzzDjBkzEj45OWvWLJ555hkef/zxw5ala/0vr9dLY2MjmzZtwmKxMGHChLj9nnnmGa666ioyMo4s4m1paaGyspKamuhddtc6arm5ueTm5jJu3DhGjx7NnXfeya9+9SsyMjJ4++23Wbp0Ke+9994R/R+nsv8+L5fvvxWdJ3ffrCxOy3Uc8V3gieDaCalcOyH1qH+/Zz90X6tmS/E+vn4kt7xbyZMHfcH21GMkD7tJxehxYW0bwsDgm6zn+m2+cPQJzxSbxqc3juKMZ8qGsGS9pdg0yheMw3wSBQn98fH1I7n01fLY3KnytsFfbHuYy8wPp6YffscTzLOXF/CXKwqHuhj9W2fsqaeeor29nblz55KXlxf789prr8X2uf/++1m4cCE/+clPOOOMM6iurubjjz/G5XIRCoV46aWXuOaaaxK+/zXXXMNLL71EKHT4hjR9+nSmT5/O+vXreeWVV5g+fTrf/va34/bZvXs3K1as6NdyE++++y7Tp0+PLQ77ve99j+nTp8eGH81mMx988AFZWVlcfvnlTJkyhRdeeIHnn3++1/8v9XbNuBRW3jKa8rvHcVquY6iLM+h63ns1HuWCmqea80c4qfjpBC4r6fvhnvieMYUNPZ7Wk1kgjg/3QYvpbu1c22tqjp0sx4nX+2TR1COau3MyOn+Ek39cNyL2s8w6ceTUE6RN9HuY8nAURWHRokUsWrSo12sWi4Wmpqbev9Tpnnvu4Z577hmwsowZM6bfK5/fcsst3HLLLYfcp6SkhDfeeKNf7ytFKUp0Iv2pqmdPeNMpGozZTAqBARyiBOKGRWxmNW7R3/0yGBtwn5Z7eq0NtbHOz+yC6NIA39QeqBNZzwc9zik4/Fqa0onlqJe2kCSp/3p+fSValf9UkO0wUeke2Jx5ph59/GZVYXSahT2d60kN9P91qqj1hvGFjdgCnV2+qurgkr/2Tk3Vc1FjsyaDscHW85jffcbQTUSXjs4JmSh84sSJOJ3OhH9efvnloS6eJPWbJ6jz8FcNcQmTK49T/swTXdeSBhBd12htjY9//aTmmPIKaj2GGlQF5o/uHtJs8eu9htSkwyv83Q7GPbWrVzqkN/tIsbOh1ocQggeX1xEc4J7PgXTAHTphU5Htbwvxy1UNtB/FMGPPnrGuDCXSyeOE7Bn74IMPCIcT380evKCsJJ0MHlnVwCMr49NElbUEMYQ4YeYsDBZbjy+Nak+Y+X/dR3vQoNYb5qWrio7qPXvOGVMV8B/0pGpFe4jJ2faDf21ACCFi6ai+ibY3BeKerNzdEp8SaEy6hd0tIXY0B/lgj4fF/czbOpie39LCbe8d4OqxKVw5NpnvTkg9ZPovIaKLKxckmwdlvtm8V/ZR3hZiS0OAF6889KRyQwjeK3MzNcdOUYoFS48n/FNkMHbSGZKrx0MPPcSZZ56Jy+UiOzubq666KvbUIkBRURGjRo3ipZdeYs6cOUyePJnbbruNYDCYcDmKxYsXo2naIZN7J1JbW8v111/P2LFjUVWVhQsXDkj5JaknQwh+v7b3XElfWFDtGdghNCEErSd4EuuecdLe1lBsGYTXtved1NgfNg45/7PnMKWmKPgPSja846CcggPpln9UUfC77WxJkNz5ZNWz56hnEmpPMJrntKeSdCvFqRYMQSyP44nqd525a9/c1c7N71bxLx/XHHL/36xpYtSTO3lqffMh9xsoXU9Bvrv78Am+//uLeq75ewWjn9zJnpYgw1zdfSs20zfzxuCbbEjO2PLly7nrrrtYvXp1LK3AvHnz6Ojo/pA/+uijPPbYYzzxxBOsXbuW3NxcLrroorjUBF2ee+457r//fp599tl+lSMYDJKVlcUvfvELpk6dOqDlHwy6IXhsdSNbGwL9flABGLB1VdxBnbuXVPPhHnef++iGYGOdnz+sa2JHU6DP/YQQfFYeTULe9bMQgiZfhD0tQTbX++OG+gDaAjr7WoOxY9AW0I/b2lJbGvzMeq6Mpft6t8O+fLzPgy8cf6ytnb1D2xr7Phb9sbHOz2vb2rj01XKyH9/OdW9U8Pu1TUcUmAkhMEQ04bc/bCRsF7oh2N8WIqQf+ri2+iPsbAqwoc5HWI+eO3/YiBsmDPd4/3UHfXlXJphsv7s5SMavt5H6q6386IMDccNmQgh2NgX4tLz7fIQNEXuazGmJXuKWlic+X/6wwcKPqxn+2+385MMDfFnp7VWfsN77eJS1BFld3cHWhgCvbG2jPWhwxWv7EULQ0BFhyV43emc9gxGDr6t9lLUEE75Xl/aAzsf7PLywpaVX+w3rAs9BQ62BiHHI9zv499fW+HiptJWtDYHDDtP1bAM13u4bhpe2tsYFZxBdSuSSUdGb5E31xx6Q6oZgQ52PP21oZsle91Fd2yDaNlZUdfDkuiY8QR3dEGxpiP+8Pbu5pdf1pEtYF9z/afRBkJ99XNNr6HB3c5CXSlspbfD361rqCxsEO28W2gI6H+5xx37u3qf7/UK6we/XNvFfX9TFrovlbSH+t0cP5PT/202tN8J5hUmMTbdSkm4hpBu9eoiPpz0tQVZUdfRqp4dzDOmx8QR1vq72sbVhYK6jQ+mYEoUPlMbGRrKzs1m+fDlz5sxBCEF+fj4LFy7kgQceAKKBU05ODo888khcGqPly5dzww03UF5ezogRI/jrX/+acA2zwznShONHUv6DHa90SMsrfVzy6v5YSqEJWTZMKqTZLZhVBasq8IUNWoM6TrOKjoohBMIwaPJH2Nc5wXlCThLpVpXCZI16bzSPGgpUuA0KXBqGblDf+QVoN6s0BcCEQb7ThN2ksrzSG5eI9ZapqYxMsbCrJcjWxiAbG0K9ksWeNTyJ0/OdpFshJ0njV6ub2N8WQigqBgouk8EvZufwq9WNtAb0Xklkx6Rb+edpaby2w8O6Wj8aBul2jVa/jgAUTWNkiplaT5DhLgvFqRY+2udBVzTSrArZDpV0mwmzqhAwDDKTrHgCEVQEhiEwAE9YYKBS4NIIhHWa/DrbGwOxVE7/NDoJp1XFHzao8UQoaw0RFAroOooSDbgy7Cb2tEUIC+KOwflFTj6p8HHnaRn85qJcIPrF//r2Nv6208P6Oj92TeAOGkzItDIxy8qedoOiZDPJFsH/zs1jXa2fP25oZnNjmGp3sM+EuRMzLeQ5zTjMKrdMS+eC4hSq2gI8ua6Rd3e5qeuIxKWnSrdrTM6yU+kOIVA4u9DFqko35W0hzKrCyDQL25vDoCh8Z0wSEzJtVHvDrKzysaMlHHeeNAV0EU0CXJBsxqaJWLsDOLswmS8rvbH9/2tODvfOyo6lcvr79lZufrcqrk65DpWFZ2ZwwBPijR1u6n16XBLgSdk2DAFbG4MsPCub362uJ8OusfPH47Cbo5+l/1nRwENf1tJTz8TG5xQk0RbU2doQQEfl26Nd2FVBjTdCjTfMAXc4YWLjH52eTrVX8PaudjQMVv9wNGd1rkivKxopFpiZZ6c5oOPQFAwFZg53sbclwHs9ekMECucUuajzBKn3hmMBUJrdxLgsB75giC31AawmhRn5DsZk2slwmDF0nYr2IGZNoTjFQkmmgw11fv68viHuC15HZWKWjVQLOMwqJlXhgCdMaWMIp0XFH+q+1qRYVe4/J49NtX7+tr2lVxv73vhkfjgllW+/Wo7DrOALi7h0SFeNSWZdrZ/ajgghoVKcrDEpy0pHSLC3LciwZAvFaTYmZZqp84Z5a6ebak84rk1OyLIRiBjMzLcTMlSSbSYcmoFZU+gIGRxwh/FGok8rp1oUXFaFdbV+9rSE0FEZk27hO2NdPLKqMa7sCMGTF+fyz9OiE96X7HXzwlY3a6s7qPXE3xgUptlZfF429d4QH+718Gm5F6PzumdXBecUODgtL9r2mgMCl9XEjvoODnii5y/TobGxPhirU26SibqOSOx8DE+2UOvuDioKU8yoqsbe1lDc5+nAzyaw4ONaXtveTooluqhx15nNcVm5eXIqX1Z4WFXtI82mcdeZmZRkOPAEw1S3B9nVHOTdMjfnFDiJoLK3JYAwDOo6IoxMs6B2poRSDkqqrSoKWU4L4UiEYERgNymk2zQK06w0+AxeLY3vPbSZTfz4jEzM6AxzmdlY72dLQ4BdLWF0A9Ks0R68Gk+YsCEYmWbHaVWJ6Dq+sMFwl5lkq4bFbMKiAkKnqj0SnRNaksw7ZV5WVXnjrntOi4rTZmG4UyPFomDRon8iKPgj0e9imwbJVpUWv84BTwSL2cTYNBN//PawaK5UTqJ0SANtz549lJSUUFpayqRJk444rRLAD37wA3JycvjlL3/JfffdR2NjY9zrR+pYgrGDy3+wXbt2JUwUvnnz5oSJwlevXp0wUfiyZcviegbNRVN4rFTHvG9ln8lle+pKQD3H2BnbFksuK9xxSbW92PhCG0+B0ZQwYW6JUUuJ6M6JVqV0JwEuEN0fyjIllzI1jzP1PbFE4RBN1lylZjJH34GT7gvQGnUUTUoy8/QtCes039hCz3u9k6VOKemZjGpaF6vTOQVJLK4uwG6389vi/extDbK+zk9IF0ddp3MsNWQnmUi2qBzQnfzVXUBBqGbQz5OhWZkb3kxPfdVpuWUqrkh7rE6qAt+ekEvupLN4ecUO/NXdw/+HOk9VjhEU+PZTIJoxKdGL33aRw+t3nMcDz3+EKdDG9Bw7U3Js3Ffq7FWnFKvK0nDxIdveN+HzpCrRgOVY6pTnNNEeMGiIWPhCG8+txUEuddbx+vY23CFjQOpkVhXaUkexvN3V72tEf+s0Vy3njHw7Fe1htrWr/TpPDaZMNlLABP34Xvd61mlKto1fNo3BQYjHSmpxmBU+2++lyitO6LZ3rOeprzpNFVWx74RjqdPNoxXyndGh3r6+c7sShX/44YcnTqLwgSKE4Morr6S1tZUvv/wS6E44Xl1dTX5+fmzfO+64g4qKCj766CMA3G43eXl5rFy5kqlTp7Jp0yZmz55NbW0tycl9LxCZyNEGY4nKf7DjnSi8zRfk430eajxhDBG9O4oYglA4QkfYQEEh12lC0zQ0VUEROnaTSppNQ1GgukOwozGANxhiuMtCqk1DIGgJKui6gUUV0TsWQ5DlMJHe2YtU1R7gwz1earxhRqZZOb84mbXVHaTZFHY1BRmbaWXmMCcum4mWjiDnFTrJcJjY1xpkyb4Ovq7xI3Sd1oBOSBd8daCD/zk/nxynmTv+URGr5+3T01l84TCSzCq6rvPTj6p5bnMrBclmMpMsfKvYxU/PSOOAJ4w7YFCUakYzmdhY6+OH71RQlGrhtmlp+CMwLS+JfKdGrTtEXUeYsNGZ1kXVCIZ1MuzRXgJNgYgAdxgUYRAMG9R7wzy8qhEDhXGZdm6dkkrYiB5Lp1VjmMtCst2MoUdwmFSCusGOpiB+XeGa8alMfmp7bPhs24/GcvnrFZS1hOJ6VoYnmzm/OJkfTEnn5S1N/GVzKwA/Pj2dSblOlu338rdt3b0TU3JsnDHMxb0zM3slAdY0jbU1HWyr91HtCfNumZu9rWHcYVCFQVGKifvOymL+6GSsJg2zFj2+m+p81HVEeGeXG09YcG6RizGpGnOLnLhDBl9Uenlzl5cl+7xYFT2WemhEqoU/XVbIuYVOAqEIe1uDmFQFp0XFHYb1tX4qW/0YAq4cm8KMZ8tivRNW1WB6roO1ncOWXT0rZkXQcyRu5a1jeXNHK6urOshN0hifaeOH0zLY3Rrh4pf3xN3JGyg03juZX62s45erGuK2d/VOPHv5cE7PdTAq3UpAV/j3ZXX4giFqPRHGZ1k5v8jJ33d5WbrPQ1NHtKfk3rMyuXpcKtPykvjpkmoq24I8dlEen1d4+elHNbE69TyvH98wklkFyTy7sYmvq72cP8LJnuYgH5V7qfIYzBuZxA8mpnBukZNqT5gtDQE+Lvfx2tZmbpuexvlFToa5zDT6DRp8BiZ0xmXYiBjRobgVB3x8UeVn/kgHY9OttAd13t/jwR0STMt1cO04J1eOSUFTFUK6QZ1PsL0xQHV7ALOmoBuCTIeJHS1hxmXYeH5TEx91DsXfMjWNoNCwqvDtUUlcPNLF9P/bzb7WELqiccuUFJ66ZBivbW/l1n8ciDt/KoLF5+di1RRcNhNjMx1UtwfY3xZkeUUH03Ns2C0mdBS21HZg0eCfxkVzSjosJvwRWHPATa03zI6mIIGIgapqGCjsavRh1RRGpJpxmlWGpdroCAne3N5CyBAUuMw8Ni8fTdO44MW9lLcGSDKr3HdWFisP+Hjg3DzOf2FP3HkCuGFqJhPSLZw93M7SfR4uK0kmyaLyy69b+GyfmxpPiPmjXPzb7GxOz09CKCorKtwsWl6HN2ywsynAsGQrF41KYVqWmUyHhtOsUtEe5qNyL2cXusi1KxhCMMxlwWFWWFUTZGKWjUtfifai5iSZKE61YDWbuGpsCt8qsvOPMncsKbiOyjkFSSy9fgQQ/R56an0zL25zMyHTyshkjQZfhDS7xqa6AD5dJcUa7TU0aQreoMHkHDsj0uy0+MJk2VVaAzopVo0cpxkUFcPQ41KGdESgLSTQRPR6vb7Wx7bGIC0Bg8k5Dr4z1sllJcnUd0S46OV97GmLcG6hk1SLoCMkmJRtZVKWjTFZDtJsGt5AmEZfhHyXmfqOCIqqEdYFJsVAiOii2IGIQUhoBCI6Hn+YiBD8enV03t+EnCRevnI4JWkW2gM6u5qj7cNpt3CgLYg3FJ1iENQNFEXFaTOjCp0WX4QWfwSHWSXNYebHS2rRhM5zlxfEsquckj1jd911F++//z4rVqxg+PBoupOuYKympoa8vLzYvrfffjtVVVUsWbIEgKeffponn3yS0tLu5NOTJ09mwYIF3HHHHf0qR6Jg7Msvv2T+/Pmxn//4xz9yww03HLb80rH7p7+V816Zh0cuyONfZmbGNeaIEX3CqTjVMujlKvzddmq9EdbfVsKUfj6dl/f4Npo6UyDtXzCePS1Brv77ftxBg2EuM/82O5vbpqUfNq9bW0DnjZ1tTM+19zuLgSEE2xuDZDo0cp3mfv3uoexsCjAyzRLr5j8Sc1/Yw1cHuueMHfjpeC5/fT8bO9ermj3cwVPfHs6UP3X3KveVdPrLSi8XvLSv13bfA5MRCE7/vzJ2NndP4l9wZiaPXZTfa/9DEUIc8qIqRDRp8zu73VxU7OK6CSn8v2V13H1mJuMzT/y8qz11PXUIEPq3yb3qPfmPu2LH87Zp6Tz17ei17z+W1fHwyvinKQc7UXgiNZ4wT69v5vIxyXGLTl/+WjlL9kaDTqdF5Y1ririguP85iwdKV+L1/5qTw7+fE79yQLMvQtHvdxDsvDtJtM+p4G/b23i3zM1vLsonw3HsC0J8780K3tjZzuMX5XP3mZkDUMKjM6RLWyxYsIB3332XL774Ii6Qyc2NzqGpq6uLC8YaGhrilrZ49tln2bZtGyZTdzUMw+CZZ57pdzCWyBlnnBHLgQm9l9Xoq/zSsXvzOyMwBAkDE5OqDEkgBrDhtjHUeMP9DsQgvi6qAucVOdl251iqPWGm59qPeImLVJvGrdOOblFHVVGYlD3wgcG4owg2/vf8POa+GB16+N7EVHKcZtb8c0mst7g/Swkkaiea0rUQpkLpnWP5tNyDqijMHObAcRTLUByuPIqi8IMp6fxgSnd+vkPl0zyR9WyLierdczmInv+elHViBp35LjP/PTe31/bXri7ivTI35xYmkWRWST5BkogHEzyYkeEw8d0JqbxYGu0t729S8W+KY80PfLALi52k2TQmZFoPv/NxNCTBmBCCBQsW8NZbb7Fs2TKKi4vjXi8uLiY3N5elS5fG5oyFQiGWL1/OI488AkBpaSnr1q1j2bJlpKd3X/za2tqYM2cOW7duTTh/qz/sdjujR4/ud/mlY6coCifiIt6ZDhOZR3k31rM+Xf/MdZoHtIfqZDK7IInW+yaioJBk6Q6ODv7yPyPPzrpa/yEDcC1BwHDw4/0XDmGPx8nmcNmMeq723vPf4QF6QnuwOMwq3x3AL/ZjZVYVwobgghHOhK//+lt50eE1m8YZecdn3bxTze3TM2D64fc73oYkGLvrrrt45ZVXeOedd3C5XNTVRcfBU1JSsNvtKIrCwoULWbx4MSUlJZSUlLB48WIcDgfXX389AM888wwzZsxI+PTirFmzeOaZZ3j88ccPW5auni+v10tjYyObNm3CYrEwYcKEoy6/JCXSs/fmBIwzh4TTcvieiL9dU8TjXzfxk0OkeEm0rJLNJI/y0TrcjVDP1d57HvuBWi7nVLXv7nHsaQlxTmHi3JJpdhNPXDJskEslDYYhCcaeeuopIDpPq6fnnnsulqT7/vvvx+/385Of/ITW1lZmzpzJxx9/jMvlIhQK8dJLL8WWvTjYNddcw0MPPcQjjzyCxXLo4ayeT2uuX7+eV155haKiIvbv339M5Zekg/X8gjvVVt0/FsOTLfz6MPO7Eh1PufDl0Ttc+zT3MUx5cCw2zHVq9voerVO5p/xUN2TDlIejKAqLFi1i0aJFvV6zWCw0NfVe0bzLPffcwz333DNgZRmI35Gk+Hk4Q1iQb6BEw2rf0OxEg6LnJPdEegZj5rhgrPvaePW4ZP5wyck5Z06SBpu8XEnSIFHiesaGrhzfRInmjCWaBC0dmeJUCxtvG0PlT8cnfN3cY3S5Z89YzyOeajMNyNNu0uGtr/Ux4emdPPRV/VAXRTpK3+hgbOLEiTidzoR/Xn755aEunnSKURNM4JcGRqLgNhCRwdixmJRtI6+PITNnj2is52hwz2HKFl/8WkzS4f1mTSPnPr+nV+qlw3n860bKWkL85/J6OXJzkupXMHYkCbKFECxatIj8/Hzsdjtz585l27ZtCd/veCb4DofDXHzxxaSnpxMOhxk+fDi/+93v2LRpE5s2beKKK65I+DsPPPAAkydPJikpifz8fH7wgx9QUxOfTDYYDLJgwQIyMzNJSkriiiuu4MCBA/2qg9Q/h8ulN1gihmBH09HlAu0ZL8g5Y0cuGInmj/yiwtvnPomCsZ6TyQMRg/9cVsew32znq6rBzSH7TZRs6/7q6GuYsrZDBmP99a+f1LK62sevVzcefuceWvzdwVtXsnHp5NKvYOxkSvD9//7f/+O1117j6aefZseOHfzsZz/jrrvuwuPxMHr06ITpCXw+Hxs2bOA//uM/2LBhA2+++Sa7d+/uFbgtXLiQt956i1dffZUVK1bg9Xq57LLLeq2+Kw2MX65qIO1XW/nVqobD73yc3bWkmil/2s1LW9v6/buHmjO2orKDD/e4T5ig80ThDuo4H93Kk+uaufDlfbFEyQdLFNxGDMEbO9owL96C69GtPLSygQZfhGvf2H+cS/3N8NT6JmwPbeHfPquNJT3vktJjPa6up4RXVHbw04+6b1zreiQYlw6v52e/wt2/gKqivXv/NTW+Q+wpnaiOaQX+EznBd35+Pr/4xS+46667YtuuuuoqnE4nL7300hG//9q1a5kxYwYVFRUUFhbS3t5OVlYWL774Itdddx0ANTU1FBQU8MEHH3DxxRf3uw5HSwjBE+uauXJMMq0BnUZfhJJ0K5l2U9y6TT21+CNsrIsmbF2y18O6Wh9XjklhcraN8ZlWzh4eXfxQVaLzP1QlmojXYVZi6z91NZlARKAq0X00te/enoghomlMlGgKkLbO9EfukIECeEIGeU5TbEjEYY6mXmr167QEIkz6Y/cK7O9+dwTzR8enujKEQAHqOiJk2LVYeh6AA+4wWxsDTM62sbneT0V7iGk5dsZn2ugIG6gKBCMCq0lBAWo8EVJtGk6LSmGKGSGivS5dde9aIRtg421jmJBl7Twm0SEaQwgMAf6IQUfYwBc2WHXAR0GymZ99XMOuzlXLW++biNOi4Q3pLPqint+uiT6QclqunQfn5HDJKFfseEYMQZMvQqbDhElVEELwXpkbAUzItJGTFD3fqqIQMaLnRCE6Z8qqKXHrdgkh2NcWiqaiybWTnWTCpil8daCDjrBBcaoFh1nFYVLJ7UwE7wsb2Exq3HpSQkSzIOxuCeINGbQGdMZmWJmeY8feOXM+YgjaAzodYQNPyOD17W2k2jQ21/uZmGXj3rOyErYZIQQC2NYY4NJXy6n1xgdgV4xJ5pnLCki1aVS0h9jZFGREqjmunQCxPIyJvHXtCC4r6TtlWntA59P9XpZVeClINqMpCslWNVa34S4zo9IsOC0a7UGdLIcJq6b0WnxWNwTlbSGqPeFYO893mcl2mGL7hnXBF5VetjUGmTXcwWm5djrCBm2BaIJl7aCepwPuMJvr/dz7SS1FKWauHpfC/FHJDE+Ofn7e3e0m065xdkFS3HwuiAa3SeboOa31RnCHdEanWUmxqnHtZHmFl2+93J3R4MIRTp67oiD2Gf3PZXU81LnSftdK8GP/sJN9PXplzKqC5/5JaGq0XXpDBi6Lyt7WEK7O9Go5SSbManwb1Q1BUBfc+f4Bmv0Rzi1MYlyGjSSLijdkUJRiZky6FYdZRev8PHSEDZLM3XXQO9NEPbmuiYJkCxOzbFw8yhV7urPeG+aJdc00+SLkJJn4p3EpTMqyxY51xBC9jl0inqBOjTfM1oYAo9KtjEq14A0btAd0xmRY+XCPh0nZNopSLPjDBjubg+xrDZLrNHNGnh1r5xivEIKb3qnkte3dyeIXzckh1aZx4QgnRSkWgrpge1OADHs0EB6bYYu1n+Rflsaue3efkcHj86LLXwQjBiFd4AsbJFs17GYVvTODiUVTyO/xtOuLpa0sq/CycEYmkzsXtTaEYNUBH6UNASZmWUmyqBS4LJS3h1hR2cEZeXZKMqwEItFr0j1Lo8F4vtPE5zeNojjVEnduazxhNtRFr8OzhjuYkm2PHWd/OJrw3KIpqEr0HHS1Dd0QRAzBrpYgEUOQZjORYu1K6RdtAwcvEt7qjxAxoje+XddEVYm+98Y6P4u+qOfbo1386PSMI1pi53g7pmDsRE7wnZGRwaOPPsqtt94a2/b973+fVatWHXLZioN98sknzJs3j7a2NpKTk/nss8+48MILaWlpIS0tLbbf1KlTueqqq/iv//qvXu9xvHJTLq/0ccmr+9FEfI+cjkqqTcMXDDMu00azL0J7UCeCSiAieuViS5RLr2t7V345kwpJZhWHWaU1pOALRVB7TNcVKBiKihkjtoSDLgQoCmGh9ipjz/yAB5c9w2GizRfqtR0g3Qp/vHQ4l5WksK81yMOrmnmxtPWo6nS47V11UoWB0xwNON1Bo8+yH6pOKErc9lunpZGZZOX/NrbQnKCuI1MtzMyzsq0pyLbGQKyMDhMEwwe9f2fZM2wq7UE9FoDoihatvxAMc5kpSDazszlEc1CgCqNXHscjrVOKNZprMiKUhHW1aAouM3hD3Xkru85fovMxt9BBriP6xTCn0Mk1f6847HlymCDNplHrjSBQUFQVYfRdpztPS+dHp2Wy8OMaPq/swG7R+PKmYoY5zayp8VHa4OeJ9a1cNCqZ/c1+VlV3dB/Hvsp+0HanRaUw2YxQTUR0g45gmNaAjr9z7lrPOjktKpeVuGjs0Pmk0o8wuusazYsabXsuEyR1fl+aVYX2kMAd5ojbXkGKleEpVsKRMFXtYeo7hw4T1WlchhW7xcS6Wn/C85RqVTkrz0ZZa5Aad4iQcfjP07+elcHfd7RT0R6O+zwpPeqKomI2aWBEiBgi1maO5PPUfa2Jbrd2tr1AxOg+7p11tamC4lRL7IbAZ6hx14gsh4bTotEUhHZ/OJqT16JhiGjezv1ug4iuU5hsQgjwhQ1aAkavOvVVdrXzvHZtt5kUvj3KRWGqhce+bkEoiT9PB5+nru2zhzuYlGXhla2t+MLdbQwhuGiEg5AeDUh7no+Dz9Pk3CRCYZ1dzd0JvgUKuS4LdZ7QUV8jDj5Po9Is7G0N9aqTArEgO1FdVQUMRUM3juxablJBM5mIRAz0Ht+5idpez7JfMsLBy/9UGMvMMRS5KY/6URchBPfccw/nnHNObKX7rsVPD04blJOTQ0VFd+Jnt9vNG2+8wcqVKwG48cYbmT17Nr///e/7neC7LxdffDGPPfYYc+bMYdSoUXz66ae88847/RpKDAQC/PznP+f666+Plauurg6LxRIXiEG0jl31P1hZWRm7d3fftRcWFjJ16lS2bt1KZWVlbPuYMWMYO3Ys69ato7Gxe85AVwb5FStWxA33mgunMDbdSlHjWkzoOEwq/ojBcnUcnoCFi40tUA9dD5d/pE7BSYgL2YUCpNs1hKrhGzELd0sTrobteMPRBuzFxhfaeIaLFiaLKjCACDT6XRzQRlMi6ikR3fWtUjIoVQoZZxygQDR3113JpUzN4zSjnCy6y75dK6TJksWM4A5cRO92BLBGHUWTP5l5xjZMRM9VbpKJC8+fy8Nr2iloWMtzf9/EcwfVaY6xM/beETQ+1qaQiYcZxt7Y9l516tSIi7XaaMbSwEQ1OgE2pAsqOus0URygIHhQnZTedSpVCqhSMplt7MZJ9OJmUmElo/CaUpgT7K7TgQ3wijoOPxauNW3ljHwHeU4Tm+sD/Nk7joY2N+0tOxlO9Px11ckRdjO3s04WTcEtrHxGZ518ves00ug8T+1AO+QrGXjMRUzUD5Cn967TbK2CDMMdexIxUZ3wd54nJZkLjW2kmKO9cYGI4FPG4tctzAx39yCqCnyoTMHex3naWlGHw9iLG9i5Gmb3OE+nqwfISTJR5Q6TnpHJS20FjBb1lITqIARTutqeKGSySND2lDw+vSBAS9MW9qyBO1yCPTipDGfyL39+v7tOQFgdxQtbdObpW7io8zxZNYXW3GkkJyWRX/c13pBBSyD6WXtXTMIietQpAJFAZ9sT7l5tryF7GmZPPQX+cghAaym04sLQRjNFa2CCUo87FP38dX2eRoQqe7U9d4/PU2GymUp3OPF5Ata0j2KFO5l5+hYy6L72faGOI6JauZSt+Luin8bEn6dLRqfy0/JiTIE21L17GQuM5fCfp9Ginq0rNzMOGNejThMTnSeRx5n6vl6fp0ZzFt+z7yfo9+ILCxQFVoiRNBFte6aD6uTXLczo0fZSrCramNnsrHOT3bgZOldEOgeNpmEzuTQvQt3OjVR7w+CN1mmPNp4C0cLkSBV0fuc2+l2Eu657bfHXvX2WEYwMVsbVaY+Sy+4E14j9thE4MvPJrN+IGvLTsQN2ABnqqLg6JXcGKMs6rxEXG911guh52nyghZTKnZzbuS3ZZmF/9pnsOVCHed8mzMDFhztP9aMpMWq5+OBruTf+82RWFXaSwy4Ofd1L14KEOq8da3rWqVmnK5fN15bxpCQ5GN+6KRoWBbrr1Nc1outablGjvc+thqX7utezToaLtWI0JUZdwu+ng9veHjWX3eTRvHcLr75dSp4zGhL19Z07c+ZMsrOzY9O0usydOxe73c6HH34Yd57mz5+P3+9POC3qYEfdM3YiJ/iG6BDq7bffzj/+8Q8URWHUqFF861vf4rnnnsPn8/Hyyy/HDZt++OGHnHvuubGfw+Ew1157LZWVlSxbtiwWjL3yyiv88Ic/JBgMxv1/F110EaNGjeLpp5/uVcbj1TOmadEhuXZ/CJdFjQ0H+CKwsznIhhovOUkmgrrAHzZIspmZV+wi1RofpZtMJoQQRCIR2gI6NZ4ItR1hhqXYaPKGyUlSOeAJoykKKTYNi9mEhsBpVnCaVXQhMES0dyIc0YkYBroR7eK2WUwkWTQ0YSA670ismopJi94Nd9VJCMGu5iC7WiO0BHRM6MwpdBLWBaPSLJhMJrwhnYdW1PKbr5tivRbfGpnCOYVJtPiC/MuMbOo7wmQ6TKQ6LNHEzsLAokWPi0VTo8fdMPCH9NgK7boATTOhYsTORzBisLc1TKrDDIZOaYMfp0Xj4lf2YaDwxPwCbpzooj1gxLrBNVXFpGnoegRNUWJDu113R9P+uCM2TFmcamZPm86PT8/gobnZseEKgICu8M7udqraAozPtFKcaiXfZSYkVJp8YTqCEXKdJgqSo3WMoFHeGqDeE2JkupVmXwSrSSEv2UZ7IMK2Bh8f7nGT7TBx3ggXZxe60BDsbQnE8vHZLRomrft8BCMG7qBBSIDTYiIYClPjjdCVB1woGhOybGhCjxu+9oSh0afT5g+R5YgOPZs1BVWNDiF13QxtqvNT6Q6xpTHMxjofH+3pHp4Zl2HlF3PyQRhcNjp6EdtQ5+OMPAdWi5kXNjdzx3vRm5hfXpjHnadn8tcdbu74R2Wvu979P51Itj2+ve9tC/P9t6vYXt8919VpUWkPwcKZWQxLUvj26GRGplljnzPovus1hEBVFMIiOoRv16LDavtaQ7QHddrDClYNsmwKKVaNfJcZm0nBbDZjGAb+UIT3ytzsag6iCxib5eA745JRiQ7F7GsNkm43k+ows6fJT0g3cAd1bCYVq1ljUrYDYURiQ7zBiEFAhw31QcKRMLOGRVdv31zvx2w2sbslhEM1SLFpjEix4LKoJFnNuKzR3sT2gM4/ytpZus+DjsYtU9P5zt/2xnqovA9MxhOGv+1o4/N97QxLNuMJ6jy/pQ1d0bhpUjLbGvx4Qgb7uno/Duq1uGSUi7vPzMRuMXNmrpWQbmBWFfa0BBGKSltQ4A2G8IUN7v+kFotJ4Z3rRlKSYe913UNR8UcEvmCYkCEIhA2cFo1KbzRI9gTCJJlVxmZaMandn7+le9t4ubSVM/MdnJbrYGaBC1WJntdAxGBTnR93SCc9yUqRy0QgolPnjeAJ6YR1gcNqAcPApEaH/20mlYIUC6l2c+wa3xE20BQFi0mjyhOh1h2gzhvGGza4cISLYckWNE0jHA6zZK+H365pYkVVBzoqc4qcfFXhBmDLHWMYmWbtvMYLKtsCNPsiTMq2ETFgZ0uY696ooNbT/T104+RUnvh2EZf+dR9fVUaHRx86P5dRaVZGpNtp90eocQdRFYXiNAvugM7LOzz8amUdLovKvJFO7j0rG1/YYGNDCH8oglmFq8elYDNFv4MCOgRCYRxmFZOqEOhsewYqqZbo58IXNthc72d6npPfr2si1Qwj0yzkJpmxmhTGZkXXsAuFI5S1BClrCdLki3Dp2DScZpWmjmgbsptUwobApytsbfCTaVOYXZAUu95EUGnzRzAMgwPuEFlJJlTAUE0Ewzp2E7HgChQUVSMciaB33vhbNAWzpjL1z3vY0+zj1asLuawkBRianrGjCsYWLFjA22+/zRdffBGXl/FIhylnzJjBunXrUNXuLyDDMDjzzDP5+uuv+1WWvoKxLoFAgObmZvLz8/n5z3/Oe++9x7Zt2/B4PNTXd6/JMmzYsFgqo3A4zHe/+1327dvHZ599RkZGdxqWoxmmlAZWtSfMzqYAI1ItjEob3OSuXXPGHr8on7vPzOzX757xzG4210dvAz3/OhFFUeKCsFNZqz/Cy1vbCBuC26enH3YOx46mACNSLLE5XNWeMCN+vyNuHwUI/fuUPt/DHYzOsyxOtcinWw/yxNom/mVpDclWleZ7e+f4ffzrRu7/tBaAv1xRwA2T0jjgDlH8RLRX44ZJqdx9ZiYZdtMhc4r2pSvgPZV0hAxSf7UVgO0/GktJ+qGvbSHdYPGKBv73q+jcvd/Oy+cnZ/TvmiTBt/+6j6Xl3lg7Hir9GqY8WRJ892Sz2Rg2bBjhcJg33niD7373uwC4XK6EXYddgVhZWRmff/55XCAGcPrpp2M2m1m6dGnsvWpra9m6dSuPPvrogJVb6tswl3nI06wUpfT//+/51aKp8RPiT3VpdlO/gtvxmba4n3vOtS5wmajyRHjuioJDvkeyVSPZeuig71T1o9MzSLdrnFOQOEdiz8ntps6gqec2VVE4I+/Qq/gfyqkWiAHYzd11TjmCdmnRVH4+OzsWjFllLtaj4uq88XMHh3Y1hH4FYydTgu+vv/6a6upqpk2bRnV1NYsWLcIwDO6///4+3zMSifCd73yHDRs28N5776HreqyO6enpWCwWUlJSuPXWW7n33nvJyMggPT2d++67j8mTJ/Otb32rP4dTOgl99P1i1tb6D/kkXl9kOqTjp2f/4gOzc7huQiqpNhloHS2TqnD9IXoJenbodv37SJ4+lPqmKgrvf6+YjpBBdtKRfTXbTCpXjElmV1OQfxqbcpxL+M00JcdGa0AnJ2mIc4KKfiC62kGvP88991xsH8MwxIMPPihyc3OF1WoVc+bMEaWlpUIIIYLBoMjIyBCPPvpowvf/9a9/LTIzM0UwGDyqshQVFcVeX7ZsmRg/frywWq0iIyND3HTTTaK6uvqQ71leXt5nHT///PPYfn6/X9x9990iPT1d2O12cdlll4nKysrDllk6tc18drcw/e9mYfrfzUI3jKEuzjdKgzccO7Z/XN801MX5xvvzhqbY8X57Z5sQQohWfyS27eZ3Koa4hKcWQ15PTnrHtLSFJElH7uy/lLG2xg9A6N8mH9GkTunItPgj5Dy+HYAnLxnGHadlHOY3pGPxl80t3P5+NOvIO98dwbdHJ+MN6aT9Kppt5XsTU3nxysKhLKIknVTk7GFJGiTxw5QyEBtIcgh4cMXNGVN7zxmT9/iS1D8nZDAmE3xL30QyRjh+5HSlwWWOm8Df+XdcpoDBLpEkndyOetHX4+mDDz4gHE6c1+zgBWUl6WQhA4bjRx7bwdVzAn/XU8E9Hw7WDSRJ6ocTMhgrKioa6iJI0oCT8cLxcyouhTCUevaCdeUD7Dn0LhPeS1L/nJDDlJL0TSQDhuNH9owNrp5r5CVa0kJ2jElS/8hgTJIGiYzFjh9NHtxB1TMAMycIxnQ5aUyS+kUGY5I0SGTvzfEjj+3gipvAn+BbRMZiktQ/MhiTpEEihymPH1VOHh9U8SvwJximlMGYJPWLDMYkaZDI3pvjp+fk8YiMBI477XDDlHICvyT1iwzGJGmQyFhscIRlMHbcmRMs+tqTPAWS1D8yGJOkQSJHKQeH7Bk7/nq2ZYe599eIXNpCkvpHBmOSJH2jyGDs+PMGuyfmpdu1Xq/LeXuS1D8yGJOkQaLIgcpBEdZlMHa8pfUIwBIPU8pzIEn9cUKuwC9JknS0ClIsQ12Eb7ypOXZ+d3E+xamJj3WiAE2SpL7JYEySBomcM3Z8Lfl+McsrOvjB5LShLsop4cenZ/b5mgzGJKl/ZDAmSYNEfj0dXxcWu7iw2DXUxZCIT5ckSdLhyTljkiRJ0oBKtPaYJEl9k8GYJEmSNKASpUiSJKlv8iMjSZIkDYjvT0wF4L5Z2UNbEEk6ycg5Y5I0SOQEfumb7vkrCvjdxcNItfVee0ySpL7JnjFJkiRpQCiKIgMxSToKMhiTpEEiO8YkSZKkRGQwJkmDRA5TSpIkSYnIYEySBolMmShJkiQlIoMxSRokMhiTJEmSEpHBmCQNEpk8WZIkSUpEBmOSNEhkz5gkSZKUiAzGJGmQyGBMkiRJSkQGY5I0SOQwpSRJkpSIDMYkaZDInjFJkiQpERmMSdIgkcGYJEmSlIgMxiRpkMhhSkmSJCkRGYxJ0iCRPWOSJElSIjIYk6RBIoMxSZIkKREZjEnSILGZZHJKSZIkqTcZjEnSIHnykmGUpFv4v8uGD3VRJEmSpBOIIoScVSxJkiRJkjRUZM+YJEmSJEnSEDINdQG+6YQQeDyeoS6GJEmSJElDxOVyoSh9zxuWwdhx5vF4SElJGepiSJIkSZI0RNrb20lOTu7zdTln7DiTPWOSJEmSdGo7XM+YDMYkSZIkSZKGkJzAL0mSJEmSNIRkMCZJkiRJkjSEZDAmSZIkSZI0hGQwJkmSJEmSNIRkMHYS+8Mf/kBxcTE2m43TTz+dL7/8cqiLdNJatGgRiqLE/cnNzY29LoRg0aJF5OfnY7fbmTt3Ltu2bYt7j2AwyIIFC8jMzCQpKYkrrriCAwcODHZVTlhffPEFl19+Ofn5+SiKwttvvx33+kAd49bWVm666SZSUlJISUnhpptuoq2t7TjX7sR0uGN+yy239Gr3Z511Vtw+8pj3z0MPPcSZZ56Jy+UiOzubq666il27dsXtI9v6wDqSY36it3UZjJ2kXnvtNRYuXMgvfvELNm7cyLnnnsv8+fOprKwc6qKdtCZOnEhtbW3sT2lpaey1Rx99lMcee4wnnniCtWvXkpuby0UXXRS3bMnChQt56623ePXVV1mxYgVer5fLLrsMXdeHojonnI6ODqZOncoTTzyR8PWBOsbXX389mzZtYsmSJSxZsoRNmzZx0003Hff6nYgOd8wBLrnkkrh2/8EHH8S9Lo95/yxfvpy77rqL1atXs3TpUiKRCPPmzaOjoyO2j2zrA+tIjjmc4G1dSCelGTNmiB/96Edx28aNGyd+/vOfD1GJTm4PPvigmDp1asLXDMMQubm54uGHH45tCwQCIiUlRTz99NNCCCHa2tqE2WwWr776amyf6upqoaqqWLJkyXEt+8kIEG+99Vbs54E6xtu3bxeAWL16dWyfVatWCUDs3LnzONfqxHbwMRdCiJtvvllceeWVff6OPObHrqGhQQBi+fLlQgjZ1gfDwcdciBO/rcuesZNQKBRi/fr1zJs3L277vHnzWLly5RCV6uRXVlZGfn4+xcXFfO9732Pfvn0AlJeXU1dXF3e8rVYr5513Xux4r1+/nnA4HLdPfn4+kyZNkufkCAzUMV61ahUpKSnMnDkzts9ZZ51FSkqKPA99WLZsGdnZ2YwZM4bbb7+dhoaG2GvymB+79vZ2ANLT0wHZ1gfDwce8y4nc1mUwdhJqampC13VycnLitufk5FBXVzdEpTq5zZw5kxdeeIGPPvqIP//5z9TV1XH22WfT3NwcO6aHOt51dXVYLBbS0tL63Efq20Ad47q6OrKzs3u9f3Z2tjwPCcyfP5+XX36Zzz77jF//+tesXbuWCy64gGAwCMhjfqyEENxzzz2cc845TJo0CZBt/XhLdMzhxG/rMjflSezg1ApCiEOmW5D6Nn/+/Ni/J0+ezKxZsxg1ahTPP/98bJLn0RxveU76ZyCOcaL95XlI7Lrrrov9e9KkSZxxxhkUFRXx/vvvc/XVV/f5e/KYH5m7776bLVu2sGLFil6vybZ+fPR1zE/0ti57xk5CmZmZaJrWKxJvaGjodbclHZ2kpCQmT55MWVlZ7KnKQx3v3NxcQqEQra2tfe4j9W2gjnFubi719fW93r+xsVGehyOQl5dHUVERZWVlgDzmx2LBggW8++67fP755wwfPjy2Xbb146evY57IidbWZTB2ErJYLJx++uksXbo0bvvSpUs5++yzh6hU3yzBYJAdO3aQl5dHcXExubm5ccc7FAqxfPny2PE+/fTTMZvNcfvU1taydetWeU6OwEAd41mzZtHe3s6aNWti+3z99de0t7fL83AEmpubqaqqIi8vD5DH/GgIIbj77rt58803+eyzzyguLo57Xbb1gXe4Y57ICdfWj2n6vzRkXn31VWE2m8Uzzzwjtm/fLhYuXCiSkpLE/v37h7poJ6V7771XLFu2TOzbt0+sXr1aXHbZZcLlcsWO58MPPyxSUlLEm2++KUpLS8X3v/99kZeXJ9xud+w9fvSjH4nhw4eLTz75RGzYsEFccMEFYurUqSISiQxVtU4oHo9HbNy4UWzcuFEA4rHHHhMbN24UFRUVQoiBO8aXXHKJmDJlili1apVYtWqVmDx5srjssssGvb4ngkMdc4/HI+69916xcuVKUV5eLj7//HMxa9YsMWzYMHnMj8GPf/xjkZKSIpYtWyZqa2tjf3w+X2wf2dYH1uGO+cnQ1mUwdhJ78sknRVFRkbBYLOK0006Le4xX6p/rrrtO5OXlCbPZLPLz88XVV18ttm3bFnvdMAzx4IMPitzcXGG1WsWcOXNEaWlp3Hv4/X5x9913i/T0dGG328Vll10mKisrB7sqJ6zPP/9cAL3+3HzzzUKIgTvGzc3N4oYbbhAul0u4XC5xww03iNbW1kGq5YnlUMfc5/OJefPmiaysLGE2m0VhYaG4+eabex1Pecz7J9HxBsRzzz0X20e29YF1uGN+MrR1pbMikiRJkiRJ0hCQc8YkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShtD/D17NLmLrkmFUAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "array([[ 35.4827, -71.0754, 137.582 ],\n",
+       "       [ 38.9305, -94.7062, 129.127 ],\n",
+       "       [ 24.7715, -70.5703, 121.098 ],\n",
+       "       ...,\n",
+       "       [-21.7413, -67.7685, 125.969 ],\n",
+       "       [-54.4597, -74.8781, 128.007 ],\n",
+       "       [-63.832 , -76.5177, 121.271 ]])"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "case.electric.bipolar_egm.points  # the x, y, z, coordinates of each mapping point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "number of mapping points: 800\n",
+      "number of samples: 2500\n",
+      "first 5 electrode names: ['20A_19-20' '20A_1-2' '20A_17-18' '20A_17-18' '20A_9-10']\n",
+      "first 5 voltage values: [0.651 0.45  1.542 0.513 0.315]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'number of mapping points: {case.electric.bipolar_egm.n_points}')\n",
+    "print(f'number of samples: {case.electric.bipolar_egm.n_samples}')\n",
+    "print(f'first 5 electrode names: {case.electric.bipolar_egm.names[:5]}')\n",
+    "print(f'first 5 voltage values: {case.electric.bipolar_egm.voltage[:5]}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAACDCAYAAADBExzWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAABUJ0lEQVR4nO3deXxU9b34/9c5Z/bMZN8hCQHCvrqAiCJqRanr1Vpbl2qvW1ul5apXe2+/98q993dxaatdtNr2qnWt2rrWBcUFFAHZIewBQhKy7zOT2c/5/P6YZJIhEyAQEpDP8/HgATlzMnw+53zmzPt8Pp/zeStCCIEkSZIkSZI0JNShLoAkSZIkSdKpTAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSdJx8bftbWyu9w91MSTphKfIROGSJEnSQFtR2cH5L+0FIPzvU4a4NJJ0YpM9Y5I0iF4sbaXod9tZX+sb6qJI0nG1uUH2iEnSkZLBmCQNon/+RxU13gg/fLdqqIvyjSSE4NlNLXxS7hnqokg9GHIARpIOyTTUBZCkU5EvYgx1Eb5RXtvWxoulrdw0OY07PziARVNoumcidrO83xwqSo9/e4IGKTZtyMoiSSc6GYxJ0hAwZEfBgLrxnUoAPtoX7REL6YIVVR1cNNI1lMU6pQX17kbeFtRlMHacCSHwhAySrfI4n4zkbaMkDQE5anP8bW8KDHURTmltAT3hv6Xj42cf15Dx622sk/NRT0oyGJOkIRCRXWPHXVlLaKiLcEp7c2d77N/tMhg77p5a3wzA/3xZP8QlkY6GDMYkaQjIOWMDxx9OfCzLWoKDXBKpp53N3ce/LSiDscGytSHA3UuqafVHhrooUj/IYEw6LiKGkE9QHUJHSAZjA6XBl/hLZ0Odn1e3tQ5yaaRE5DDl8dVzudBKd5g/bmjmzg8ODGGJpP6SwZg04Fr8EcY9tZNZz+1Bl8NxMT0DMF0elgFT1R5OuL0toHPTO1XypuAE0BaQNx/HU0eC3uG3drmHoCTS0ZLBmDTglu7zUtEeZkOdn9JGOYm6y11L5J3q8VDh7j03rOeyCl7ZCznoDk7s0i6HKY+rZn/i4ysT7Jw8ZDAmDbhdzd0BWFW7nETd5eWtbUNdhJPW/rYQIT1xUFXe2ruNjcu0xv7dKofIBt3BHeJymPL48gQTfzb299FrLJ14+hWMPfTQQ5x55pm4XC6ys7O56qqr2LVrV9w+QggWLVpEfn4+druduXPnsm3btoTvt3jxYjRN4+GHH+5XoWtra7n++usZO3YsqqqycOHCXvvMnTsXRVF6/bn00ksP+d5vvvkmF198MZmZmSiKwqZNm3rtU1dXx0033URubi5JSUmcdtpp/P3vf+9XHb7JNvZIDPzVgcF9zPr17W2c98IeqhL0lgyEZl+Et3a29/tpSHmHevS+quqg5A87ueSV8oSvb0yQiHpMencwJntljo47qNPcx3y8w9EPau8NHcd/MnkwYuANnZrn2tNHvd/d3Z5wu3Ti6Vcwtnz5cu666y5Wr17N0qVLiUQizJs3j46Ojtg+jz76KI899hhPPPEEa9euJTc3l4suugiPp3d6kueee47777+fZ599tl+FDgaDZGVl8Ytf/IKpU6cm3OfNN9+ktrY29mfr1q1omsa11157yPfu6Ohg9uzZhwwQb7rpJnbt2sW7775LaWkpV199Nddddx0bN27sVz0Gwom4RMKOpu6nqL6qiraNWm+Yz3qkqPnF57WYF2/h/bLueQ3VnjA//EcVzkdKMS/ewtl/KSPQz6cOb3i7kpUHfPzrJ7XHWIvEvvtmBd99s4KHv2ro1+81+XpfLOVcpiPz/JYWAL6s6uj1WkfI4MvK+O02k0JxqiX280AOUwYjBtsaA7ScAk+qzf7LHgp+t6PPgGzVgQ5WHehI2I4P/tjubD626QpCCP6yuYUHl9clvOaFdcHw3+0g7VfbsD20hW2d0yMaOyKsru7dbo6lHG0Bnb9ua2XZfu9h9//Nmkbm/3Ufv17dQLDzoBzqxuzVba1c8OJeShPk9XxrZzvX/n0/td7evV19tfG3dh59MLa2xseHe+LnnX1a7uHLSi/727pvdoUQvLWzHfvDW1iwpDq2PRgxaPZFCOkG7qDeZ73bAzpPr2/mopf3cu3f9x/xNV83BIuW1/FC5/XhZKeIY7hlb2xsJDs7m+XLlzNnzhyEEOTn57Nw4UIeeOABIBo45eTk8Mgjj3DnnXfGfnf58uXccMMNlJeXM2LECP76178yZ86cfpdh7ty5TJs2jd/85jeH3O83v/kN//mf/0ltbS1JSUmHfd/9+/dTXFzMxo0bmTZtWtxrTqeTp556iptuuim2LSMjg0cffZRbb72133U4Ws2+CNP+vJvvTkhl/mgXhoiuPO6yqNR6w7QFDKo9YarcIXxhg7KW6N9Tc2xkJ5nJtGu4rCrPbmohJ8lMfUeYM/IdnJHnwKRCjSdCilUl12kmxarismj4Igab6/28V+ahxR/BEDDMZea0PDuZdhPtQZ1frW6MK+d9Z2XFts0tSuLv14wg87Fob+kwl5n9C8bzj93tXP33il51nJJt4+EL8rCbVOo7wqyp8bG+1k9a52reG+r8JJlVpuTYyHWa+e2aptjv+h6YTI03jE1TyEoysaHOz+oDPv6+o43ythBOi8p1E1I5a3gSmQ6N3c1BLJqKzaTgNKtUuMN8tt+LN6iTbNOwm1T+uKE59v6/v3gYigJ2k4LDrNLQEaEjbKAqoBvgDulUtIUJRAwq3dE5dD39bEYmz21uoSTdynmFSZw/wklxqoUvKjv4VrGLWm+Y0oYADrOKP2xgUhUOuEPYTCqaGh2aeHlrK6k2jUBEYDerdIR0zKpCrtPMuYVJnJZrp8mvs6Kqg2FOE2l2E7oQfFXZQb0vwvlFTiZk2jBrCq2BCC1+HZOqcKQihiCsC7KSTGQ5TFg0hRpPmNaAji9sEIgI/BGDNTU+hIDxmTam5tgYlWbFG9LZ2xqizhsh1aaRZFaxmhQ0RUFTwaQqBCOCez+pif1//3NeLhcWO1my18Pu5iCf7vfQeFCgm2bT+MvlBVz5t/0APHf5cG6cnB57vaEjwivbWnmptJVaT4TpuXbMGtx5WgY1nghra3w4zCpmTSHNphHWBXvbQizd56G+s4fHYVa4eUo6cwqTcFk09rYGURWFPa1Brh2fyrQcG56QQWlDgGpPGEMIdBE9XhFDoBvRz2qzP0JQF1g0BVUBq6aSnWRiYqaNVJtGUDf4orKD8rYQFk2hoi1EyBC0B3SGJ5sJRAS6EBSlWBjuMqN1njt3MHr8S9KtuCwaI1It5DpN7GoOsrbGx7paH2XNIcyawph0KxOzrNjNKmFdENIFvojB419HP0v3npXFHdPTaQno7GwKoijw9PpmVld393pfPNLFvrYg5xQk8dt5w3hlWys/+qD7i9lmUmj4l+70VPvbQpQ2+KnxRmLXmv2dUxrynWYafBF8YYOx6VZCuuDNne3s6lyqZGy6lV+cm82141NRFZj5bBmb6uODvbOGOfjsxlE4HikFop/Rl68qZNbwJE7/v93UeCNMy7ExuyCJB87Oxhsy+NXqRr6s9BKMCPJcZhbNyeHB5fWsqYnWc0Kmle1N8culXDraxcY6P4UpFi4Y4aQoxcLcoiTcIYPfrmnipdLeT/PaTQo/nJrO7IIkluz1oCjR4/ePMjevbmuL7bfqh6NZUdWBpiicU5DEjGfLALBqCovPz6PBF2Zsho3zi5KY+ufduBMMVSrA2ltLmJpjp84bZn97CENAZXuo8xqo0dgRIaAbOEwqVZ4wFW0hFAWWVUSD2MnZNuaNdLGiqoOve5zza8en8OzlBdz3SW3cdXHnj8cS0gXnvbA3borA+Awr105I5fpJqYxKi/Zc72gKcMYzZYQOeqKpINlMcaqFjrDBeYVJnJnvwKQq/KPMTW6SiXS7xiflXj4pjwbEt01L58E5OezvrFdYF+xqDhLSBQIYmWoh2aqhKLC7Ocj/bWwhzaZxxdhkfGGDZIvGg3NyYp+foXBMwdiePXsoKSmhtLSUSZMmsW/fPkaNGsWGDRuYPn16bL8rr7yS1NRUnn/++di2H/zgB+Tk5PDLX/6S++67j8bGxrjXj9SRBmOTJ09m1qxZ/OlPfzqi9z1UMHbJJZdgMpl44YUXSE1N5fXXX+e2225j8+bNjBo1qtd7GYaBYXR/UBRFQdM0dD3+bkFVVVRVJRKJvxPta/vTG1v5l6W1aCL+y0jv7PDUMI5su6KBEAm3K8JARRx2u0DBUFRUYaD02G6gIBQ1roz/Pjub/++rRoSiYhI6628r4fLX9lPtCaOjUpRq4UBb/MX1RK/TobbrqKAoJ915OlnqZNFUTstPYlWVFwVBvtPEG9eOYOZzexGKSqpZ8If5w/i6xsfr29qp8+knfJ2+Secp32mixhthfkkyNpOJPS1+SnsMLR+vOhWmmKlsD8dtH5VmYW/nHMNv+nm6oiSZdztHHgazTv8+O5vFXzUcsk52k0IocoR1HaTztPSGkcwaHu2o6es7V9M0FEVJuB1A1/WE2xXl8EHeUeemFEJwzz33cM455zBp0iQgOpcKICcnJ27fnJwcKiq6ez3cbjdvvPEGK1euBODGG29k9uzZ/P73vyc5Ofloi9SnNWvWsHXrVp555pkBeb/XXnuN6667joyMDEwmEw6Hg7feeithIAZQVlbG7t27Yz8XFhYydepUtm7dSmVlZWz7mDFjGDt2LOvWraOxsbt3aerUqRQWFrJixYq44d7vzJhB5pUFLPvkY1p9QQIRgQLsTZmMbrIyo2Mj2UkmVEXBooJjwrnsa/QwvHkzjb4IAjCbTFRkz8DT2sj0yF72t4XITTLjwUpZ6hT8TTXM1A7gDup4QgatajIF409jjKjF0laF06zijwhqtAz+Up/FyGAlBaKZcRlWar1h1oWyKVPyOM0oJ4to2dd/CcOVAqqUTM42drP4L1uZFDKYBDx800WMH5HPhx9+iNsfYuUBH/vbQ6y1jKcwM5lZvo24rCpdc7mHnXYebq+f+m2rsWgKmXYTpc1h/hqaSCYeZhh7Y8fLp9hoyp7OOFMLZ6gHqPGEafLplAUdlFpLuDi5nXTfAUK6IBARhJzZjJs0hbS2vQSbawkbgk31fsqUXMqUPL6TUoMt2EYwYiAAb/pozGl5DG/ejCniR1HAZdFoSBvH07sEFxrbMNH9Yf1CHcel4zKZ6tlIrTdMky9Ce9DgI3UKdkLMFTtJtmhEDIFmMrHMMhWTv5UrHJVEDEGVO4wXGzPPmcNYrYWm8h20BXQiBuj2VPY6x1K2ezeT1HqKUy2EDYHblkWdcyQjAvvJDDVR6w3TETZocQxDZI6g2LMTU6AtVkZv2mgCzhzSajeiRbrvitszJxC2p5JWtRoMnaBu0B4wKE+dTE6qk5KWdZhUhYghUBUYd9YFWEWIPRtW0uzX8YYMFFWjYdhM6hsamKOWYxjRu1jdZKchZzomTy1GbVnssf1GXKzVRjNRbWC2o4k8pxmnWeWM8cWsMVJwV+6kQDSTHFDZtGIPo4WDMiWPksBeXnprEwDTgVKlgHpTFvPVvYx0RD8Hu1uCrFFH0aIk8z3rTjKsxMofGH4aDoed1KqvyU0ykWbXqHaH+dI6jX2NHsZ7t5Jmj15KazoM3hGTY20vyazitKhgcVCfPY1kfwPp7ftQlc4nPpPSsBVPxV9bjq09ugxHR9hgZySN5cFhTOEAM51uUm0a/rBBcn4xeSNKCO7fjKe1GU2Fak+E1pSRGMm5ZNZvQov40I3ovK0q1zh2BBxMaV9PuPMLJNNhInXcDPJTnVj2rcQTMmgL6BiAt+gsrEaIA6WrY8OBiqqx3DKNPNycrZRjUsFhUglodsyjzqSl7gBjwxU0+XXK20Kx8zRa1FMi6jg/zcnnbi8VuzMoVQuZbFRysWhGU6KBNBmFOPNHktKwjYC7BbtZxWVR0fLGUKmkkV67ESXsJ8thIifJxJeimGfK6PV5unDuXK6bmsODz7xBrTcCrTAeaBo2k+217cwxdkIzjAZyXVamnfst/nvJztg1Is9poigrlc+V8ewp389kURV77551Ot/ZzOyCJDwhg22hFFZGhjM2VIG3qbsHt+sacWNGLfNzI4QNwbpaP43OYiyZ+VRsXIldBGJtbI06iiaSE14j/Fi42NhCklnltFw7+9tDvKlPYkSSQVbDlti+ETQ+1qaQiYdZYi9Xm1LRaafNsPKFNp7hooWZWjUCsGgKblMy+51jmWZqoCBcQ9gAb0gnmJRD9qgJJDXvQXXXUd8RYV9biDIll3OnT2RiYDf7q+vZ3x5CF7DXUsRN507g408/x0mA9V/CxcAadRSv3ziNbSs/JdUC+1pDbGsK8EFkDP5ItE4AmXYTs4Y7uPmay1i9v5U3l3xKeVuIiVk2zCYTpamn425uJKlhO4LoaAoWB8vUcZg99ZSEKgh3ttWu83Rpehs5gWocJhVVVWizZrGBAor85YxUWgjpAqtJRaQX8rtyJ6cZ5Wz5qpy2ZPMhv3NnzpxJdnZ2bJpWl7lz52K32/nwww/paf78+fj9flyuw+fIPeqesbvuuov333+fFStWMHz4cABWrlzJ7NmzqampIS8vL7bv7bffTlVVFUuWLAHg6aef5sknn6S0tDS2z+TJk1mwYAF33HFHv8pxJD1jd955JytXroz7/15++eW4YdMPP/yQc889N/bzoXrGFixYwJo1a1i8eDGZmZm8/fbbPP7443z55ZdMnjy51/9/vHrGDo7ShRCx94a+o/SDt5tMJoQQCbcfXPa+tieqk24IHvyygS+qfPxpfh5/2tDMnzZEx/cT3WUtODODRy8q6HXnoRsCi9nUrzpVdxg0doQpcmlsbQigqQpn5juwW829yr6tMUBxuh2nWTlsnZyPlGKg8Ot5w/nx9NS4//NQ5+l/vqznze0tlLeFYgmUhaKy7+7x5Di6p24GIwYOq5mOkIFZMeK6zY/mPB3cxo5X2+u5HQ59np5Y28jPP6vj1asLuWp8xmHr5Hyk+3P79W3jGJFsIsncfVwUReHJ9a3869IDKAgmZtl48pJhzHlxH0JRybEDIvpU5ag0KzdPzWDhWdkII/p/hnXBVa/vR9VU3v/+SIwjbGOH2t7si2BSDJyW7qTN/f08KapKIBTBonXX9VjOU0V7iGEuMyb18NeIDTVeZv9lDwDeByb32fZu/aCGv5a28NuL8rj9tAwWr6iP9or06J3wPjCZj/e5eaG0naABp+dYuXVqOllJpqOu07paP3d/UEFJmoV/npbBzGEOHNboF+m9H1fxh3XRYbOzhjn45KYS/m9TCwuXRIOrf56Wxu8uHo7JZGJPS4APd7cxLdfOWcMcKIqCyWSi0RvixS3NTM2xc16RE0MILObe146en6eIbrC1McDjqxuYNzqVG6ek92pLXXXa3uDFHTA4I99BY0eEuz6q5Z+nZ/Cd16OB4fYfjaUg2Rz9DBuCqvYAw13mWA9L13l6fFUd//55Xez9u3qR8pNU9t49nhWVXpZVdDCzwMWYdAtFyfH9L0d6Le+5vet8lLcG2dUS5JxCF6l2M7b/7Z4znWHXeOd7ozgjP6nX+dvcGOQ/Pq/js3I335+Ywp8uLTjk91ZX26v3BHFZVKwmNWHZ9c4pAEk2S7++c+e/up/l5e08c/lwrpuQFneeBrNn7KiCsQULFvD222/zxRdfUFxcHNt+pMOUM2bMYN26dahq95eQYRiceeaZfP311/0qy+GCMZ/PR15eHv/93//Nz372s9h2j8dDfX13Dq9hw4Zht9tjP/cVjO3du5fRo0ezdetWJk6cGNv+rW99i9GjR/P000/3q/ynkrAuYnM4AL4/MZVPyrvn/Gy9cwxjM2xDVbwjYl4cvZt76cpCrpuY2u/fH/abbTR01vfVfyrkmvH9f4+TXdcxtJsU3Pf3vnnpa3+A8L9PSbjPk+uaWPhxtGfizHw7j12Uz7nPR7/YHr4gl3vPyj7WYp9yvqz0kp1kOuRnsuvcZNo1av9lIutqfcx6bk/cPn2ds+Ol2hPmf1fU809jU7hoZLRH4u1d7Vz7RnR0puXeibis2qHeYsgs3efBFza4cmzKEe2vG4IXS1u5/f34NQxL0i1s/9G441HEPp37/B5WV/tQleh83aGcf9Uf3/n7ft7Z7eaJS4Zx52kZQ1aOfg1TCiFYsGABb731FsuWLYsLxACKi4vJzc1l6dKlsWAsFAqxfPlyHnnkEQBKS0tZt24dy5YtIz29e1JtW1sbc+bMYevWrbFhz4Hw+uuvEwwGufHGG+O2u1yuI+o6PJjPFx2q6RlIQjQCPviOV4pn1hRK0i2xBM4RQ/DU/OH895f13Dcr64QPxABeuaqQFVUdfGf8kV0sD9bzzifRqtmnEn9k4J4m7fnQgd2kxj3NJ1NPHZ1zC52HfD3cY9J1V67VyVk2Uqwq7X2sezUYhrnM/GH+8Lht5xc5yXaYmDHMfsIGYkAseDxSmqpwy9T0XsGYyzL4dXz16iI+3ufhxklpJ00gBuC0RB/aGuqVCfoVjN1111288sorvPPOO7hcrtgcsZSUFOx2O4qisHDhQhYvXkxJSQklJSUsXrwYh8PB9ddfD8AzzzzDjBkzEj45OWvWLJ555hkef/zxw5ala/0vr9dLY2MjmzZtwmKxMGHChLj9nnnmGa666ioyMo4s4m1paaGyspKamuhddtc6arm5ueTm5jJu3DhGjx7NnXfeya9+9SsyMjJ4++23Wbp0Ke+9994R/R+nsv8+L5fvvxWdJ3ffrCxOy3Uc8V3gieDaCalcOyH1qH+/Zz90X6tmS/E+vn4kt7xbyZMHfcH21GMkD7tJxehxYW0bwsDgm6zn+m2+cPQJzxSbxqc3juKMZ8qGsGS9pdg0yheMw3wSBQn98fH1I7n01fLY3KnytsFfbHuYy8wPp6YffscTzLOXF/CXKwqHuhj9W2fsqaeeor29nblz55KXlxf789prr8X2uf/++1m4cCE/+clPOOOMM6iurubjjz/G5XIRCoV46aWXuOaaaxK+/zXXXMNLL71EKHT4hjR9+nSmT5/O+vXreeWVV5g+fTrf/va34/bZvXs3K1as6NdyE++++y7Tp0+PLQ77ve99j+nTp8eGH81mMx988AFZWVlcfvnlTJkyhRdeeIHnn3++1/8v9XbNuBRW3jKa8rvHcVquY6iLM+h63ns1HuWCmqea80c4qfjpBC4r6fvhnvieMYUNPZ7Wk1kgjg/3QYvpbu1c22tqjp0sx4nX+2TR1COau3MyOn+Ek39cNyL2s8w6ceTUE6RN9HuY8nAURWHRokUsWrSo12sWi4Wmpqbev9Tpnnvu4Z577hmwsowZM6bfK5/fcsst3HLLLYfcp6SkhDfeeKNf7ytFKUp0Iv2pqmdPeNMpGozZTAqBARyiBOKGRWxmNW7R3/0yGBtwn5Z7eq0NtbHOz+yC6NIA39QeqBNZzwc9zik4/Fqa0onlqJe2kCSp/3p+fSValf9UkO0wUeke2Jx5ph59/GZVYXSahT2d60kN9P91qqj1hvGFjdgCnV2+qurgkr/2Tk3Vc1FjsyaDscHW85jffcbQTUSXjs4JmSh84sSJOJ3OhH9efvnloS6eJPWbJ6jz8FcNcQmTK49T/swTXdeSBhBd12htjY9//aTmmPIKaj2GGlQF5o/uHtJs8eu9htSkwyv83Q7GPbWrVzqkN/tIsbOh1ocQggeX1xEc4J7PgXTAHTphU5Htbwvxy1UNtB/FMGPPnrGuDCXSyeOE7Bn74IMPCIcT380evKCsJJ0MHlnVwCMr49NElbUEMYQ4YeYsDBZbjy+Nak+Y+X/dR3vQoNYb5qWrio7qPXvOGVMV8B/0pGpFe4jJ2faDf21ACCFi6ai+ibY3BeKerNzdEp8SaEy6hd0tIXY0B/lgj4fF/czbOpie39LCbe8d4OqxKVw5NpnvTkg9ZPovIaKLKxckmwdlvtm8V/ZR3hZiS0OAF6889KRyQwjeK3MzNcdOUYoFS48n/FNkMHbSGZKrx0MPPcSZZ56Jy+UiOzubq666KvbUIkBRURGjRo3ipZdeYs6cOUyePJnbbruNYDCYcDmKxYsXo2naIZN7J1JbW8v111/P2LFjUVWVhQsXDkj5JaknQwh+v7b3XElfWFDtGdghNCEErSd4EuuecdLe1lBsGYTXtved1NgfNg45/7PnMKWmKPgPSja846CcggPpln9UUfC77WxJkNz5ZNWz56hnEmpPMJrntKeSdCvFqRYMQSyP44nqd525a9/c1c7N71bxLx/XHHL/36xpYtSTO3lqffMh9xsoXU9Bvrv78Am+//uLeq75ewWjn9zJnpYgw1zdfSs20zfzxuCbbEjO2PLly7nrrrtYvXp1LK3AvHnz6Ojo/pA/+uijPPbYYzzxxBOsXbuW3NxcLrroorjUBF2ee+457r//fp599tl+lSMYDJKVlcUvfvELpk6dOqDlHwy6IXhsdSNbGwL9flABGLB1VdxBnbuXVPPhHnef++iGYGOdnz+sa2JHU6DP/YQQfFYeTULe9bMQgiZfhD0tQTbX++OG+gDaAjr7WoOxY9AW0I/b2lJbGvzMeq6Mpft6t8O+fLzPgy8cf6ytnb1D2xr7Phb9sbHOz2vb2rj01XKyH9/OdW9U8Pu1TUcUmAkhMEQ04bc/bCRsF7oh2N8WIqQf+ri2+iPsbAqwoc5HWI+eO3/YiBsmDPd4/3UHfXlXJphsv7s5SMavt5H6q6386IMDccNmQgh2NgX4tLz7fIQNEXuazGmJXuKWlic+X/6wwcKPqxn+2+385MMDfFnp7VWfsN77eJS1BFld3cHWhgCvbG2jPWhwxWv7EULQ0BFhyV43emc9gxGDr6t9lLUEE75Xl/aAzsf7PLywpaVX+w3rAs9BQ62BiHHI9zv499fW+HiptJWtDYHDDtP1bAM13u4bhpe2tsYFZxBdSuSSUdGb5E31xx6Q6oZgQ52PP21oZsle91Fd2yDaNlZUdfDkuiY8QR3dEGxpiP+8Pbu5pdf1pEtYF9z/afRBkJ99XNNr6HB3c5CXSlspbfD361rqCxsEO28W2gI6H+5xx37u3qf7/UK6we/XNvFfX9TFrovlbSH+t0cP5PT/202tN8J5hUmMTbdSkm4hpBu9eoiPpz0tQVZUdfRqp4dzDOmx8QR1vq72sbVhYK6jQ+mYEoUPlMbGRrKzs1m+fDlz5sxBCEF+fj4LFy7kgQceAKKBU05ODo888khcGqPly5dzww03UF5ezogRI/jrX/+acA2zwznShONHUv6DHa90SMsrfVzy6v5YSqEJWTZMKqTZLZhVBasq8IUNWoM6TrOKjoohBMIwaPJH2Nc5wXlCThLpVpXCZI16bzSPGgpUuA0KXBqGblDf+QVoN6s0BcCEQb7ThN2ksrzSG5eI9ZapqYxMsbCrJcjWxiAbG0K9ksWeNTyJ0/OdpFshJ0njV6ub2N8WQigqBgouk8EvZufwq9WNtAb0Xklkx6Rb+edpaby2w8O6Wj8aBul2jVa/jgAUTWNkiplaT5DhLgvFqRY+2udBVzTSrArZDpV0mwmzqhAwDDKTrHgCEVQEhiEwAE9YYKBS4NIIhHWa/DrbGwOxVE7/NDoJp1XFHzao8UQoaw0RFAroOooSDbgy7Cb2tEUIC+KOwflFTj6p8HHnaRn85qJcIPrF//r2Nv6208P6Oj92TeAOGkzItDIxy8qedoOiZDPJFsH/zs1jXa2fP25oZnNjmGp3sM+EuRMzLeQ5zTjMKrdMS+eC4hSq2gI8ua6Rd3e5qeuIxKWnSrdrTM6yU+kOIVA4u9DFqko35W0hzKrCyDQL25vDoCh8Z0wSEzJtVHvDrKzysaMlHHeeNAV0EU0CXJBsxqaJWLsDOLswmS8rvbH9/2tODvfOyo6lcvr79lZufrcqrk65DpWFZ2ZwwBPijR1u6n16XBLgSdk2DAFbG4MsPCub362uJ8OusfPH47Cbo5+l/1nRwENf1tJTz8TG5xQk0RbU2doQQEfl26Nd2FVBjTdCjTfMAXc4YWLjH52eTrVX8PaudjQMVv9wNGd1rkivKxopFpiZZ6c5oOPQFAwFZg53sbclwHs9ekMECucUuajzBKn3hmMBUJrdxLgsB75giC31AawmhRn5DsZk2slwmDF0nYr2IGZNoTjFQkmmgw11fv68viHuC15HZWKWjVQLOMwqJlXhgCdMaWMIp0XFH+q+1qRYVe4/J49NtX7+tr2lVxv73vhkfjgllW+/Wo7DrOALi7h0SFeNSWZdrZ/ajgghoVKcrDEpy0pHSLC3LciwZAvFaTYmZZqp84Z5a6ebak84rk1OyLIRiBjMzLcTMlSSbSYcmoFZU+gIGRxwh/FGok8rp1oUXFaFdbV+9rSE0FEZk27hO2NdPLKqMa7sCMGTF+fyz9OiE96X7HXzwlY3a6s7qPXE3xgUptlZfF429d4QH+718Gm5F6PzumdXBecUODgtL9r2mgMCl9XEjvoODnii5y/TobGxPhirU26SibqOSOx8DE+2UOvuDioKU8yoqsbe1lDc5+nAzyaw4ONaXtveTooluqhx15nNcVm5eXIqX1Z4WFXtI82mcdeZmZRkOPAEw1S3B9nVHOTdMjfnFDiJoLK3JYAwDOo6IoxMs6B2poRSDkqqrSoKWU4L4UiEYERgNymk2zQK06w0+AxeLY3vPbSZTfz4jEzM6AxzmdlY72dLQ4BdLWF0A9Ks0R68Gk+YsCEYmWbHaVWJ6Dq+sMFwl5lkq4bFbMKiAkKnqj0SnRNaksw7ZV5WVXnjrntOi4rTZmG4UyPFomDRon8iKPgj0e9imwbJVpUWv84BTwSL2cTYNBN//PawaK5UTqJ0SANtz549lJSUUFpayqRJk444rRLAD37wA3JycvjlL3/JfffdR2NjY9zrR+pYgrGDy3+wXbt2JUwUvnnz5oSJwlevXp0wUfiyZcviegbNRVN4rFTHvG9ln8lle+pKQD3H2BnbFksuK9xxSbW92PhCG0+B0ZQwYW6JUUuJ6M6JVqV0JwEuEN0fyjIllzI1jzP1PbFE4RBN1lylZjJH34GT7gvQGnUUTUoy8/QtCes039hCz3u9k6VOKemZjGpaF6vTOQVJLK4uwG6389vi/extDbK+zk9IF0ddp3MsNWQnmUi2qBzQnfzVXUBBqGbQz5OhWZkb3kxPfdVpuWUqrkh7rE6qAt+ekEvupLN4ecUO/NXdw/+HOk9VjhEU+PZTIJoxKdGL33aRw+t3nMcDz3+EKdDG9Bw7U3Js3Ffq7FWnFKvK0nDxIdveN+HzpCrRgOVY6pTnNNEeMGiIWPhCG8+txUEuddbx+vY23CFjQOpkVhXaUkexvN3V72tEf+s0Vy3njHw7Fe1htrWr/TpPDaZMNlLABP34Xvd61mlKto1fNo3BQYjHSmpxmBU+2++lyitO6LZ3rOeprzpNFVWx74RjqdPNoxXyndGh3r6+c7sShX/44YcnTqLwgSKE4Morr6S1tZUvv/wS6E44Xl1dTX5+fmzfO+64g4qKCj766CMA3G43eXl5rFy5kqlTp7Jp0yZmz55NbW0tycl9LxCZyNEGY4nKf7DjnSi8zRfk430eajxhDBG9O4oYglA4QkfYQEEh12lC0zQ0VUEROnaTSppNQ1GgukOwozGANxhiuMtCqk1DIGgJKui6gUUV0TsWQ5DlMJHe2YtU1R7gwz1earxhRqZZOb84mbXVHaTZFHY1BRmbaWXmMCcum4mWjiDnFTrJcJjY1xpkyb4Ovq7xI3Sd1oBOSBd8daCD/zk/nxynmTv+URGr5+3T01l84TCSzCq6rvPTj6p5bnMrBclmMpMsfKvYxU/PSOOAJ4w7YFCUakYzmdhY6+OH71RQlGrhtmlp+CMwLS+JfKdGrTtEXUeYsNGZ1kXVCIZ1MuzRXgJNgYgAdxgUYRAMG9R7wzy8qhEDhXGZdm6dkkrYiB5Lp1VjmMtCst2MoUdwmFSCusGOpiB+XeGa8alMfmp7bPhs24/GcvnrFZS1hOJ6VoYnmzm/OJkfTEnn5S1N/GVzKwA/Pj2dSblOlu338rdt3b0TU3JsnDHMxb0zM3slAdY0jbU1HWyr91HtCfNumZu9rWHcYVCFQVGKifvOymL+6GSsJg2zFj2+m+p81HVEeGeXG09YcG6RizGpGnOLnLhDBl9Uenlzl5cl+7xYFT2WemhEqoU/XVbIuYVOAqEIe1uDmFQFp0XFHYb1tX4qW/0YAq4cm8KMZ8tivRNW1WB6roO1ncOWXT0rZkXQcyRu5a1jeXNHK6urOshN0hifaeOH0zLY3Rrh4pf3xN3JGyg03juZX62s45erGuK2d/VOPHv5cE7PdTAq3UpAV/j3ZXX4giFqPRHGZ1k5v8jJ33d5WbrPQ1NHtKfk3rMyuXpcKtPykvjpkmoq24I8dlEen1d4+elHNbE69TyvH98wklkFyTy7sYmvq72cP8LJnuYgH5V7qfIYzBuZxA8mpnBukZNqT5gtDQE+Lvfx2tZmbpuexvlFToa5zDT6DRp8BiZ0xmXYiBjRobgVB3x8UeVn/kgHY9OttAd13t/jwR0STMt1cO04J1eOSUFTFUK6QZ1PsL0xQHV7ALOmoBuCTIeJHS1hxmXYeH5TEx91DsXfMjWNoNCwqvDtUUlcPNLF9P/bzb7WELqiccuUFJ66ZBivbW/l1n8ciDt/KoLF5+di1RRcNhNjMx1UtwfY3xZkeUUH03Ns2C0mdBS21HZg0eCfxkVzSjosJvwRWHPATa03zI6mIIGIgapqGCjsavRh1RRGpJpxmlWGpdroCAne3N5CyBAUuMw8Ni8fTdO44MW9lLcGSDKr3HdWFisP+Hjg3DzOf2FP3HkCuGFqJhPSLZw93M7SfR4uK0kmyaLyy69b+GyfmxpPiPmjXPzb7GxOz09CKCorKtwsWl6HN2ywsynAsGQrF41KYVqWmUyHhtOsUtEe5qNyL2cXusi1KxhCMMxlwWFWWFUTZGKWjUtfifai5iSZKE61YDWbuGpsCt8qsvOPMncsKbiOyjkFSSy9fgQQ/R56an0zL25zMyHTyshkjQZfhDS7xqa6AD5dJcUa7TU0aQreoMHkHDsj0uy0+MJk2VVaAzopVo0cpxkUFcPQ41KGdESgLSTQRPR6vb7Wx7bGIC0Bg8k5Dr4z1sllJcnUd0S46OV97GmLcG6hk1SLoCMkmJRtZVKWjTFZDtJsGt5AmEZfhHyXmfqOCIqqEdYFJsVAiOii2IGIQUhoBCI6Hn+YiBD8enV03t+EnCRevnI4JWkW2gM6u5qj7cNpt3CgLYg3FJ1iENQNFEXFaTOjCp0WX4QWfwSHWSXNYebHS2rRhM5zlxfEsquckj1jd911F++//z4rVqxg+PBoupOuYKympoa8vLzYvrfffjtVVVUsWbIEgKeffponn3yS0tLu5NOTJ09mwYIF3HHHHf0qR6Jg7Msvv2T+/Pmxn//4xz9yww03HLb80rH7p7+V816Zh0cuyONfZmbGNeaIEX3CqTjVMujlKvzddmq9EdbfVsKUfj6dl/f4Npo6UyDtXzCePS1Brv77ftxBg2EuM/82O5vbpqUfNq9bW0DnjZ1tTM+19zuLgSEE2xuDZDo0cp3mfv3uoexsCjAyzRLr5j8Sc1/Yw1cHuueMHfjpeC5/fT8bO9ermj3cwVPfHs6UP3X3KveVdPrLSi8XvLSv13bfA5MRCE7/vzJ2NndP4l9wZiaPXZTfa/9DEUIc8qIqRDRp8zu73VxU7OK6CSn8v2V13H1mJuMzT/y8qz11PXUIEPq3yb3qPfmPu2LH87Zp6Tz17ei17z+W1fHwyvinKQc7UXgiNZ4wT69v5vIxyXGLTl/+WjlL9kaDTqdF5Y1ririguP85iwdKV+L1/5qTw7+fE79yQLMvQtHvdxDsvDtJtM+p4G/b23i3zM1vLsonw3HsC0J8780K3tjZzuMX5XP3mZkDUMKjM6RLWyxYsIB3332XL774Ii6Qyc2NzqGpq6uLC8YaGhrilrZ49tln2bZtGyZTdzUMw+CZZ57pdzCWyBlnnBHLgQm9l9Xoq/zSsXvzOyMwBAkDE5OqDEkgBrDhtjHUeMP9DsQgvi6qAucVOdl251iqPWGm59qPeImLVJvGrdOOblFHVVGYlD3wgcG4owg2/vf8POa+GB16+N7EVHKcZtb8c0mst7g/Swkkaiea0rUQpkLpnWP5tNyDqijMHObAcRTLUByuPIqi8IMp6fxgSnd+vkPl0zyR9WyLierdczmInv+elHViBp35LjP/PTe31/bXri7ivTI35xYmkWRWST5BkogHEzyYkeEw8d0JqbxYGu0t729S8W+KY80PfLALi52k2TQmZFoPv/NxNCTBmBCCBQsW8NZbb7Fs2TKKi4vjXi8uLiY3N5elS5fG5oyFQiGWL1/OI488AkBpaSnr1q1j2bJlpKd3X/za2tqYM2cOW7duTTh/qz/sdjujR4/ud/mlY6coCifiIt6ZDhOZR3k31rM+Xf/MdZoHtIfqZDK7IInW+yaioJBk6Q6ODv7yPyPPzrpa/yEDcC1BwHDw4/0XDmGPx8nmcNmMeq723vPf4QF6QnuwOMwq3x3AL/ZjZVYVwobgghHOhK//+lt50eE1m8YZecdn3bxTze3TM2D64fc73oYkGLvrrrt45ZVXeOedd3C5XNTVRcfBU1JSsNvtKIrCwoULWbx4MSUlJZSUlLB48WIcDgfXX389AM888wwzZsxI+PTirFmzeOaZZ3j88ccPW5auni+v10tjYyObNm3CYrEwYcKEoy6/JCXSs/fmBIwzh4TTcvieiL9dU8TjXzfxk0OkeEm0rJLNJI/y0TrcjVDP1d57HvuBWi7nVLXv7nHsaQlxTmHi3JJpdhNPXDJskEslDYYhCcaeeuopIDpPq6fnnnsulqT7/vvvx+/385Of/ITW1lZmzpzJxx9/jMvlIhQK8dJLL8WWvTjYNddcw0MPPcQjjzyCxXLo4ayeT2uuX7+eV155haKiIvbv339M5Zekg/X8gjvVVt0/FsOTLfz6MPO7Eh1PufDl0Ttc+zT3MUx5cCw2zHVq9voerVO5p/xUN2TDlIejKAqLFi1i0aJFvV6zWCw0NfVe0bzLPffcwz333DNgZRmI35Gk+Hk4Q1iQb6BEw2rf0OxEg6LnJPdEegZj5rhgrPvaePW4ZP5wyck5Z06SBpu8XEnSIFHiesaGrhzfRInmjCWaBC0dmeJUCxtvG0PlT8cnfN3cY3S5Z89YzyOeajMNyNNu0uGtr/Ux4emdPPRV/VAXRTpK3+hgbOLEiTidzoR/Xn755aEunnSKURNM4JcGRqLgNhCRwdixmJRtI6+PITNnj2is52hwz2HKFl/8WkzS4f1mTSPnPr+nV+qlw3n860bKWkL85/J6OXJzkupXMHYkCbKFECxatIj8/Hzsdjtz585l27ZtCd/veCb4DofDXHzxxaSnpxMOhxk+fDi/+93v2LRpE5s2beKKK65I+DsPPPAAkydPJikpifz8fH7wgx9QUxOfTDYYDLJgwQIyMzNJSkriiiuu4MCBA/2qg9Q/h8ulN1gihmBH09HlAu0ZL8g5Y0cuGInmj/yiwtvnPomCsZ6TyQMRg/9cVsew32znq6rBzSH7TZRs6/7q6GuYsrZDBmP99a+f1LK62sevVzcefuceWvzdwVtXsnHp5NKvYOxkSvD9//7f/+O1117j6aefZseOHfzsZz/jrrvuwuPxMHr06ITpCXw+Hxs2bOA//uM/2LBhA2+++Sa7d+/uFbgtXLiQt956i1dffZUVK1bg9Xq57LLLeq2+Kw2MX65qIO1XW/nVqobD73yc3bWkmil/2s1LW9v6/buHmjO2orKDD/e4T5ig80ThDuo4H93Kk+uaufDlfbFEyQdLFNxGDMEbO9owL96C69GtPLSygQZfhGvf2H+cS/3N8NT6JmwPbeHfPquNJT3vktJjPa6up4RXVHbw04+6b1zreiQYlw6v52e/wt2/gKqivXv/NTW+Q+wpnaiOaQX+EznBd35+Pr/4xS+46667YtuuuuoqnE4nL7300hG//9q1a5kxYwYVFRUUFhbS3t5OVlYWL774Itdddx0ANTU1FBQU8MEHH3DxxRf3uw5HSwjBE+uauXJMMq0BnUZfhJJ0K5l2U9y6TT21+CNsrIsmbF2y18O6Wh9XjklhcraN8ZlWzh4eXfxQVaLzP1QlmojXYVZi6z91NZlARKAq0X00te/enoghomlMlGgKkLbO9EfukIECeEIGeU5TbEjEYY6mXmr167QEIkz6Y/cK7O9+dwTzR8enujKEQAHqOiJk2LVYeh6AA+4wWxsDTM62sbneT0V7iGk5dsZn2ugIG6gKBCMCq0lBAWo8EVJtGk6LSmGKGSGivS5dde9aIRtg421jmJBl7Twm0SEaQwgMAf6IQUfYwBc2WHXAR0GymZ99XMOuzlXLW++biNOi4Q3pLPqint+uiT6QclqunQfn5HDJKFfseEYMQZMvQqbDhElVEELwXpkbAUzItJGTFD3fqqIQMaLnRCE6Z8qqKXHrdgkh2NcWiqaiybWTnWTCpil8daCDjrBBcaoFh1nFYVLJ7UwE7wsb2Exq3HpSQkSzIOxuCeINGbQGdMZmWJmeY8feOXM+YgjaAzodYQNPyOD17W2k2jQ21/uZmGXj3rOyErYZIQQC2NYY4NJXy6n1xgdgV4xJ5pnLCki1aVS0h9jZFGREqjmunQCxPIyJvHXtCC4r6TtlWntA59P9XpZVeClINqMpCslWNVa34S4zo9IsOC0a7UGdLIcJq6b0WnxWNwTlbSGqPeFYO893mcl2mGL7hnXBF5VetjUGmTXcwWm5djrCBm2BaIJl7aCepwPuMJvr/dz7SS1FKWauHpfC/FHJDE+Ofn7e3e0m065xdkFS3HwuiAa3SeboOa31RnCHdEanWUmxqnHtZHmFl2+93J3R4MIRTp67oiD2Gf3PZXU81LnSftdK8GP/sJN9PXplzKqC5/5JaGq0XXpDBi6Lyt7WEK7O9Go5SSbManwb1Q1BUBfc+f4Bmv0Rzi1MYlyGjSSLijdkUJRiZky6FYdZRev8PHSEDZLM3XXQO9NEPbmuiYJkCxOzbFw8yhV7urPeG+aJdc00+SLkJJn4p3EpTMqyxY51xBC9jl0inqBOjTfM1oYAo9KtjEq14A0btAd0xmRY+XCPh0nZNopSLPjDBjubg+xrDZLrNHNGnh1r5xivEIKb3qnkte3dyeIXzckh1aZx4QgnRSkWgrpge1OADHs0EB6bYYu1n+Rflsaue3efkcHj86LLXwQjBiFd4AsbJFs17GYVvTODiUVTyO/xtOuLpa0sq/CycEYmkzsXtTaEYNUBH6UNASZmWUmyqBS4LJS3h1hR2cEZeXZKMqwEItFr0j1Lo8F4vtPE5zeNojjVEnduazxhNtRFr8OzhjuYkm2PHWd/OJrw3KIpqEr0HHS1Dd0QRAzBrpYgEUOQZjORYu1K6RdtAwcvEt7qjxAxoje+XddEVYm+98Y6P4u+qOfbo1386PSMI1pi53g7pmDsRE7wnZGRwaOPPsqtt94a2/b973+fVatWHXLZioN98sknzJs3j7a2NpKTk/nss8+48MILaWlpIS0tLbbf1KlTueqqq/iv//qvXu9xvHJTLq/0ccmr+9FEfI+cjkqqTcMXDDMu00azL0J7UCeCSiAieuViS5RLr2t7V345kwpJZhWHWaU1pOALRVB7TNcVKBiKihkjtoSDLgQoCmGh9ipjz/yAB5c9w2GizRfqtR0g3Qp/vHQ4l5WksK81yMOrmnmxtPWo6nS47V11UoWB0xwNON1Bo8+yH6pOKErc9lunpZGZZOX/NrbQnKCuI1MtzMyzsq0pyLbGQKyMDhMEwwe9f2fZM2wq7UE9FoDoihatvxAMc5kpSDazszlEc1CgCqNXHscjrVOKNZprMiKUhHW1aAouM3hD3Xkru85fovMxt9BBriP6xTCn0Mk1f6847HlymCDNplHrjSBQUFQVYfRdpztPS+dHp2Wy8OMaPq/swG7R+PKmYoY5zayp8VHa4OeJ9a1cNCqZ/c1+VlV3dB/Hvsp+0HanRaUw2YxQTUR0g45gmNaAjr9z7lrPOjktKpeVuGjs0Pmk0o8wuusazYsabXsuEyR1fl+aVYX2kMAd5ojbXkGKleEpVsKRMFXtYeo7hw4T1WlchhW7xcS6Wn/C85RqVTkrz0ZZa5Aad4iQcfjP07+elcHfd7RT0R6O+zwpPeqKomI2aWBEiBgi1maO5PPUfa2Jbrd2tr1AxOg+7p11tamC4lRL7IbAZ6hx14gsh4bTotEUhHZ/OJqT16JhiGjezv1ug4iuU5hsQgjwhQ1aAkavOvVVdrXzvHZtt5kUvj3KRWGqhce+bkEoiT9PB5+nru2zhzuYlGXhla2t+MLdbQwhuGiEg5AeDUh7no+Dz9Pk3CRCYZ1dzd0JvgUKuS4LdZ7QUV8jDj5Po9Is7G0N9aqTArEgO1FdVQUMRUM3juxablJBM5mIRAz0Ht+5idpez7JfMsLBy/9UGMvMMRS5KY/6URchBPfccw/nnHNObKX7rsVPD04blJOTQ0VFd+Jnt9vNG2+8wcqVKwG48cYbmT17Nr///e/7neC7LxdffDGPPfYYc+bMYdSoUXz66ae88847/RpKDAQC/PznP+f666+Plauurg6LxRIXiEG0jl31P1hZWRm7d3fftRcWFjJ16lS2bt1KZWVlbPuYMWMYO3Ys69ato7Gxe85AVwb5FStWxA33mgunMDbdSlHjWkzoOEwq/ojBcnUcnoCFi40tUA9dD5d/pE7BSYgL2YUCpNs1hKrhGzELd0sTrobteMPRBuzFxhfaeIaLFiaLKjCACDT6XRzQRlMi6ikR3fWtUjIoVQoZZxygQDR3113JpUzN4zSjnCy6y75dK6TJksWM4A5cRO92BLBGHUWTP5l5xjZMRM9VbpKJC8+fy8Nr2iloWMtzf9/EcwfVaY6xM/beETQ+1qaQiYcZxt7Y9l516tSIi7XaaMbSwEQ1OgE2pAsqOus0URygIHhQnZTedSpVCqhSMplt7MZJ9OJmUmElo/CaUpgT7K7TgQ3wijoOPxauNW3ljHwHeU4Tm+sD/Nk7joY2N+0tOxlO9Px11ckRdjO3s04WTcEtrHxGZ518ves00ug8T+1AO+QrGXjMRUzUD5Cn967TbK2CDMMdexIxUZ3wd54nJZkLjW2kmKO9cYGI4FPG4tctzAx39yCqCnyoTMHex3naWlGHw9iLG9i5Gmb3OE+nqwfISTJR5Q6TnpHJS20FjBb1lITqIARTutqeKGSySND2lDw+vSBAS9MW9qyBO1yCPTipDGfyL39+v7tOQFgdxQtbdObpW7io8zxZNYXW3GkkJyWRX/c13pBBSyD6WXtXTMIietQpAJFAZ9sT7l5tryF7GmZPPQX+cghAaym04sLQRjNFa2CCUo87FP38dX2eRoQqe7U9d4/PU2GymUp3OPF5Ata0j2KFO5l5+hYy6L72faGOI6JauZSt+Luin8bEn6dLRqfy0/JiTIE21L17GQuM5fCfp9Ginq0rNzMOGNejThMTnSeRx5n6vl6fp0ZzFt+z7yfo9+ILCxQFVoiRNBFte6aD6uTXLczo0fZSrCramNnsrHOT3bgZOldEOgeNpmEzuTQvQt3OjVR7w+CN1mmPNp4C0cLkSBV0fuc2+l2Eu657bfHXvX2WEYwMVsbVaY+Sy+4E14j9thE4MvPJrN+IGvLTsQN2ABnqqLg6JXcGKMs6rxEXG911guh52nyghZTKnZzbuS3ZZmF/9pnsOVCHed8mzMDFhztP9aMpMWq5+OBruTf+82RWFXaSwy4Ofd1L14KEOq8da3rWqVmnK5fN15bxpCQ5GN+6KRoWBbrr1Nc1outablGjvc+thqX7utezToaLtWI0JUZdwu+ng9veHjWX3eTRvHcLr75dSp4zGhL19Z07c+ZMsrOzY9O0usydOxe73c6HH34Yd57mz5+P3+9POC3qYEfdM3YiJ/iG6BDq7bffzj/+8Q8URWHUqFF861vf4rnnnsPn8/Hyyy/HDZt++OGHnHvuubGfw+Ew1157LZWVlSxbtiwWjL3yyiv88Ic/JBgMxv1/F110EaNGjeLpp5/uVcbj1TOmadEhuXZ/CJdFjQ0H+CKwsznIhhovOUkmgrrAHzZIspmZV+wi1RofpZtMJoQQRCIR2gI6NZ4ItR1hhqXYaPKGyUlSOeAJoykKKTYNi9mEhsBpVnCaVXQhMES0dyIc0YkYBroR7eK2WUwkWTQ0YSA670ismopJi94Nd9VJCMGu5iC7WiO0BHRM6MwpdBLWBaPSLJhMJrwhnYdW1PKbr5tivRbfGpnCOYVJtPiC/MuMbOo7wmQ6TKQ6LNHEzsLAokWPi0VTo8fdMPCH9NgK7boATTOhYsTORzBisLc1TKrDDIZOaYMfp0Xj4lf2YaDwxPwCbpzooj1gxLrBNVXFpGnoegRNUWJDu113R9P+uCM2TFmcamZPm86PT8/gobnZseEKgICu8M7udqraAozPtFKcaiXfZSYkVJp8YTqCEXKdJgqSo3WMoFHeGqDeE2JkupVmXwSrSSEv2UZ7IMK2Bh8f7nGT7TBx3ggXZxe60BDsbQnE8vHZLRomrft8BCMG7qBBSIDTYiIYClPjjdCVB1woGhOybGhCjxu+9oSh0afT5g+R5YgOPZs1BVWNDiF13QxtqvNT6Q6xpTHMxjofH+3pHp4Zl2HlF3PyQRhcNjp6EdtQ5+OMPAdWi5kXNjdzx3vRm5hfXpjHnadn8tcdbu74R2Wvu979P51Itj2+ve9tC/P9t6vYXt8919VpUWkPwcKZWQxLUvj26GRGplljnzPovus1hEBVFMIiOoRv16LDavtaQ7QHddrDClYNsmwKKVaNfJcZm0nBbDZjGAb+UIT3ytzsag6iCxib5eA745JRiQ7F7GsNkm43k+ows6fJT0g3cAd1bCYVq1ljUrYDYURiQ7zBiEFAhw31QcKRMLOGRVdv31zvx2w2sbslhEM1SLFpjEix4LKoJFnNuKzR3sT2gM4/ytpZus+DjsYtU9P5zt/2xnqovA9MxhOGv+1o4/N97QxLNuMJ6jy/pQ1d0bhpUjLbGvx4Qgb7uno/Duq1uGSUi7vPzMRuMXNmrpWQbmBWFfa0BBGKSltQ4A2G8IUN7v+kFotJ4Z3rRlKSYe913UNR8UcEvmCYkCEIhA2cFo1KbzRI9gTCJJlVxmZaMandn7+le9t4ubSVM/MdnJbrYGaBC1WJntdAxGBTnR93SCc9yUqRy0QgolPnjeAJ6YR1gcNqAcPApEaH/20mlYIUC6l2c+wa3xE20BQFi0mjyhOh1h2gzhvGGza4cISLYckWNE0jHA6zZK+H365pYkVVBzoqc4qcfFXhBmDLHWMYmWbtvMYLKtsCNPsiTMq2ETFgZ0uY696ooNbT/T104+RUnvh2EZf+dR9fVUaHRx86P5dRaVZGpNtp90eocQdRFYXiNAvugM7LOzz8amUdLovKvJFO7j0rG1/YYGNDCH8oglmFq8elYDNFv4MCOgRCYRxmFZOqEOhsewYqqZbo58IXNthc72d6npPfr2si1Qwj0yzkJpmxmhTGZkXXsAuFI5S1BClrCdLki3Dp2DScZpWmjmgbsptUwobApytsbfCTaVOYXZAUu95EUGnzRzAMgwPuEFlJJlTAUE0Ewzp2E7HgChQUVSMciaB33vhbNAWzpjL1z3vY0+zj1asLuawkBRianrGjCsYWLFjA22+/zRdffBGXl/FIhylnzJjBunXrUNXuLyDDMDjzzDP5+uuv+1WWvoKxLoFAgObmZvLz8/n5z3/Oe++9x7Zt2/B4PNTXd6/JMmzYsFgqo3A4zHe/+1327dvHZ599RkZGdxqWoxmmlAZWtSfMzqYAI1ItjEob3OSuXXPGHr8on7vPzOzX757xzG4210dvAz3/OhFFUeKCsFNZqz/Cy1vbCBuC26enH3YOx46mACNSLLE5XNWeMCN+vyNuHwUI/fuUPt/DHYzOsyxOtcinWw/yxNom/mVpDclWleZ7e+f4ffzrRu7/tBaAv1xRwA2T0jjgDlH8RLRX44ZJqdx9ZiYZdtMhc4r2pSvgPZV0hAxSf7UVgO0/GktJ+qGvbSHdYPGKBv73q+jcvd/Oy+cnZ/TvmiTBt/+6j6Xl3lg7Hir9GqY8WRJ892Sz2Rg2bBjhcJg33niD7373uwC4XK6EXYddgVhZWRmff/55XCAGcPrpp2M2m1m6dGnsvWpra9m6dSuPPvrogJVb6tswl3nI06wUpfT//+/51aKp8RPiT3VpdlO/gtvxmba4n3vOtS5wmajyRHjuioJDvkeyVSPZeuig71T1o9MzSLdrnFOQOEdiz8ntps6gqec2VVE4I+/Qq/gfyqkWiAHYzd11TjmCdmnRVH4+OzsWjFllLtaj4uq88XMHh3Y1hH4FYydTgu+vv/6a6upqpk2bRnV1NYsWLcIwDO6///4+3zMSifCd73yHDRs28N5776HreqyO6enpWCwWUlJSuPXWW7n33nvJyMggPT2d++67j8mTJ/Otb32rP4dTOgl99P1i1tb6D/kkXl9kOqTjp2f/4gOzc7huQiqpNhloHS2TqnD9IXoJenbodv37SJ4+lPqmKgrvf6+YjpBBdtKRfTXbTCpXjElmV1OQfxqbcpxL+M00JcdGa0AnJ2mIc4KKfiC62kGvP88991xsH8MwxIMPPihyc3OF1WoVc+bMEaWlpUIIIYLBoMjIyBCPPvpowvf/9a9/LTIzM0UwGDyqshQVFcVeX7ZsmRg/frywWq0iIyND3HTTTaK6uvqQ71leXt5nHT///PPYfn6/X9x9990iPT1d2O12cdlll4nKysrDllk6tc18drcw/e9mYfrfzUI3jKEuzjdKgzccO7Z/XN801MX5xvvzhqbY8X57Z5sQQohWfyS27eZ3Koa4hKcWQ15PTnrHtLSFJElH7uy/lLG2xg9A6N8mH9GkTunItPgj5Dy+HYAnLxnGHadlHOY3pGPxl80t3P5+NOvIO98dwbdHJ+MN6aT9Kppt5XsTU3nxysKhLKIknVTk7GFJGiTxw5QyEBtIcgh4cMXNGVN7zxmT9/iS1D8nZDAmE3xL30QyRjh+5HSlwWWOm8Df+XdcpoDBLpEkndyOetHX4+mDDz4gHE6c1+zgBWUl6WQhA4bjRx7bwdVzAn/XU8E9Hw7WDSRJ6ocTMhgrKioa6iJI0oCT8cLxcyouhTCUevaCdeUD7Dn0LhPeS1L/nJDDlJL0TSQDhuNH9owNrp5r5CVa0kJ2jElS/8hgTJIGiYzFjh9NHtxB1TMAMycIxnQ5aUyS+kUGY5I0SGTvzfEjj+3gipvAn+BbRMZiktQ/MhiTpEEihymPH1VOHh9U8SvwJximlMGYJPWLDMYkaZDI3pvjp+fk8YiMBI477XDDlHICvyT1iwzGJGmQyFhscIRlMHbcmRMs+tqTPAWS1D8yGJOkQSJHKQeH7Bk7/nq2ZYe599eIXNpCkvpHBmOSJH2jyGDs+PMGuyfmpdu1Xq/LeXuS1D8yGJOkQaLIgcpBEdZlMHa8pfUIwBIPU8pzIEn9cUKuwC9JknS0ClIsQ12Eb7ypOXZ+d3E+xamJj3WiAE2SpL7JYEySBomcM3Z8Lfl+McsrOvjB5LShLsop4cenZ/b5mgzGJKl/ZDAmSYNEfj0dXxcWu7iw2DXUxZCIT5ckSdLhyTljkiRJ0oBKtPaYJEl9k8GYJEmSNKASpUiSJKlv8iMjSZIkDYjvT0wF4L5Z2UNbEEk6ycg5Y5I0SOQEfumb7vkrCvjdxcNItfVee0ySpL7JnjFJkiRpQCiKIgMxSToKMhiTpEEiO8YkSZKkRGQwJkmDRA5TSpIkSYnIYEySBolMmShJkiQlIoMxSRokMhiTJEmSEpHBmCQNEpk8WZIkSUpEBmOSNEhkz5gkSZKUiAzGJGmQyGBMkiRJSkQGY5I0SOQwpSRJkpSIDMYkaZDInjFJkiQpERmMSdIgkcGYJEmSlIgMxiRpkMhhSkmSJCkRGYxJ0iCRPWOSJElSIjIYk6RBIoMxSZIkKREZjEnSILGZZHJKSZIkqTcZjEnSIHnykmGUpFv4v8uGD3VRJEmSpBOIIoScVSxJkiRJkjRUZM+YJEmSJEnSEDINdQG+6YQQeDyeoS6GJEmSJElDxOVyoSh9zxuWwdhx5vF4SElJGepiSJIkSZI0RNrb20lOTu7zdTln7DiTPWOSJEmSdGo7XM+YDMYkSZIkSZKGkJzAL0mSJEmSNIRkMCZJkiRJkjSEZDAmSZIkSZI0hGQwJkmSJEmSNIRkMHYS+8Mf/kBxcTE2m43TTz+dL7/8cqiLdNJatGgRiqLE/cnNzY29LoRg0aJF5OfnY7fbmTt3Ltu2bYt7j2AwyIIFC8jMzCQpKYkrrriCAwcODHZVTlhffPEFl19+Ofn5+SiKwttvvx33+kAd49bWVm666SZSUlJISUnhpptuoq2t7TjX7sR0uGN+yy239Gr3Z511Vtw+8pj3z0MPPcSZZ56Jy+UiOzubq666il27dsXtI9v6wDqSY36it3UZjJ2kXnvtNRYuXMgvfvELNm7cyLnnnsv8+fOprKwc6qKdtCZOnEhtbW3sT2lpaey1Rx99lMcee4wnnniCtWvXkpuby0UXXRS3bMnChQt56623ePXVV1mxYgVer5fLLrsMXdeHojonnI6ODqZOncoTTzyR8PWBOsbXX389mzZtYsmSJSxZsoRNmzZx0003Hff6nYgOd8wBLrnkkrh2/8EHH8S9Lo95/yxfvpy77rqL1atXs3TpUiKRCPPmzaOjoyO2j2zrA+tIjjmc4G1dSCelGTNmiB/96Edx28aNGyd+/vOfD1GJTm4PPvigmDp1asLXDMMQubm54uGHH45tCwQCIiUlRTz99NNCCCHa2tqE2WwWr776amyf6upqoaqqWLJkyXEt+8kIEG+99Vbs54E6xtu3bxeAWL16dWyfVatWCUDs3LnzONfqxHbwMRdCiJtvvllceeWVff6OPObHrqGhQQBi+fLlQgjZ1gfDwcdciBO/rcuesZNQKBRi/fr1zJs3L277vHnzWLly5RCV6uRXVlZGfn4+xcXFfO9732Pfvn0AlJeXU1dXF3e8rVYr5513Xux4r1+/nnA4HLdPfn4+kyZNkufkCAzUMV61ahUpKSnMnDkzts9ZZ51FSkqKPA99WLZsGdnZ2YwZM4bbb7+dhoaG2GvymB+79vZ2ANLT0wHZ1gfDwce8y4nc1mUwdhJqampC13VycnLitufk5FBXVzdEpTq5zZw5kxdeeIGPPvqIP//5z9TV1XH22WfT3NwcO6aHOt51dXVYLBbS0tL63Efq20Ad47q6OrKzs3u9f3Z2tjwPCcyfP5+XX36Zzz77jF//+tesXbuWCy64gGAwCMhjfqyEENxzzz2cc845TJo0CZBt/XhLdMzhxG/rMjflSezg1ApCiEOmW5D6Nn/+/Ni/J0+ezKxZsxg1ahTPP/98bJLn0RxveU76ZyCOcaL95XlI7Lrrrov9e9KkSZxxxhkUFRXx/vvvc/XVV/f5e/KYH5m7776bLVu2sGLFil6vybZ+fPR1zE/0ti57xk5CmZmZaJrWKxJvaGjodbclHZ2kpCQmT55MWVlZ7KnKQx3v3NxcQqEQra2tfe4j9W2gjnFubi719fW93r+xsVGehyOQl5dHUVERZWVlgDzmx2LBggW8++67fP755wwfPjy2Xbb146evY57IidbWZTB2ErJYLJx++uksXbo0bvvSpUs5++yzh6hU3yzBYJAdO3aQl5dHcXExubm5ccc7FAqxfPny2PE+/fTTMZvNcfvU1taydetWeU6OwEAd41mzZtHe3s6aNWti+3z99de0t7fL83AEmpubqaqqIi8vD5DH/GgIIbj77rt58803+eyzzyguLo57Xbb1gXe4Y57ICdfWj2n6vzRkXn31VWE2m8Uzzzwjtm/fLhYuXCiSkpLE/v37h7poJ6V7771XLFu2TOzbt0+sXr1aXHbZZcLlcsWO58MPPyxSUlLEm2++KUpLS8X3v/99kZeXJ9xud+w9fvSjH4nhw4eLTz75RGzYsEFccMEFYurUqSISiQxVtU4oHo9HbNy4UWzcuFEA4rHHHhMbN24UFRUVQoiBO8aXXHKJmDJlili1apVYtWqVmDx5srjssssGvb4ngkMdc4/HI+69916xcuVKUV5eLj7//HMxa9YsMWzYMHnMj8GPf/xjkZKSIpYtWyZqa2tjf3w+X2wf2dYH1uGO+cnQ1mUwdhJ78sknRVFRkbBYLOK0006Le4xX6p/rrrtO5OXlCbPZLPLz88XVV18ttm3bFnvdMAzx4IMPitzcXGG1WsWcOXNEaWlp3Hv4/X5x9913i/T0dGG328Vll10mKisrB7sqJ6zPP/9cAL3+3HzzzUKIgTvGzc3N4oYbbhAul0u4XC5xww03iNbW1kGq5YnlUMfc5/OJefPmiaysLGE2m0VhYaG4+eabex1Pecz7J9HxBsRzzz0X20e29YF1uGN+MrR1pbMikiRJkiRJ0hCQc8YkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShtD/D17NLmLrkmFUAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 600x120 with 1 Axes>"
       ]
@@ -451,17 +449,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAACDCAYAAADBExzWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAABUJ0lEQVR4nO3deXxU9b34/9c5Z/bMZN8hCQHCvrqAiCJqRanr1Vpbl2qvW1ul5apXe2+/98q993dxaatdtNr2qnWt2rrWBcUFFAHZIewBQhKy7zOT2c/5/P6YZJIhEyAQEpDP8/HgATlzMnw+53zmzPt8Pp/zeStCCIEkSZIkSZI0JNShLoAkSZIkSdKpTAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSdJx8bftbWyu9w91MSTphKfIROGSJEnSQFtR2cH5L+0FIPzvU4a4NJJ0YpM9Y5I0iF4sbaXod9tZX+sb6qJI0nG1uUH2iEnSkZLBmCQNon/+RxU13gg/fLdqqIvyjSSE4NlNLXxS7hnqokg9GHIARpIOyTTUBZCkU5EvYgx1Eb5RXtvWxoulrdw0OY07PziARVNoumcidrO83xwqSo9/e4IGKTZtyMoiSSc6GYxJ0hAwZEfBgLrxnUoAPtoX7REL6YIVVR1cNNI1lMU6pQX17kbeFtRlMHacCSHwhAySrfI4n4zkbaMkDQE5anP8bW8KDHURTmltAT3hv6Xj42cf15Dx622sk/NRT0oyGJOkIRCRXWPHXVlLaKiLcEp7c2d77N/tMhg77p5a3wzA/3xZP8QlkY6GDMYkaQjIOWMDxx9OfCzLWoKDXBKpp53N3ce/LSiDscGytSHA3UuqafVHhrooUj/IYEw6LiKGkE9QHUJHSAZjA6XBl/hLZ0Odn1e3tQ5yaaRE5DDl8dVzudBKd5g/bmjmzg8ODGGJpP6SwZg04Fr8EcY9tZNZz+1Bl8NxMT0DMF0elgFT1R5OuL0toHPTO1XypuAE0BaQNx/HU0eC3uG3drmHoCTS0ZLBmDTglu7zUtEeZkOdn9JGOYm6y11L5J3q8VDh7j03rOeyCl7ZCznoDk7s0i6HKY+rZn/i4ysT7Jw8ZDAmDbhdzd0BWFW7nETd5eWtbUNdhJPW/rYQIT1xUFXe2ruNjcu0xv7dKofIBt3BHeJymPL48gQTfzb299FrLJ14+hWMPfTQQ5x55pm4XC6ys7O56qqr2LVrV9w+QggWLVpEfn4+druduXPnsm3btoTvt3jxYjRN4+GHH+5XoWtra7n++usZO3YsqqqycOHCXvvMnTsXRVF6/bn00ksP+d5vvvkmF198MZmZmSiKwqZNm3rtU1dXx0033URubi5JSUmcdtpp/P3vf+9XHb7JNvZIDPzVgcF9zPr17W2c98IeqhL0lgyEZl+Et3a29/tpSHmHevS+quqg5A87ueSV8oSvb0yQiHpMencwJntljo47qNPcx3y8w9EPau8NHcd/MnkwYuANnZrn2tNHvd/d3Z5wu3Ti6Vcwtnz5cu666y5Wr17N0qVLiUQizJs3j46Ojtg+jz76KI899hhPPPEEa9euJTc3l4suugiPp3d6kueee47777+fZ599tl+FDgaDZGVl8Ytf/IKpU6cm3OfNN9+ktrY29mfr1q1omsa11157yPfu6Ohg9uzZhwwQb7rpJnbt2sW7775LaWkpV199Nddddx0bN27sVz0Gwom4RMKOpu6nqL6qiraNWm+Yz3qkqPnF57WYF2/h/bLueQ3VnjA//EcVzkdKMS/ewtl/KSPQz6cOb3i7kpUHfPzrJ7XHWIvEvvtmBd99s4KHv2ro1+81+XpfLOVcpiPz/JYWAL6s6uj1WkfI4MvK+O02k0JxqiX280AOUwYjBtsaA7ScAk+qzf7LHgp+t6PPgGzVgQ5WHehI2I4P/tjubD626QpCCP6yuYUHl9clvOaFdcHw3+0g7VfbsD20hW2d0yMaOyKsru7dbo6lHG0Bnb9ua2XZfu9h9//Nmkbm/3Ufv17dQLDzoBzqxuzVba1c8OJeShPk9XxrZzvX/n0/td7evV19tfG3dh59MLa2xseHe+LnnX1a7uHLSi/727pvdoUQvLWzHfvDW1iwpDq2PRgxaPZFCOkG7qDeZ73bAzpPr2/mopf3cu3f9x/xNV83BIuW1/FC5/XhZKeIY7hlb2xsJDs7m+XLlzNnzhyEEOTn57Nw4UIeeOABIBo45eTk8Mgjj3DnnXfGfnf58uXccMMNlJeXM2LECP76178yZ86cfpdh7ty5TJs2jd/85jeH3O83v/kN//mf/0ltbS1JSUmHfd/9+/dTXFzMxo0bmTZtWtxrTqeTp556iptuuim2LSMjg0cffZRbb72133U4Ws2+CNP+vJvvTkhl/mgXhoiuPO6yqNR6w7QFDKo9YarcIXxhg7KW6N9Tc2xkJ5nJtGu4rCrPbmohJ8lMfUeYM/IdnJHnwKRCjSdCilUl12kmxarismj4Igab6/28V+ahxR/BEDDMZea0PDuZdhPtQZ1frW6MK+d9Z2XFts0tSuLv14wg87Fob+kwl5n9C8bzj93tXP33il51nJJt4+EL8rCbVOo7wqyp8bG+1k9a52reG+r8JJlVpuTYyHWa+e2aptjv+h6YTI03jE1TyEoysaHOz+oDPv6+o43ythBOi8p1E1I5a3gSmQ6N3c1BLJqKzaTgNKtUuMN8tt+LN6iTbNOwm1T+uKE59v6/v3gYigJ2k4LDrNLQEaEjbKAqoBvgDulUtIUJRAwq3dE5dD39bEYmz21uoSTdynmFSZw/wklxqoUvKjv4VrGLWm+Y0oYADrOKP2xgUhUOuEPYTCqaGh2aeHlrK6k2jUBEYDerdIR0zKpCrtPMuYVJnJZrp8mvs6Kqg2FOE2l2E7oQfFXZQb0vwvlFTiZk2jBrCq2BCC1+HZOqcKQihiCsC7KSTGQ5TFg0hRpPmNaAji9sEIgI/BGDNTU+hIDxmTam5tgYlWbFG9LZ2xqizhsh1aaRZFaxmhQ0RUFTwaQqBCOCez+pif1//3NeLhcWO1my18Pu5iCf7vfQeFCgm2bT+MvlBVz5t/0APHf5cG6cnB57vaEjwivbWnmptJVaT4TpuXbMGtx5WgY1nghra3w4zCpmTSHNphHWBXvbQizd56G+s4fHYVa4eUo6cwqTcFk09rYGURWFPa1Brh2fyrQcG56QQWlDgGpPGEMIdBE9XhFDoBvRz2qzP0JQF1g0BVUBq6aSnWRiYqaNVJtGUDf4orKD8rYQFk2hoi1EyBC0B3SGJ5sJRAS6EBSlWBjuMqN1njt3MHr8S9KtuCwaI1It5DpN7GoOsrbGx7paH2XNIcyawph0KxOzrNjNKmFdENIFvojB419HP0v3npXFHdPTaQno7GwKoijw9PpmVld393pfPNLFvrYg5xQk8dt5w3hlWys/+qD7i9lmUmj4l+70VPvbQpQ2+KnxRmLXmv2dUxrynWYafBF8YYOx6VZCuuDNne3s6lyqZGy6lV+cm82141NRFZj5bBmb6uODvbOGOfjsxlE4HikFop/Rl68qZNbwJE7/v93UeCNMy7ExuyCJB87Oxhsy+NXqRr6s9BKMCPJcZhbNyeHB5fWsqYnWc0Kmle1N8culXDraxcY6P4UpFi4Y4aQoxcLcoiTcIYPfrmnipdLeT/PaTQo/nJrO7IIkluz1oCjR4/ePMjevbmuL7bfqh6NZUdWBpiicU5DEjGfLALBqCovPz6PBF2Zsho3zi5KY+ufduBMMVSrA2ltLmJpjp84bZn97CENAZXuo8xqo0dgRIaAbOEwqVZ4wFW0hFAWWVUSD2MnZNuaNdLGiqoOve5zza8en8OzlBdz3SW3cdXHnj8cS0gXnvbA3borA+Awr105I5fpJqYxKi/Zc72gKcMYzZYQOeqKpINlMcaqFjrDBeYVJnJnvwKQq/KPMTW6SiXS7xiflXj4pjwbEt01L58E5OezvrFdYF+xqDhLSBQIYmWoh2aqhKLC7Ocj/bWwhzaZxxdhkfGGDZIvGg3NyYp+foXBMwdiePXsoKSmhtLSUSZMmsW/fPkaNGsWGDRuYPn16bL8rr7yS1NRUnn/++di2H/zgB+Tk5PDLX/6S++67j8bGxrjXj9SRBmOTJ09m1qxZ/OlPfzqi9z1UMHbJJZdgMpl44YUXSE1N5fXXX+e2225j8+bNjBo1qtd7GYaBYXR/UBRFQdM0dD3+bkFVVVRVJRKJvxPta/vTG1v5l6W1aCL+y0jv7PDUMI5su6KBEAm3K8JARRx2u0DBUFRUYaD02G6gIBQ1roz/Pjub/++rRoSiYhI6628r4fLX9lPtCaOjUpRq4UBb/MX1RK/TobbrqKAoJ915OlnqZNFUTstPYlWVFwVBvtPEG9eOYOZzexGKSqpZ8If5w/i6xsfr29qp8+knfJ2+Secp32mixhthfkkyNpOJPS1+SnsMLR+vOhWmmKlsD8dtH5VmYW/nHMNv+nm6oiSZdztHHgazTv8+O5vFXzUcsk52k0IocoR1HaTztPSGkcwaHu2o6es7V9M0FEVJuB1A1/WE2xXl8EHeUeemFEJwzz33cM455zBp0iQgOpcKICcnJ27fnJwcKiq6ez3cbjdvvPEGK1euBODGG29k9uzZ/P73vyc5Ofloi9SnNWvWsHXrVp555pkBeb/XXnuN6667joyMDEwmEw6Hg7feeithIAZQVlbG7t27Yz8XFhYydepUtm7dSmVlZWz7mDFjGDt2LOvWraOxsbt3aerUqRQWFrJixYq44d7vzJhB5pUFLPvkY1p9QQIRgQLsTZmMbrIyo2Mj2UkmVEXBooJjwrnsa/QwvHkzjb4IAjCbTFRkz8DT2sj0yF72t4XITTLjwUpZ6hT8TTXM1A7gDup4QgatajIF409jjKjF0laF06zijwhqtAz+Up/FyGAlBaKZcRlWar1h1oWyKVPyOM0oJ4to2dd/CcOVAqqUTM42drP4L1uZFDKYBDx800WMH5HPhx9+iNsfYuUBH/vbQ6y1jKcwM5lZvo24rCpdc7mHnXYebq+f+m2rsWgKmXYTpc1h/hqaSCYeZhh7Y8fLp9hoyp7OOFMLZ6gHqPGEafLplAUdlFpLuDi5nXTfAUK6IBARhJzZjJs0hbS2vQSbawkbgk31fsqUXMqUPL6TUoMt2EYwYiAAb/pozGl5DG/ejCniR1HAZdFoSBvH07sEFxrbMNH9Yf1CHcel4zKZ6tlIrTdMky9Ce9DgI3UKdkLMFTtJtmhEDIFmMrHMMhWTv5UrHJVEDEGVO4wXGzPPmcNYrYWm8h20BXQiBuj2VPY6x1K2ezeT1HqKUy2EDYHblkWdcyQjAvvJDDVR6w3TETZocQxDZI6g2LMTU6AtVkZv2mgCzhzSajeiRbrvitszJxC2p5JWtRoMnaBu0B4wKE+dTE6qk5KWdZhUhYghUBUYd9YFWEWIPRtW0uzX8YYMFFWjYdhM6hsamKOWYxjRu1jdZKchZzomTy1GbVnssf1GXKzVRjNRbWC2o4k8pxmnWeWM8cWsMVJwV+6kQDSTHFDZtGIPo4WDMiWPksBeXnprEwDTgVKlgHpTFvPVvYx0RD8Hu1uCrFFH0aIk8z3rTjKsxMofGH4aDoed1KqvyU0ykWbXqHaH+dI6jX2NHsZ7t5Jmj15KazoM3hGTY20vyazitKhgcVCfPY1kfwPp7ftQlc4nPpPSsBVPxV9bjq09ugxHR9hgZySN5cFhTOEAM51uUm0a/rBBcn4xeSNKCO7fjKe1GU2Fak+E1pSRGMm5ZNZvQov40I3ovK0q1zh2BBxMaV9PuPMLJNNhInXcDPJTnVj2rcQTMmgL6BiAt+gsrEaIA6WrY8OBiqqx3DKNPNycrZRjUsFhUglodsyjzqSl7gBjwxU0+XXK20Kx8zRa1FMi6jg/zcnnbi8VuzMoVQuZbFRysWhGU6KBNBmFOPNHktKwjYC7BbtZxWVR0fLGUKmkkV67ESXsJ8thIifJxJeimGfK6PV5unDuXK6bmsODz7xBrTcCrTAeaBo2k+217cwxdkIzjAZyXVamnfst/nvJztg1Is9poigrlc+V8ewp389kURV77551Ot/ZzOyCJDwhg22hFFZGhjM2VIG3qbsHt+sacWNGLfNzI4QNwbpaP43OYiyZ+VRsXIldBGJtbI06iiaSE14j/Fi42NhCklnltFw7+9tDvKlPYkSSQVbDlti+ETQ+1qaQiYdZYi9Xm1LRaafNsPKFNp7hooWZWjUCsGgKblMy+51jmWZqoCBcQ9gAb0gnmJRD9qgJJDXvQXXXUd8RYV9biDIll3OnT2RiYDf7q+vZ3x5CF7DXUsRN507g408/x0mA9V/CxcAadRSv3ziNbSs/JdUC+1pDbGsK8EFkDP5ItE4AmXYTs4Y7uPmay1i9v5U3l3xKeVuIiVk2zCYTpamn425uJKlhO4LoaAoWB8vUcZg99ZSEKgh3ttWu83Rpehs5gWocJhVVVWizZrGBAor85YxUWgjpAqtJRaQX8rtyJ6cZ5Wz5qpy2ZPMhv3NnzpxJdnZ2bJpWl7lz52K32/nwww/paf78+fj9flyuw+fIPeqesbvuuov333+fFStWMHz4cABWrlzJ7NmzqampIS8vL7bv7bffTlVVFUuWLAHg6aef5sknn6S0tDS2z+TJk1mwYAF33HFHv8pxJD1jd955JytXroz7/15++eW4YdMPP/yQc889N/bzoXrGFixYwJo1a1i8eDGZmZm8/fbbPP7443z55ZdMnjy51/9/vHrGDo7ShRCx94a+o/SDt5tMJoQQCbcfXPa+tieqk24IHvyygS+qfPxpfh5/2tDMnzZEx/cT3WUtODODRy8q6HXnoRsCi9nUrzpVdxg0doQpcmlsbQigqQpn5juwW829yr6tMUBxuh2nWTlsnZyPlGKg8Ot5w/nx9NS4//NQ5+l/vqznze0tlLeFYgmUhaKy7+7x5Di6p24GIwYOq5mOkIFZMeK6zY/mPB3cxo5X2+u5HQ59np5Y28jPP6vj1asLuWp8xmHr5Hyk+3P79W3jGJFsIsncfVwUReHJ9a3869IDKAgmZtl48pJhzHlxH0JRybEDIvpU5ag0KzdPzWDhWdkII/p/hnXBVa/vR9VU3v/+SIwjbGOH2t7si2BSDJyW7qTN/f08KapKIBTBonXX9VjOU0V7iGEuMyb18NeIDTVeZv9lDwDeByb32fZu/aCGv5a28NuL8rj9tAwWr6iP9or06J3wPjCZj/e5eaG0naABp+dYuXVqOllJpqOu07paP3d/UEFJmoV/npbBzGEOHNboF+m9H1fxh3XRYbOzhjn45KYS/m9TCwuXRIOrf56Wxu8uHo7JZGJPS4APd7cxLdfOWcMcKIqCyWSi0RvixS3NTM2xc16RE0MILObe146en6eIbrC1McDjqxuYNzqVG6ek92pLXXXa3uDFHTA4I99BY0eEuz6q5Z+nZ/Cd16OB4fYfjaUg2Rz9DBuCqvYAw13mWA9L13l6fFUd//55Xez9u3qR8pNU9t49nhWVXpZVdDCzwMWYdAtFyfH9L0d6Le+5vet8lLcG2dUS5JxCF6l2M7b/7Z4znWHXeOd7ozgjP6nX+dvcGOQ/Pq/js3I335+Ywp8uLTjk91ZX26v3BHFZVKwmNWHZ9c4pAEk2S7++c+e/up/l5e08c/lwrpuQFneeBrNn7KiCsQULFvD222/zxRdfUFxcHNt+pMOUM2bMYN26dahq95eQYRiceeaZfP311/0qy+GCMZ/PR15eHv/93//Nz372s9h2j8dDfX13Dq9hw4Zht9tjP/cVjO3du5fRo0ezdetWJk6cGNv+rW99i9GjR/P000/3q/ynkrAuYnM4AL4/MZVPyrvn/Gy9cwxjM2xDVbwjYl4cvZt76cpCrpuY2u/fH/abbTR01vfVfyrkmvH9f4+TXdcxtJsU3Pf3vnnpa3+A8L9PSbjPk+uaWPhxtGfizHw7j12Uz7nPR7/YHr4gl3vPyj7WYp9yvqz0kp1kOuRnsuvcZNo1av9lIutqfcx6bk/cPn2ds+Ol2hPmf1fU809jU7hoZLRH4u1d7Vz7RnR0puXeibis2qHeYsgs3efBFza4cmzKEe2vG4IXS1u5/f34NQxL0i1s/9G441HEPp37/B5WV/tQleh83aGcf9Uf3/n7ft7Z7eaJS4Zx52kZQ1aOfg1TCiFYsGABb731FsuWLYsLxACKi4vJzc1l6dKlsWAsFAqxfPlyHnnkEQBKS0tZt24dy5YtIz29e1JtW1sbc+bMYevWrbFhz4Hw+uuvEwwGufHGG+O2u1yuI+o6PJjPFx2q6RlIQjQCPviOV4pn1hRK0i2xBM4RQ/DU/OH895f13Dcr64QPxABeuaqQFVUdfGf8kV0sD9bzzifRqtmnEn9k4J4m7fnQgd2kxj3NJ1NPHZ1zC52HfD3cY9J1V67VyVk2Uqwq7X2sezUYhrnM/GH+8Lht5xc5yXaYmDHMfsIGYkAseDxSmqpwy9T0XsGYyzL4dXz16iI+3ufhxklpJ00gBuC0RB/aGuqVCfoVjN1111288sorvPPOO7hcrtgcsZSUFOx2O4qisHDhQhYvXkxJSQklJSUsXrwYh8PB9ddfD8AzzzzDjBkzEj45OWvWLJ555hkef/zxw5ala/0vr9dLY2MjmzZtwmKxMGHChLj9nnnmGa666ioyMo4s4m1paaGyspKamuhddtc6arm5ueTm5jJu3DhGjx7NnXfeya9+9SsyMjJ4++23Wbp0Ke+9994R/R+nsv8+L5fvvxWdJ3ffrCxOy3Uc8V3gieDaCalcOyH1qH+/Zz90X6tmS/E+vn4kt7xbyZMHfcH21GMkD7tJxehxYW0bwsDgm6zn+m2+cPQJzxSbxqc3juKMZ8qGsGS9pdg0yheMw3wSBQn98fH1I7n01fLY3KnytsFfbHuYy8wPp6YffscTzLOXF/CXKwqHuhj9W2fsqaeeor29nblz55KXlxf789prr8X2uf/++1m4cCE/+clPOOOMM6iurubjjz/G5XIRCoV46aWXuOaaaxK+/zXXXMNLL71EKHT4hjR9+nSmT5/O+vXreeWVV5g+fTrf/va34/bZvXs3K1as6NdyE++++y7Tp0+PLQ77ve99j+nTp8eGH81mMx988AFZWVlcfvnlTJkyhRdeeIHnn3++1/8v9XbNuBRW3jKa8rvHcVquY6iLM+h63ns1HuWCmqea80c4qfjpBC4r6fvhnvieMYUNPZ7Wk1kgjg/3QYvpbu1c22tqjp0sx4nX+2TR1COau3MyOn+Ek39cNyL2s8w6ceTUE6RN9HuY8nAURWHRokUsWrSo12sWi4Wmpqbev9Tpnnvu4Z577hmwsowZM6bfK5/fcsst3HLLLYfcp6SkhDfeeKNf7ytFKUp0Iv2pqmdPeNMpGozZTAqBARyiBOKGRWxmNW7R3/0yGBtwn5Z7eq0NtbHOz+yC6NIA39QeqBNZzwc9zik4/Fqa0onlqJe2kCSp/3p+fSValf9UkO0wUeke2Jx5ph59/GZVYXSahT2d60kN9P91qqj1hvGFjdgCnV2+qurgkr/2Tk3Vc1FjsyaDscHW85jffcbQTUSXjs4JmSh84sSJOJ3OhH9efvnloS6eJPWbJ6jz8FcNcQmTK49T/swTXdeSBhBd12htjY9//aTmmPIKaj2GGlQF5o/uHtJs8eu9htSkwyv83Q7GPbWrVzqkN/tIsbOh1ocQggeX1xEc4J7PgXTAHTphU5Htbwvxy1UNtB/FMGPPnrGuDCXSyeOE7Bn74IMPCIcT380evKCsJJ0MHlnVwCMr49NElbUEMYQ4YeYsDBZbjy+Nak+Y+X/dR3vQoNYb5qWrio7qPXvOGVMV8B/0pGpFe4jJ2faDf21ACCFi6ai+ibY3BeKerNzdEp8SaEy6hd0tIXY0B/lgj4fF/czbOpie39LCbe8d4OqxKVw5NpnvTkg9ZPovIaKLKxckmwdlvtm8V/ZR3hZiS0OAF6889KRyQwjeK3MzNcdOUYoFS48n/FNkMHbSGZKrx0MPPcSZZ56Jy+UiOzubq666KvbUIkBRURGjRo3ipZdeYs6cOUyePJnbbruNYDCYcDmKxYsXo2naIZN7J1JbW8v111/P2LFjUVWVhQsXDkj5JaknQwh+v7b3XElfWFDtGdghNCEErSd4EuuecdLe1lBsGYTXtved1NgfNg45/7PnMKWmKPgPSja846CcggPpln9UUfC77WxJkNz5ZNWz56hnEmpPMJrntKeSdCvFqRYMQSyP44nqd525a9/c1c7N71bxLx/XHHL/36xpYtSTO3lqffMh9xsoXU9Bvrv78Am+//uLeq75ewWjn9zJnpYgw1zdfSs20zfzxuCbbEjO2PLly7nrrrtYvXp1LK3AvHnz6Ojo/pA/+uijPPbYYzzxxBOsXbuW3NxcLrroorjUBF2ee+457r//fp599tl+lSMYDJKVlcUvfvELpk6dOqDlHwy6IXhsdSNbGwL9flABGLB1VdxBnbuXVPPhHnef++iGYGOdnz+sa2JHU6DP/YQQfFYeTULe9bMQgiZfhD0tQTbX++OG+gDaAjr7WoOxY9AW0I/b2lJbGvzMeq6Mpft6t8O+fLzPgy8cf6ytnb1D2xr7Phb9sbHOz2vb2rj01XKyH9/OdW9U8Pu1TUcUmAkhMEQ04bc/bCRsF7oh2N8WIqQf+ri2+iPsbAqwoc5HWI+eO3/YiBsmDPd4/3UHfXlXJphsv7s5SMavt5H6q6386IMDccNmQgh2NgX4tLz7fIQNEXuazGmJXuKWlic+X/6wwcKPqxn+2+385MMDfFnp7VWfsN77eJS1BFld3cHWhgCvbG2jPWhwxWv7EULQ0BFhyV43emc9gxGDr6t9lLUEE75Xl/aAzsf7PLywpaVX+w3rAs9BQ62BiHHI9zv499fW+HiptJWtDYHDDtP1bAM13u4bhpe2tsYFZxBdSuSSUdGb5E31xx6Q6oZgQ52PP21oZsle91Fd2yDaNlZUdfDkuiY8QR3dEGxpiP+8Pbu5pdf1pEtYF9z/afRBkJ99XNNr6HB3c5CXSlspbfD361rqCxsEO28W2gI6H+5xx37u3qf7/UK6we/XNvFfX9TFrovlbSH+t0cP5PT/202tN8J5hUmMTbdSkm4hpBu9eoiPpz0tQVZUdfRqp4dzDOmx8QR1vq72sbVhYK6jQ+mYEoUPlMbGRrKzs1m+fDlz5sxBCEF+fj4LFy7kgQceAKKBU05ODo888khcGqPly5dzww03UF5ezogRI/jrX/+acA2zwznShONHUv6DHa90SMsrfVzy6v5YSqEJWTZMKqTZLZhVBasq8IUNWoM6TrOKjoohBMIwaPJH2Nc5wXlCThLpVpXCZI16bzSPGgpUuA0KXBqGblDf+QVoN6s0BcCEQb7ThN2ksrzSG5eI9ZapqYxMsbCrJcjWxiAbG0K9ksWeNTyJ0/OdpFshJ0njV6ub2N8WQigqBgouk8EvZufwq9WNtAb0Xklkx6Rb+edpaby2w8O6Wj8aBul2jVa/jgAUTWNkiplaT5DhLgvFqRY+2udBVzTSrArZDpV0mwmzqhAwDDKTrHgCEVQEhiEwAE9YYKBS4NIIhHWa/DrbGwOxVE7/NDoJp1XFHzao8UQoaw0RFAroOooSDbgy7Cb2tEUIC+KOwflFTj6p8HHnaRn85qJcIPrF//r2Nv6208P6Oj92TeAOGkzItDIxy8qedoOiZDPJFsH/zs1jXa2fP25oZnNjmGp3sM+EuRMzLeQ5zTjMKrdMS+eC4hSq2gI8ua6Rd3e5qeuIxKWnSrdrTM6yU+kOIVA4u9DFqko35W0hzKrCyDQL25vDoCh8Z0wSEzJtVHvDrKzysaMlHHeeNAV0EU0CXJBsxqaJWLsDOLswmS8rvbH9/2tODvfOyo6lcvr79lZufrcqrk65DpWFZ2ZwwBPijR1u6n16XBLgSdk2DAFbG4MsPCub362uJ8OusfPH47Cbo5+l/1nRwENf1tJTz8TG5xQk0RbU2doQQEfl26Nd2FVBjTdCjTfMAXc4YWLjH52eTrVX8PaudjQMVv9wNGd1rkivKxopFpiZZ6c5oOPQFAwFZg53sbclwHs9ekMECucUuajzBKn3hmMBUJrdxLgsB75giC31AawmhRn5DsZk2slwmDF0nYr2IGZNoTjFQkmmgw11fv68viHuC15HZWKWjVQLOMwqJlXhgCdMaWMIp0XFH+q+1qRYVe4/J49NtX7+tr2lVxv73vhkfjgllW+/Wo7DrOALi7h0SFeNSWZdrZ/ajgghoVKcrDEpy0pHSLC3LciwZAvFaTYmZZqp84Z5a6ebak84rk1OyLIRiBjMzLcTMlSSbSYcmoFZU+gIGRxwh/FGok8rp1oUXFaFdbV+9rSE0FEZk27hO2NdPLKqMa7sCMGTF+fyz9OiE96X7HXzwlY3a6s7qPXE3xgUptlZfF429d4QH+718Gm5F6PzumdXBecUODgtL9r2mgMCl9XEjvoODnii5y/TobGxPhirU26SibqOSOx8DE+2UOvuDioKU8yoqsbe1lDc5+nAzyaw4ONaXtveTooluqhx15nNcVm5eXIqX1Z4WFXtI82mcdeZmZRkOPAEw1S3B9nVHOTdMjfnFDiJoLK3JYAwDOo6IoxMs6B2poRSDkqqrSoKWU4L4UiEYERgNymk2zQK06w0+AxeLY3vPbSZTfz4jEzM6AxzmdlY72dLQ4BdLWF0A9Ks0R68Gk+YsCEYmWbHaVWJ6Dq+sMFwl5lkq4bFbMKiAkKnqj0SnRNaksw7ZV5WVXnjrntOi4rTZmG4UyPFomDRon8iKPgj0e9imwbJVpUWv84BTwSL2cTYNBN//PawaK5UTqJ0SANtz549lJSUUFpayqRJk444rRLAD37wA3JycvjlL3/JfffdR2NjY9zrR+pYgrGDy3+wXbt2JUwUvnnz5oSJwlevXp0wUfiyZcviegbNRVN4rFTHvG9ln8lle+pKQD3H2BnbFksuK9xxSbW92PhCG0+B0ZQwYW6JUUuJ6M6JVqV0JwEuEN0fyjIllzI1jzP1PbFE4RBN1lylZjJH34GT7gvQGnUUTUoy8/QtCes039hCz3u9k6VOKemZjGpaF6vTOQVJLK4uwG6389vi/extDbK+zk9IF0ddp3MsNWQnmUi2qBzQnfzVXUBBqGbQz5OhWZkb3kxPfdVpuWUqrkh7rE6qAt+ekEvupLN4ecUO/NXdw/+HOk9VjhEU+PZTIJoxKdGL33aRw+t3nMcDz3+EKdDG9Bw7U3Js3Ffq7FWnFKvK0nDxIdveN+HzpCrRgOVY6pTnNNEeMGiIWPhCG8+txUEuddbx+vY23CFjQOpkVhXaUkexvN3V72tEf+s0Vy3njHw7Fe1htrWr/TpPDaZMNlLABP34Xvd61mlKto1fNo3BQYjHSmpxmBU+2++lyitO6LZ3rOeprzpNFVWx74RjqdPNoxXyndGh3r6+c7sShX/44YcnTqLwgSKE4Morr6S1tZUvv/wS6E44Xl1dTX5+fmzfO+64g4qKCj766CMA3G43eXl5rFy5kqlTp7Jp0yZmz55NbW0tycl9LxCZyNEGY4nKf7DjnSi8zRfk430eajxhDBG9O4oYglA4QkfYQEEh12lC0zQ0VUEROnaTSppNQ1GgukOwozGANxhiuMtCqk1DIGgJKui6gUUV0TsWQ5DlMJHe2YtU1R7gwz1earxhRqZZOb84mbXVHaTZFHY1BRmbaWXmMCcum4mWjiDnFTrJcJjY1xpkyb4Ovq7xI3Sd1oBOSBd8daCD/zk/nxynmTv+URGr5+3T01l84TCSzCq6rvPTj6p5bnMrBclmMpMsfKvYxU/PSOOAJ4w7YFCUakYzmdhY6+OH71RQlGrhtmlp+CMwLS+JfKdGrTtEXUeYsNGZ1kXVCIZ1MuzRXgJNgYgAdxgUYRAMG9R7wzy8qhEDhXGZdm6dkkrYiB5Lp1VjmMtCst2MoUdwmFSCusGOpiB+XeGa8alMfmp7bPhs24/GcvnrFZS1hOJ6VoYnmzm/OJkfTEnn5S1N/GVzKwA/Pj2dSblOlu338rdt3b0TU3JsnDHMxb0zM3slAdY0jbU1HWyr91HtCfNumZu9rWHcYVCFQVGKifvOymL+6GSsJg2zFj2+m+p81HVEeGeXG09YcG6RizGpGnOLnLhDBl9Uenlzl5cl+7xYFT2WemhEqoU/XVbIuYVOAqEIe1uDmFQFp0XFHYb1tX4qW/0YAq4cm8KMZ8tivRNW1WB6roO1ncOWXT0rZkXQcyRu5a1jeXNHK6urOshN0hifaeOH0zLY3Rrh4pf3xN3JGyg03juZX62s45erGuK2d/VOPHv5cE7PdTAq3UpAV/j3ZXX4giFqPRHGZ1k5v8jJ33d5WbrPQ1NHtKfk3rMyuXpcKtPykvjpkmoq24I8dlEen1d4+elHNbE69TyvH98wklkFyTy7sYmvq72cP8LJnuYgH5V7qfIYzBuZxA8mpnBukZNqT5gtDQE+Lvfx2tZmbpuexvlFToa5zDT6DRp8BiZ0xmXYiBjRobgVB3x8UeVn/kgHY9OttAd13t/jwR0STMt1cO04J1eOSUFTFUK6QZ1PsL0xQHV7ALOmoBuCTIeJHS1hxmXYeH5TEx91DsXfMjWNoNCwqvDtUUlcPNLF9P/bzb7WELqiccuUFJ66ZBivbW/l1n8ciDt/KoLF5+di1RRcNhNjMx1UtwfY3xZkeUUH03Ns2C0mdBS21HZg0eCfxkVzSjosJvwRWHPATa03zI6mIIGIgapqGCjsavRh1RRGpJpxmlWGpdroCAne3N5CyBAUuMw8Ni8fTdO44MW9lLcGSDKr3HdWFisP+Hjg3DzOf2FP3HkCuGFqJhPSLZw93M7SfR4uK0kmyaLyy69b+GyfmxpPiPmjXPzb7GxOz09CKCorKtwsWl6HN2ywsynAsGQrF41KYVqWmUyHhtOsUtEe5qNyL2cXusi1KxhCMMxlwWFWWFUTZGKWjUtfifai5iSZKE61YDWbuGpsCt8qsvOPMncsKbiOyjkFSSy9fgQQ/R56an0zL25zMyHTyshkjQZfhDS7xqa6AD5dJcUa7TU0aQreoMHkHDsj0uy0+MJk2VVaAzopVo0cpxkUFcPQ41KGdESgLSTQRPR6vb7Wx7bGIC0Bg8k5Dr4z1sllJcnUd0S46OV97GmLcG6hk1SLoCMkmJRtZVKWjTFZDtJsGt5AmEZfhHyXmfqOCIqqEdYFJsVAiOii2IGIQUhoBCI6Hn+YiBD8enV03t+EnCRevnI4JWkW2gM6u5qj7cNpt3CgLYg3FJ1iENQNFEXFaTOjCp0WX4QWfwSHWSXNYebHS2rRhM5zlxfEsquckj1jd911F++//z4rVqxg+PBoupOuYKympoa8vLzYvrfffjtVVVUsWbIEgKeffponn3yS0tLu5NOTJ09mwYIF3HHHHf0qR6Jg7Msvv2T+/Pmxn//4xz9yww03HLb80rH7p7+V816Zh0cuyONfZmbGNeaIEX3CqTjVMujlKvzddmq9EdbfVsKUfj6dl/f4Npo6UyDtXzCePS1Brv77ftxBg2EuM/82O5vbpqUfNq9bW0DnjZ1tTM+19zuLgSEE2xuDZDo0cp3mfv3uoexsCjAyzRLr5j8Sc1/Yw1cHuueMHfjpeC5/fT8bO9ermj3cwVPfHs6UP3X3KveVdPrLSi8XvLSv13bfA5MRCE7/vzJ2NndP4l9wZiaPXZTfa/9DEUIc8qIqRDRp8zu73VxU7OK6CSn8v2V13H1mJuMzT/y8qz11PXUIEPq3yb3qPfmPu2LH87Zp6Tz17ei17z+W1fHwyvinKQc7UXgiNZ4wT69v5vIxyXGLTl/+WjlL9kaDTqdF5Y1ririguP85iwdKV+L1/5qTw7+fE79yQLMvQtHvdxDsvDtJtM+p4G/b23i3zM1vLsonw3HsC0J8780K3tjZzuMX5XP3mZkDUMKjM6RLWyxYsIB3332XL774Ii6Qyc2NzqGpq6uLC8YaGhrilrZ49tln2bZtGyZTdzUMw+CZZ57pdzCWyBlnnBHLgQm9l9Xoq/zSsXvzOyMwBAkDE5OqDEkgBrDhtjHUeMP9DsQgvi6qAucVOdl251iqPWGm59qPeImLVJvGrdOOblFHVVGYlD3wgcG4owg2/vf8POa+GB16+N7EVHKcZtb8c0mst7g/Swkkaiea0rUQpkLpnWP5tNyDqijMHObAcRTLUByuPIqi8IMp6fxgSnd+vkPl0zyR9WyLierdczmInv+elHViBp35LjP/PTe31/bXri7ivTI35xYmkWRWST5BkogHEzyYkeEw8d0JqbxYGu0t729S8W+KY80PfLALi52k2TQmZFoPv/NxNCTBmBCCBQsW8NZbb7Fs2TKKi4vjXi8uLiY3N5elS5fG5oyFQiGWL1/OI488AkBpaSnr1q1j2bJlpKd3X/za2tqYM2cOW7duTTh/qz/sdjujR4/ud/mlY6coCifiIt6ZDhOZR3k31rM+Xf/MdZoHtIfqZDK7IInW+yaioJBk6Q6ODv7yPyPPzrpa/yEDcC1BwHDw4/0XDmGPx8nmcNmMeq723vPf4QF6QnuwOMwq3x3AL/ZjZVYVwobgghHOhK//+lt50eE1m8YZecdn3bxTze3TM2D64fc73oYkGLvrrrt45ZVXeOedd3C5XNTVRcfBU1JSsNvtKIrCwoULWbx4MSUlJZSUlLB48WIcDgfXX389AM888wwzZsxI+PTirFmzeOaZZ3j88ccPW5auni+v10tjYyObNm3CYrEwYcKEoy6/JCXSs/fmBIwzh4TTcvieiL9dU8TjXzfxk0OkeEm0rJLNJI/y0TrcjVDP1d57HvuBWi7nVLXv7nHsaQlxTmHi3JJpdhNPXDJskEslDYYhCcaeeuopIDpPq6fnnnsulqT7/vvvx+/385Of/ITW1lZmzpzJxx9/jMvlIhQK8dJLL8WWvTjYNddcw0MPPcQjjzyCxXLo4ayeT2uuX7+eV155haKiIvbv339M5Zekg/X8gjvVVt0/FsOTLfz6MPO7Eh1PufDl0Ttc+zT3MUx5cCw2zHVq9voerVO5p/xUN2TDlIejKAqLFi1i0aJFvV6zWCw0NfVe0bzLPffcwz333DNgZRmI35Gk+Hk4Q1iQb6BEw2rf0OxEg6LnJPdEegZj5rhgrPvaePW4ZP5wyck5Z06SBpu8XEnSIFHiesaGrhzfRInmjCWaBC0dmeJUCxtvG0PlT8cnfN3cY3S5Z89YzyOeajMNyNNu0uGtr/Ux4emdPPRV/VAXRTpK3+hgbOLEiTidzoR/Xn755aEunnSKURNM4JcGRqLgNhCRwdixmJRtI6+PITNnj2is52hwz2HKFl/8WkzS4f1mTSPnPr+nV+qlw3n860bKWkL85/J6OXJzkupXMHYkCbKFECxatIj8/Hzsdjtz585l27ZtCd/veCb4DofDXHzxxaSnpxMOhxk+fDi/+93v2LRpE5s2beKKK65I+DsPPPAAkydPJikpifz8fH7wgx9QUxOfTDYYDLJgwQIyMzNJSkriiiuu4MCBA/2qg9Q/h8ulN1gihmBH09HlAu0ZL8g5Y0cuGInmj/yiwtvnPomCsZ6TyQMRg/9cVsew32znq6rBzSH7TZRs6/7q6GuYsrZDBmP99a+f1LK62sevVzcefuceWvzdwVtXsnHp5NKvYOxkSvD9//7f/+O1117j6aefZseOHfzsZz/jrrvuwuPxMHr06ITpCXw+Hxs2bOA//uM/2LBhA2+++Sa7d+/uFbgtXLiQt956i1dffZUVK1bg9Xq57LLLeq2+Kw2MX65qIO1XW/nVqobD73yc3bWkmil/2s1LW9v6/buHmjO2orKDD/e4T5ig80ThDuo4H93Kk+uaufDlfbFEyQdLFNxGDMEbO9owL96C69GtPLSygQZfhGvf2H+cS/3N8NT6JmwPbeHfPquNJT3vktJjPa6up4RXVHbw04+6b1zreiQYlw6v52e/wt2/gKqivXv/NTW+Q+wpnaiOaQX+EznBd35+Pr/4xS+46667YtuuuuoqnE4nL7300hG//9q1a5kxYwYVFRUUFhbS3t5OVlYWL774Itdddx0ANTU1FBQU8MEHH3DxxRf3uw5HSwjBE+uauXJMMq0BnUZfhJJ0K5l2U9y6TT21+CNsrIsmbF2y18O6Wh9XjklhcraN8ZlWzh4eXfxQVaLzP1QlmojXYVZi6z91NZlARKAq0X00te/enoghomlMlGgKkLbO9EfukIECeEIGeU5TbEjEYY6mXmr167QEIkz6Y/cK7O9+dwTzR8enujKEQAHqOiJk2LVYeh6AA+4wWxsDTM62sbneT0V7iGk5dsZn2ugIG6gKBCMCq0lBAWo8EVJtGk6LSmGKGSGivS5dde9aIRtg421jmJBl7Twm0SEaQwgMAf6IQUfYwBc2WHXAR0GymZ99XMOuzlXLW++biNOi4Q3pLPqint+uiT6QclqunQfn5HDJKFfseEYMQZMvQqbDhElVEELwXpkbAUzItJGTFD3fqqIQMaLnRCE6Z8qqKXHrdgkh2NcWiqaiybWTnWTCpil8daCDjrBBcaoFh1nFYVLJ7UwE7wsb2Exq3HpSQkSzIOxuCeINGbQGdMZmWJmeY8feOXM+YgjaAzodYQNPyOD17W2k2jQ21/uZmGXj3rOyErYZIQQC2NYY4NJXy6n1xgdgV4xJ5pnLCki1aVS0h9jZFGREqjmunQCxPIyJvHXtCC4r6TtlWntA59P9XpZVeClINqMpCslWNVa34S4zo9IsOC0a7UGdLIcJq6b0WnxWNwTlbSGqPeFYO893mcl2mGL7hnXBF5VetjUGmTXcwWm5djrCBm2BaIJl7aCepwPuMJvr/dz7SS1FKWauHpfC/FHJDE+Ofn7e3e0m065xdkFS3HwuiAa3SeboOa31RnCHdEanWUmxqnHtZHmFl2+93J3R4MIRTp67oiD2Gf3PZXU81LnSftdK8GP/sJN9PXplzKqC5/5JaGq0XXpDBi6Lyt7WEK7O9Go5SSbManwb1Q1BUBfc+f4Bmv0Rzi1MYlyGjSSLijdkUJRiZky6FYdZRev8PHSEDZLM3XXQO9NEPbmuiYJkCxOzbFw8yhV7urPeG+aJdc00+SLkJJn4p3EpTMqyxY51xBC9jl0inqBOjTfM1oYAo9KtjEq14A0btAd0xmRY+XCPh0nZNopSLPjDBjubg+xrDZLrNHNGnh1r5xivEIKb3qnkte3dyeIXzckh1aZx4QgnRSkWgrpge1OADHs0EB6bYYu1n+Rflsaue3efkcHj86LLXwQjBiFd4AsbJFs17GYVvTODiUVTyO/xtOuLpa0sq/CycEYmkzsXtTaEYNUBH6UNASZmWUmyqBS4LJS3h1hR2cEZeXZKMqwEItFr0j1Lo8F4vtPE5zeNojjVEnduazxhNtRFr8OzhjuYkm2PHWd/OJrw3KIpqEr0HHS1Dd0QRAzBrpYgEUOQZjORYu1K6RdtAwcvEt7qjxAxoje+XddEVYm+98Y6P4u+qOfbo1386PSMI1pi53g7pmDsRE7wnZGRwaOPPsqtt94a2/b973+fVatWHXLZioN98sknzJs3j7a2NpKTk/nss8+48MILaWlpIS0tLbbf1KlTueqqq/iv//qvXu9xvHJTLq/0ccmr+9FEfI+cjkqqTcMXDDMu00azL0J7UCeCSiAieuViS5RLr2t7V345kwpJZhWHWaU1pOALRVB7TNcVKBiKihkjtoSDLgQoCmGh9ipjz/yAB5c9w2GizRfqtR0g3Qp/vHQ4l5WksK81yMOrmnmxtPWo6nS47V11UoWB0xwNON1Bo8+yH6pOKErc9lunpZGZZOX/NrbQnKCuI1MtzMyzsq0pyLbGQKyMDhMEwwe9f2fZM2wq7UE9FoDoihatvxAMc5kpSDazszlEc1CgCqNXHscjrVOKNZprMiKUhHW1aAouM3hD3Xkru85fovMxt9BBriP6xTCn0Mk1f6847HlymCDNplHrjSBQUFQVYfRdpztPS+dHp2Wy8OMaPq/swG7R+PKmYoY5zayp8VHa4OeJ9a1cNCqZ/c1+VlV3dB/Hvsp+0HanRaUw2YxQTUR0g45gmNaAjr9z7lrPOjktKpeVuGjs0Pmk0o8wuusazYsabXsuEyR1fl+aVYX2kMAd5ojbXkGKleEpVsKRMFXtYeo7hw4T1WlchhW7xcS6Wn/C85RqVTkrz0ZZa5Aad4iQcfjP07+elcHfd7RT0R6O+zwpPeqKomI2aWBEiBgi1maO5PPUfa2Jbrd2tr1AxOg+7p11tamC4lRL7IbAZ6hx14gsh4bTotEUhHZ/OJqT16JhiGjezv1ug4iuU5hsQgjwhQ1aAkavOvVVdrXzvHZtt5kUvj3KRWGqhce+bkEoiT9PB5+nru2zhzuYlGXhla2t+MLdbQwhuGiEg5AeDUh7no+Dz9Pk3CRCYZ1dzd0JvgUKuS4LdZ7QUV8jDj5Po9Is7G0N9aqTArEgO1FdVQUMRUM3juxablJBM5mIRAz0Ht+5idpez7JfMsLBy/9UGMvMMRS5KY/6URchBPfccw/nnHNObKX7rsVPD04blJOTQ0VFd+Jnt9vNG2+8wcqVKwG48cYbmT17Nr///e/7neC7LxdffDGPPfYYc+bMYdSoUXz66ae88847/RpKDAQC/PznP+f666+Plauurg6LxRIXiEG0jl31P1hZWRm7d3fftRcWFjJ16lS2bt1KZWVlbPuYMWMYO3Ys69ato7Gxe85AVwb5FStWxA33mgunMDbdSlHjWkzoOEwq/ojBcnUcnoCFi40tUA9dD5d/pE7BSYgL2YUCpNs1hKrhGzELd0sTrobteMPRBuzFxhfaeIaLFiaLKjCACDT6XRzQRlMi6ikR3fWtUjIoVQoZZxygQDR3113JpUzN4zSjnCy6y75dK6TJksWM4A5cRO92BLBGHUWTP5l5xjZMRM9VbpKJC8+fy8Nr2iloWMtzf9/EcwfVaY6xM/beETQ+1qaQiYcZxt7Y9l516tSIi7XaaMbSwEQ1OgE2pAsqOus0URygIHhQnZTedSpVCqhSMplt7MZJ9OJmUmElo/CaUpgT7K7TgQ3wijoOPxauNW3ljHwHeU4Tm+sD/Nk7joY2N+0tOxlO9Px11ckRdjO3s04WTcEtrHxGZ518ves00ug8T+1AO+QrGXjMRUzUD5Cn967TbK2CDMMdexIxUZ3wd54nJZkLjW2kmKO9cYGI4FPG4tctzAx39yCqCnyoTMHex3naWlGHw9iLG9i5Gmb3OE+nqwfISTJR5Q6TnpHJS20FjBb1lITqIARTutqeKGSySND2lDw+vSBAS9MW9qyBO1yCPTipDGfyL39+v7tOQFgdxQtbdObpW7io8zxZNYXW3GkkJyWRX/c13pBBSyD6WXtXTMIietQpAJFAZ9sT7l5tryF7GmZPPQX+cghAaym04sLQRjNFa2CCUo87FP38dX2eRoQqe7U9d4/PU2GymUp3OPF5Ata0j2KFO5l5+hYy6L72faGOI6JauZSt+Luin8bEn6dLRqfy0/JiTIE21L17GQuM5fCfp9Ginq0rNzMOGNejThMTnSeRx5n6vl6fp0ZzFt+z7yfo9+ILCxQFVoiRNBFte6aD6uTXLczo0fZSrCramNnsrHOT3bgZOldEOgeNpmEzuTQvQt3OjVR7w+CN1mmPNp4C0cLkSBV0fuc2+l2Eu657bfHXvX2WEYwMVsbVaY+Sy+4E14j9thE4MvPJrN+IGvLTsQN2ABnqqLg6JXcGKMs6rxEXG911guh52nyghZTKnZzbuS3ZZmF/9pnsOVCHed8mzMDFhztP9aMpMWq5+OBruTf+82RWFXaSwy4Ofd1L14KEOq8da3rWqVmnK5fN15bxpCQ5GN+6KRoWBbrr1Nc1outablGjvc+thqX7utezToaLtWI0JUZdwu+ng9veHjWX3eTRvHcLr75dSp4zGhL19Z07c+ZMsrOzY9O0usydOxe73c6HH34Yd57mz5+P3+9POC3qYEfdM3YiJ/iG6BDq7bffzj/+8Q8URWHUqFF861vf4rnnnsPn8/Hyyy/HDZt++OGHnHvuubGfw+Ew1157LZWVlSxbtiwWjL3yyiv88Ic/JBgMxv1/F110EaNGjeLpp5/uVcbj1TOmadEhuXZ/CJdFjQ0H+CKwsznIhhovOUkmgrrAHzZIspmZV+wi1RofpZtMJoQQRCIR2gI6NZ4ItR1hhqXYaPKGyUlSOeAJoykKKTYNi9mEhsBpVnCaVXQhMES0dyIc0YkYBroR7eK2WUwkWTQ0YSA670ismopJi94Nd9VJCMGu5iC7WiO0BHRM6MwpdBLWBaPSLJhMJrwhnYdW1PKbr5tivRbfGpnCOYVJtPiC/MuMbOo7wmQ6TKQ6LNHEzsLAokWPi0VTo8fdMPCH9NgK7boATTOhYsTORzBisLc1TKrDDIZOaYMfp0Xj4lf2YaDwxPwCbpzooj1gxLrBNVXFpGnoegRNUWJDu113R9P+uCM2TFmcamZPm86PT8/gobnZseEKgICu8M7udqraAozPtFKcaiXfZSYkVJp8YTqCEXKdJgqSo3WMoFHeGqDeE2JkupVmXwSrSSEv2UZ7IMK2Bh8f7nGT7TBx3ggXZxe60BDsbQnE8vHZLRomrft8BCMG7qBBSIDTYiIYClPjjdCVB1woGhOybGhCjxu+9oSh0afT5g+R5YgOPZs1BVWNDiF13QxtqvNT6Q6xpTHMxjofH+3pHp4Zl2HlF3PyQRhcNjp6EdtQ5+OMPAdWi5kXNjdzx3vRm5hfXpjHnadn8tcdbu74R2Wvu979P51Itj2+ve9tC/P9t6vYXt8919VpUWkPwcKZWQxLUvj26GRGplljnzPovus1hEBVFMIiOoRv16LDavtaQ7QHddrDClYNsmwKKVaNfJcZm0nBbDZjGAb+UIT3ytzsag6iCxib5eA745JRiQ7F7GsNkm43k+ows6fJT0g3cAd1bCYVq1ljUrYDYURiQ7zBiEFAhw31QcKRMLOGRVdv31zvx2w2sbslhEM1SLFpjEix4LKoJFnNuKzR3sT2gM4/ytpZus+DjsYtU9P5zt/2xnqovA9MxhOGv+1o4/N97QxLNuMJ6jy/pQ1d0bhpUjLbGvx4Qgb7uno/Duq1uGSUi7vPzMRuMXNmrpWQbmBWFfa0BBGKSltQ4A2G8IUN7v+kFotJ4Z3rRlKSYe913UNR8UcEvmCYkCEIhA2cFo1KbzRI9gTCJJlVxmZaMandn7+le9t4ubSVM/MdnJbrYGaBC1WJntdAxGBTnR93SCc9yUqRy0QgolPnjeAJ6YR1gcNqAcPApEaH/20mlYIUC6l2c+wa3xE20BQFi0mjyhOh1h2gzhvGGza4cISLYckWNE0jHA6zZK+H365pYkVVBzoqc4qcfFXhBmDLHWMYmWbtvMYLKtsCNPsiTMq2ETFgZ0uY696ooNbT/T104+RUnvh2EZf+dR9fVUaHRx86P5dRaVZGpNtp90eocQdRFYXiNAvugM7LOzz8amUdLovKvJFO7j0rG1/YYGNDCH8oglmFq8elYDNFv4MCOgRCYRxmFZOqEOhsewYqqZbo58IXNthc72d6npPfr2si1Qwj0yzkJpmxmhTGZkXXsAuFI5S1BClrCdLki3Dp2DScZpWmjmgbsptUwobApytsbfCTaVOYXZAUu95EUGnzRzAMgwPuEFlJJlTAUE0Ewzp2E7HgChQUVSMciaB33vhbNAWzpjL1z3vY0+zj1asLuawkBRianrGjCsYWLFjA22+/zRdffBGXl/FIhylnzJjBunXrUNXuLyDDMDjzzDP5+uuv+1WWvoKxLoFAgObmZvLz8/n5z3/Oe++9x7Zt2/B4PNTXd6/JMmzYsFgqo3A4zHe/+1327dvHZ599RkZGdxqWoxmmlAZWtSfMzqYAI1ItjEob3OSuXXPGHr8on7vPzOzX757xzG4210dvAz3/OhFFUeKCsFNZqz/Cy1vbCBuC26enH3YOx46mACNSLLE5XNWeMCN+vyNuHwUI/fuUPt/DHYzOsyxOtcinWw/yxNom/mVpDclWleZ7e+f4ffzrRu7/tBaAv1xRwA2T0jjgDlH8RLRX44ZJqdx9ZiYZdtMhc4r2pSvgPZV0hAxSf7UVgO0/GktJ+qGvbSHdYPGKBv73q+jcvd/Oy+cnZ/TvmiTBt/+6j6Xl3lg7Hir9GqY8WRJ892Sz2Rg2bBjhcJg33niD7373uwC4XK6EXYddgVhZWRmff/55XCAGcPrpp2M2m1m6dGnsvWpra9m6dSuPPvrogJVb6tswl3nI06wUpfT//+/51aKp8RPiT3VpdlO/gtvxmba4n3vOtS5wmajyRHjuioJDvkeyVSPZeuig71T1o9MzSLdrnFOQOEdiz8ntps6gqec2VVE4I+/Qq/gfyqkWiAHYzd11TjmCdmnRVH4+OzsWjFllLtaj4uq88XMHh3Y1hH4FYydTgu+vv/6a6upqpk2bRnV1NYsWLcIwDO6///4+3zMSifCd73yHDRs28N5776HreqyO6enpWCwWUlJSuPXWW7n33nvJyMggPT2d++67j8mTJ/Otb32rP4dTOgl99P1i1tb6D/kkXl9kOqTjp2f/4gOzc7huQiqpNhloHS2TqnD9IXoJenbodv37SJ4+lPqmKgrvf6+YjpBBdtKRfTXbTCpXjElmV1OQfxqbcpxL+M00JcdGa0AnJ2mIc4KKfiC62kGvP88991xsH8MwxIMPPihyc3OF1WoVc+bMEaWlpUIIIYLBoMjIyBCPPvpowvf/9a9/LTIzM0UwGDyqshQVFcVeX7ZsmRg/frywWq0iIyND3HTTTaK6uvqQ71leXt5nHT///PPYfn6/X9x9990iPT1d2O12cdlll4nKysrDllk6tc18drcw/e9mYfrfzUI3jKEuzjdKgzccO7Z/XN801MX5xvvzhqbY8X57Z5sQQohWfyS27eZ3Koa4hKcWQ15PTnrHtLSFJElH7uy/lLG2xg9A6N8mH9GkTunItPgj5Dy+HYAnLxnGHadlHOY3pGPxl80t3P5+NOvIO98dwbdHJ+MN6aT9Kppt5XsTU3nxysKhLKIknVTk7GFJGiTxw5QyEBtIcgh4cMXNGVN7zxmT9/iS1D8nZDAmE3xL30QyRjh+5HSlwWWOm8Df+XdcpoDBLpEkndyOetHX4+mDDz4gHE6c1+zgBWUl6WQhA4bjRx7bwdVzAn/XU8E9Hw7WDSRJ6ocTMhgrKioa6iJI0oCT8cLxcyouhTCUevaCdeUD7Dn0LhPeS1L/nJDDlJL0TSQDhuNH9owNrp5r5CVa0kJ2jElS/8hgTJIGiYzFjh9NHtxB1TMAMycIxnQ5aUyS+kUGY5I0SGTvzfEjj+3gipvAn+BbRMZiktQ/MhiTpEEihymPH1VOHh9U8SvwJximlMGYJPWLDMYkaZDI3pvjp+fk8YiMBI477XDDlHICvyT1iwzGJGmQyFhscIRlMHbcmRMs+tqTPAWS1D8yGJOkQSJHKQeH7Bk7/nq2ZYe599eIXNpCkvpHBmOSJH2jyGDs+PMGuyfmpdu1Xq/LeXuS1D8yGJOkQaLIgcpBEdZlMHa8pfUIwBIPU8pzIEn9cUKuwC9JknS0ClIsQ12Eb7ypOXZ+d3E+xamJj3WiAE2SpL7JYEySBomcM3Z8Lfl+McsrOvjB5LShLsop4cenZ/b5mgzGJKl/ZDAmSYNEfj0dXxcWu7iw2DXUxZCIT5ckSdLhyTljkiRJ0oBKtPaYJEl9k8GYJEmSNKASpUiSJKlv8iMjSZIkDYjvT0wF4L5Z2UNbEEk6ycg5Y5I0SOQEfumb7vkrCvjdxcNItfVee0ySpL7JnjFJkiRpQCiKIgMxSToKMhiTpEEiO8YkSZKkRGQwJkmDRA5TSpIkSYnIYEySBolMmShJkiQlIoMxSRokMhiTJEmSEpHBmCQNEpk8WZIkSUpEBmOSNEhkz5gkSZKUiAzGJGmQyGBMkiRJSkQGY5I0SOQwpSRJkpSIDMYkaZDInjFJkiQpERmMSdIgkcGYJEmSlIgMxiRpkMhhSkmSJCkRGYxJ0iCRPWOSJElSIjIYk6RBIoMxSZIkKREZjEnSILGZZHJKSZIkqTcZjEnSIHnykmGUpFv4v8uGD3VRJEmSpBOIIoScVSxJkiRJkjRUZM+YJEmSJEnSEDINdQG+6YQQeDyeoS6GJEmSJElDxOVyoSh9zxuWwdhx5vF4SElJGepiSJIkSZI0RNrb20lOTu7zdTln7DiTPWOSJEmSdGo7XM+YDMYkSZIkSZKGkJzAL0mSJEmSNIRkMCZJkiRJkjSEZDAmSZIkSZI0hGQwJkmSJEmSNIRkMHYS+8Mf/kBxcTE2m43TTz+dL7/8cqiLdNJatGgRiqLE/cnNzY29LoRg0aJF5OfnY7fbmTt3Ltu2bYt7j2AwyIIFC8jMzCQpKYkrrriCAwcODHZVTlhffPEFl19+Ofn5+SiKwttvvx33+kAd49bWVm666SZSUlJISUnhpptuoq2t7TjX7sR0uGN+yy239Gr3Z511Vtw+8pj3z0MPPcSZZ56Jy+UiOzubq666il27dsXtI9v6wDqSY36it3UZjJ2kXnvtNRYuXMgvfvELNm7cyLnnnsv8+fOprKwc6qKdtCZOnEhtbW3sT2lpaey1Rx99lMcee4wnnniCtWvXkpuby0UXXRS3bMnChQt56623ePXVV1mxYgVer5fLLrsMXdeHojonnI6ODqZOncoTTzyR8PWBOsbXX389mzZtYsmSJSxZsoRNmzZx0003Hff6nYgOd8wBLrnkkrh2/8EHH8S9Lo95/yxfvpy77rqL1atXs3TpUiKRCPPmzaOjoyO2j2zrA+tIjjmc4G1dSCelGTNmiB/96Edx28aNGyd+/vOfD1GJTm4PPvigmDp1asLXDMMQubm54uGHH45tCwQCIiUlRTz99NNCCCHa2tqE2WwWr776amyf6upqoaqqWLJkyXEt+8kIEG+99Vbs54E6xtu3bxeAWL16dWyfVatWCUDs3LnzONfqxHbwMRdCiJtvvllceeWVff6OPObHrqGhQQBi+fLlQgjZ1gfDwcdciBO/rcuesZNQKBRi/fr1zJs3L277vHnzWLly5RCV6uRXVlZGfn4+xcXFfO9732Pfvn0AlJeXU1dXF3e8rVYr5513Xux4r1+/nnA4HLdPfn4+kyZNkufkCAzUMV61ahUpKSnMnDkzts9ZZ51FSkqKPA99WLZsGdnZ2YwZM4bbb7+dhoaG2GvymB+79vZ2ANLT0wHZ1gfDwce8y4nc1mUwdhJqampC13VycnLitufk5FBXVzdEpTq5zZw5kxdeeIGPPvqIP//5z9TV1XH22WfT3NwcO6aHOt51dXVYLBbS0tL63Efq20Ad47q6OrKzs3u9f3Z2tjwPCcyfP5+XX36Zzz77jF//+tesXbuWCy64gGAwCMhjfqyEENxzzz2cc845TJo0CZBt/XhLdMzhxG/rMjflSezg1ApCiEOmW5D6Nn/+/Ni/J0+ezKxZsxg1ahTPP/98bJLn0RxveU76ZyCOcaL95XlI7Lrrrov9e9KkSZxxxhkUFRXx/vvvc/XVV/f5e/KYH5m7776bLVu2sGLFil6vybZ+fPR1zE/0ti57xk5CmZmZaJrWKxJvaGjodbclHZ2kpCQmT55MWVlZ7KnKQx3v3NxcQqEQra2tfe4j9W2gjnFubi719fW93r+xsVGehyOQl5dHUVERZWVlgDzmx2LBggW8++67fP755wwfPjy2Xbb146evY57IidbWZTB2ErJYLJx++uksXbo0bvvSpUs5++yzh6hU3yzBYJAdO3aQl5dHcXExubm5ccc7FAqxfPny2PE+/fTTMZvNcfvU1taydetWeU6OwEAd41mzZtHe3s6aNWti+3z99de0t7fL83AEmpubqaqqIi8vD5DH/GgIIbj77rt58803+eyzzyguLo57Xbb1gXe4Y57ICdfWj2n6vzRkXn31VWE2m8Uzzzwjtm/fLhYuXCiSkpLE/v37h7poJ6V7771XLFu2TOzbt0+sXr1aXHbZZcLlcsWO58MPPyxSUlLEm2++KUpLS8X3v/99kZeXJ9xud+w9fvSjH4nhw4eLTz75RGzYsEFccMEFYurUqSISiQxVtU4oHo9HbNy4UWzcuFEA4rHHHhMbN24UFRUVQoiBO8aXXHKJmDJlili1apVYtWqVmDx5srjssssGvb4ngkMdc4/HI+69916xcuVKUV5eLj7//HMxa9YsMWzYMHnMj8GPf/xjkZKSIpYtWyZqa2tjf3w+X2wf2dYH1uGO+cnQ1mUwdhJ78sknRVFRkbBYLOK0006Le4xX6p/rrrtO5OXlCbPZLPLz88XVV18ttm3bFnvdMAzx4IMPitzcXGG1WsWcOXNEaWlp3Hv4/X5x9913i/T0dGG328Vll10mKisrB7sqJ6zPP/9cAL3+3HzzzUKIgTvGzc3N4oYbbhAul0u4XC5xww03iNbW1kGq5YnlUMfc5/OJefPmiaysLGE2m0VhYaG4+eabex1Pecz7J9HxBsRzzz0X20e29YF1uGN+MrR1pbMikiRJkiRJ0hCQc8YkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShtD/D17NLmLrkmFUAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAACDCAYAAADBExzWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAABUJ0lEQVR4nO3deXxU9b34/9c5Z/bMZN8hCQHCvrqAiCJqRanr1Vpbl2qvW1ul5apXe2+/98q993dxaatdtNr2qnWt2rrWBcUFFAHZIewBQhKy7zOT2c/5/P6YZJIhEyAQEpDP8/HgATlzMnw+53zmzPt8Pp/zeStCCIEkSZIkSZI0JNShLoAkSZIkSdKpTAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSdJx8bftbWyu9w91MSTphKfIROGSJEnSQFtR2cH5L+0FIPzvU4a4NJJ0YpM9Y5I0iF4sbaXod9tZX+sb6qJI0nG1uUH2iEnSkZLBmCQNon/+RxU13gg/fLdqqIvyjSSE4NlNLXxS7hnqokg9GHIARpIOyTTUBZCkU5EvYgx1Eb5RXtvWxoulrdw0OY07PziARVNoumcidrO83xwqSo9/e4IGKTZtyMoiSSc6GYxJ0hAwZEfBgLrxnUoAPtoX7REL6YIVVR1cNNI1lMU6pQX17kbeFtRlMHacCSHwhAySrfI4n4zkbaMkDQE5anP8bW8KDHURTmltAT3hv6Xj42cf15Dx622sk/NRT0oyGJOkIRCRXWPHXVlLaKiLcEp7c2d77N/tMhg77p5a3wzA/3xZP8QlkY6GDMYkaQjIOWMDxx9OfCzLWoKDXBKpp53N3ce/LSiDscGytSHA3UuqafVHhrooUj/IYEw6LiKGkE9QHUJHSAZjA6XBl/hLZ0Odn1e3tQ5yaaRE5DDl8dVzudBKd5g/bmjmzg8ODGGJpP6SwZg04Fr8EcY9tZNZz+1Bl8NxMT0DMF0elgFT1R5OuL0toHPTO1XypuAE0BaQNx/HU0eC3uG3drmHoCTS0ZLBmDTglu7zUtEeZkOdn9JGOYm6y11L5J3q8VDh7j03rOeyCl7ZCznoDk7s0i6HKY+rZn/i4ysT7Jw8ZDAmDbhdzd0BWFW7nETd5eWtbUNdhJPW/rYQIT1xUFXe2ruNjcu0xv7dKofIBt3BHeJymPL48gQTfzb299FrLJ14+hWMPfTQQ5x55pm4XC6ys7O56qqr2LVrV9w+QggWLVpEfn4+druduXPnsm3btoTvt3jxYjRN4+GHH+5XoWtra7n++usZO3YsqqqycOHCXvvMnTsXRVF6/bn00ksP+d5vvvkmF198MZmZmSiKwqZNm3rtU1dXx0033URubi5JSUmcdtpp/P3vf+9XHb7JNvZIDPzVgcF9zPr17W2c98IeqhL0lgyEZl+Et3a29/tpSHmHevS+quqg5A87ueSV8oSvb0yQiHpMencwJntljo47qNPcx3y8w9EPau8NHcd/MnkwYuANnZrn2tNHvd/d3Z5wu3Ti6Vcwtnz5cu666y5Wr17N0qVLiUQizJs3j46Ojtg+jz76KI899hhPPPEEa9euJTc3l4suugiPp3d6kueee47777+fZ599tl+FDgaDZGVl8Ytf/IKpU6cm3OfNN9+ktrY29mfr1q1omsa11157yPfu6Ohg9uzZhwwQb7rpJnbt2sW7775LaWkpV199Nddddx0bN27sVz0Gwom4RMKOpu6nqL6qiraNWm+Yz3qkqPnF57WYF2/h/bLueQ3VnjA//EcVzkdKMS/ewtl/KSPQz6cOb3i7kpUHfPzrJ7XHWIvEvvtmBd99s4KHv2ro1+81+XpfLOVcpiPz/JYWAL6s6uj1WkfI4MvK+O02k0JxqiX280AOUwYjBtsaA7ScAk+qzf7LHgp+t6PPgGzVgQ5WHehI2I4P/tjubD626QpCCP6yuYUHl9clvOaFdcHw3+0g7VfbsD20hW2d0yMaOyKsru7dbo6lHG0Bnb9ua2XZfu9h9//Nmkbm/3Ufv17dQLDzoBzqxuzVba1c8OJeShPk9XxrZzvX/n0/td7evV19tfG3dh59MLa2xseHe+LnnX1a7uHLSi/727pvdoUQvLWzHfvDW1iwpDq2PRgxaPZFCOkG7qDeZ73bAzpPr2/mopf3cu3f9x/xNV83BIuW1/FC5/XhZKeIY7hlb2xsJDs7m+XLlzNnzhyEEOTn57Nw4UIeeOABIBo45eTk8Mgjj3DnnXfGfnf58uXccMMNlJeXM2LECP76178yZ86cfpdh7ty5TJs2jd/85jeH3O83v/kN//mf/0ltbS1JSUmHfd/9+/dTXFzMxo0bmTZtWtxrTqeTp556iptuuim2LSMjg0cffZRbb72133U4Ws2+CNP+vJvvTkhl/mgXhoiuPO6yqNR6w7QFDKo9YarcIXxhg7KW6N9Tc2xkJ5nJtGu4rCrPbmohJ8lMfUeYM/IdnJHnwKRCjSdCilUl12kmxarismj4Igab6/28V+ahxR/BEDDMZea0PDuZdhPtQZ1frW6MK+d9Z2XFts0tSuLv14wg87Fob+kwl5n9C8bzj93tXP33il51nJJt4+EL8rCbVOo7wqyp8bG+1k9a52reG+r8JJlVpuTYyHWa+e2aptjv+h6YTI03jE1TyEoysaHOz+oDPv6+o43ythBOi8p1E1I5a3gSmQ6N3c1BLJqKzaTgNKtUuMN8tt+LN6iTbNOwm1T+uKE59v6/v3gYigJ2k4LDrNLQEaEjbKAqoBvgDulUtIUJRAwq3dE5dD39bEYmz21uoSTdynmFSZw/wklxqoUvKjv4VrGLWm+Y0oYADrOKP2xgUhUOuEPYTCqaGh2aeHlrK6k2jUBEYDerdIR0zKpCrtPMuYVJnJZrp8mvs6Kqg2FOE2l2E7oQfFXZQb0vwvlFTiZk2jBrCq2BCC1+HZOqcKQihiCsC7KSTGQ5TFg0hRpPmNaAji9sEIgI/BGDNTU+hIDxmTam5tgYlWbFG9LZ2xqizhsh1aaRZFaxmhQ0RUFTwaQqBCOCez+pif1//3NeLhcWO1my18Pu5iCf7vfQeFCgm2bT+MvlBVz5t/0APHf5cG6cnB57vaEjwivbWnmptJVaT4TpuXbMGtx5WgY1nghra3w4zCpmTSHNphHWBXvbQizd56G+s4fHYVa4eUo6cwqTcFk09rYGURWFPa1Brh2fyrQcG56QQWlDgGpPGEMIdBE9XhFDoBvRz2qzP0JQF1g0BVUBq6aSnWRiYqaNVJtGUDf4orKD8rYQFk2hoi1EyBC0B3SGJ5sJRAS6EBSlWBjuMqN1njt3MHr8S9KtuCwaI1It5DpN7GoOsrbGx7paH2XNIcyawph0KxOzrNjNKmFdENIFvojB419HP0v3npXFHdPTaQno7GwKoijw9PpmVld393pfPNLFvrYg5xQk8dt5w3hlWys/+qD7i9lmUmj4l+70VPvbQpQ2+KnxRmLXmv2dUxrynWYafBF8YYOx6VZCuuDNne3s6lyqZGy6lV+cm82141NRFZj5bBmb6uODvbOGOfjsxlE4HikFop/Rl68qZNbwJE7/v93UeCNMy7ExuyCJB87Oxhsy+NXqRr6s9BKMCPJcZhbNyeHB5fWsqYnWc0Kmle1N8culXDraxcY6P4UpFi4Y4aQoxcLcoiTcIYPfrmnipdLeT/PaTQo/nJrO7IIkluz1oCjR4/ePMjevbmuL7bfqh6NZUdWBpiicU5DEjGfLALBqCovPz6PBF2Zsho3zi5KY+ufduBMMVSrA2ltLmJpjp84bZn97CENAZXuo8xqo0dgRIaAbOEwqVZ4wFW0hFAWWVUSD2MnZNuaNdLGiqoOve5zza8en8OzlBdz3SW3cdXHnj8cS0gXnvbA3borA+Awr105I5fpJqYxKi/Zc72gKcMYzZYQOeqKpINlMcaqFjrDBeYVJnJnvwKQq/KPMTW6SiXS7xiflXj4pjwbEt01L58E5OezvrFdYF+xqDhLSBQIYmWoh2aqhKLC7Ocj/bWwhzaZxxdhkfGGDZIvGg3NyYp+foXBMwdiePXsoKSmhtLSUSZMmsW/fPkaNGsWGDRuYPn16bL8rr7yS1NRUnn/++di2H/zgB+Tk5PDLX/6S++67j8bGxrjXj9SRBmOTJ09m1qxZ/OlPfzqi9z1UMHbJJZdgMpl44YUXSE1N5fXXX+e2225j8+bNjBo1qtd7GYaBYXR/UBRFQdM0dD3+bkFVVVRVJRKJvxPta/vTG1v5l6W1aCL+y0jv7PDUMI5su6KBEAm3K8JARRx2u0DBUFRUYaD02G6gIBQ1roz/Pjub/++rRoSiYhI6628r4fLX9lPtCaOjUpRq4UBb/MX1RK/TobbrqKAoJ915OlnqZNFUTstPYlWVFwVBvtPEG9eOYOZzexGKSqpZ8If5w/i6xsfr29qp8+knfJ2+Secp32mixhthfkkyNpOJPS1+SnsMLR+vOhWmmKlsD8dtH5VmYW/nHMNv+nm6oiSZdztHHgazTv8+O5vFXzUcsk52k0IocoR1HaTztPSGkcwaHu2o6es7V9M0FEVJuB1A1/WE2xXl8EHeUeemFEJwzz33cM455zBp0iQgOpcKICcnJ27fnJwcKiq6ez3cbjdvvPEGK1euBODGG29k9uzZ/P73vyc5Ofloi9SnNWvWsHXrVp555pkBeb/XXnuN6667joyMDEwmEw6Hg7feeithIAZQVlbG7t27Yz8XFhYydepUtm7dSmVlZWz7mDFjGDt2LOvWraOxsbt3aerUqRQWFrJixYq44d7vzJhB5pUFLPvkY1p9QQIRgQLsTZmMbrIyo2Mj2UkmVEXBooJjwrnsa/QwvHkzjb4IAjCbTFRkz8DT2sj0yF72t4XITTLjwUpZ6hT8TTXM1A7gDup4QgatajIF409jjKjF0laF06zijwhqtAz+Up/FyGAlBaKZcRlWar1h1oWyKVPyOM0oJ4to2dd/CcOVAqqUTM42drP4L1uZFDKYBDx800WMH5HPhx9+iNsfYuUBH/vbQ6y1jKcwM5lZvo24rCpdc7mHnXYebq+f+m2rsWgKmXYTpc1h/hqaSCYeZhh7Y8fLp9hoyp7OOFMLZ6gHqPGEafLplAUdlFpLuDi5nXTfAUK6IBARhJzZjJs0hbS2vQSbawkbgk31fsqUXMqUPL6TUoMt2EYwYiAAb/pozGl5DG/ejCniR1HAZdFoSBvH07sEFxrbMNH9Yf1CHcel4zKZ6tlIrTdMky9Ce9DgI3UKdkLMFTtJtmhEDIFmMrHMMhWTv5UrHJVEDEGVO4wXGzPPmcNYrYWm8h20BXQiBuj2VPY6x1K2ezeT1HqKUy2EDYHblkWdcyQjAvvJDDVR6w3TETZocQxDZI6g2LMTU6AtVkZv2mgCzhzSajeiRbrvitszJxC2p5JWtRoMnaBu0B4wKE+dTE6qk5KWdZhUhYghUBUYd9YFWEWIPRtW0uzX8YYMFFWjYdhM6hsamKOWYxjRu1jdZKchZzomTy1GbVnssf1GXKzVRjNRbWC2o4k8pxmnWeWM8cWsMVJwV+6kQDSTHFDZtGIPo4WDMiWPksBeXnprEwDTgVKlgHpTFvPVvYx0RD8Hu1uCrFFH0aIk8z3rTjKsxMofGH4aDoed1KqvyU0ykWbXqHaH+dI6jX2NHsZ7t5Jmj15KazoM3hGTY20vyazitKhgcVCfPY1kfwPp7ftQlc4nPpPSsBVPxV9bjq09ugxHR9hgZySN5cFhTOEAM51uUm0a/rBBcn4xeSNKCO7fjKe1GU2Fak+E1pSRGMm5ZNZvQov40I3ovK0q1zh2BBxMaV9PuPMLJNNhInXcDPJTnVj2rcQTMmgL6BiAt+gsrEaIA6WrY8OBiqqx3DKNPNycrZRjUsFhUglodsyjzqSl7gBjwxU0+XXK20Kx8zRa1FMi6jg/zcnnbi8VuzMoVQuZbFRysWhGU6KBNBmFOPNHktKwjYC7BbtZxWVR0fLGUKmkkV67ESXsJ8thIifJxJeimGfK6PV5unDuXK6bmsODz7xBrTcCrTAeaBo2k+217cwxdkIzjAZyXVamnfst/nvJztg1Is9poigrlc+V8ewp389kURV77551Ot/ZzOyCJDwhg22hFFZGhjM2VIG3qbsHt+sacWNGLfNzI4QNwbpaP43OYiyZ+VRsXIldBGJtbI06iiaSE14j/Fi42NhCklnltFw7+9tDvKlPYkSSQVbDlti+ETQ+1qaQiYdZYi9Xm1LRaafNsPKFNp7hooWZWjUCsGgKblMy+51jmWZqoCBcQ9gAb0gnmJRD9qgJJDXvQXXXUd8RYV9biDIll3OnT2RiYDf7q+vZ3x5CF7DXUsRN507g408/x0mA9V/CxcAadRSv3ziNbSs/JdUC+1pDbGsK8EFkDP5ItE4AmXYTs4Y7uPmay1i9v5U3l3xKeVuIiVk2zCYTpamn425uJKlhO4LoaAoWB8vUcZg99ZSEKgh3ttWu83Rpehs5gWocJhVVVWizZrGBAor85YxUWgjpAqtJRaQX8rtyJ6cZ5Wz5qpy2ZPMhv3NnzpxJdnZ2bJpWl7lz52K32/nwww/paf78+fj9flyuw+fIPeqesbvuuov333+fFStWMHz4cABWrlzJ7NmzqampIS8vL7bv7bffTlVVFUuWLAHg6aef5sknn6S0tDS2z+TJk1mwYAF33HFHv8pxJD1jd955JytXroz7/15++eW4YdMPP/yQc889N/bzoXrGFixYwJo1a1i8eDGZmZm8/fbbPP7443z55ZdMnjy51/9/vHrGDo7ShRCx94a+o/SDt5tMJoQQCbcfXPa+tieqk24IHvyygS+qfPxpfh5/2tDMnzZEx/cT3WUtODODRy8q6HXnoRsCi9nUrzpVdxg0doQpcmlsbQigqQpn5juwW829yr6tMUBxuh2nWTlsnZyPlGKg8Ot5w/nx9NS4//NQ5+l/vqznze0tlLeFYgmUhaKy7+7x5Di6p24GIwYOq5mOkIFZMeK6zY/mPB3cxo5X2+u5HQ59np5Y28jPP6vj1asLuWp8xmHr5Hyk+3P79W3jGJFsIsncfVwUReHJ9a3869IDKAgmZtl48pJhzHlxH0JRybEDIvpU5ag0KzdPzWDhWdkII/p/hnXBVa/vR9VU3v/+SIwjbGOH2t7si2BSDJyW7qTN/f08KapKIBTBonXX9VjOU0V7iGEuMyb18NeIDTVeZv9lDwDeByb32fZu/aCGv5a28NuL8rj9tAwWr6iP9or06J3wPjCZj/e5eaG0naABp+dYuXVqOllJpqOu07paP3d/UEFJmoV/npbBzGEOHNboF+m9H1fxh3XRYbOzhjn45KYS/m9TCwuXRIOrf56Wxu8uHo7JZGJPS4APd7cxLdfOWcMcKIqCyWSi0RvixS3NTM2xc16RE0MILObe146en6eIbrC1McDjqxuYNzqVG6ek92pLXXXa3uDFHTA4I99BY0eEuz6q5Z+nZ/Cd16OB4fYfjaUg2Rz9DBuCqvYAw13mWA9L13l6fFUd//55Xez9u3qR8pNU9t49nhWVXpZVdDCzwMWYdAtFyfH9L0d6Le+5vet8lLcG2dUS5JxCF6l2M7b/7Z4znWHXeOd7ozgjP6nX+dvcGOQ/Pq/js3I335+Ywp8uLTjk91ZX26v3BHFZVKwmNWHZ9c4pAEk2S7++c+e/up/l5e08c/lwrpuQFneeBrNn7KiCsQULFvD222/zxRdfUFxcHNt+pMOUM2bMYN26dahq95eQYRiceeaZfP311/0qy+GCMZ/PR15eHv/93//Nz372s9h2j8dDfX13Dq9hw4Zht9tjP/cVjO3du5fRo0ezdetWJk6cGNv+rW99i9GjR/P000/3q/ynkrAuYnM4AL4/MZVPyrvn/Gy9cwxjM2xDVbwjYl4cvZt76cpCrpuY2u/fH/abbTR01vfVfyrkmvH9f4+TXdcxtJsU3Pf3vnnpa3+A8L9PSbjPk+uaWPhxtGfizHw7j12Uz7nPR7/YHr4gl3vPyj7WYp9yvqz0kp1kOuRnsuvcZNo1av9lIutqfcx6bk/cPn2ds+Ol2hPmf1fU809jU7hoZLRH4u1d7Vz7RnR0puXeibis2qHeYsgs3efBFza4cmzKEe2vG4IXS1u5/f34NQxL0i1s/9G441HEPp37/B5WV/tQleh83aGcf9Uf3/n7ft7Z7eaJS4Zx52kZQ1aOfg1TCiFYsGABb731FsuWLYsLxACKi4vJzc1l6dKlsWAsFAqxfPlyHnnkEQBKS0tZt24dy5YtIz29e1JtW1sbc+bMYevWrbFhz4Hw+uuvEwwGufHGG+O2u1yuI+o6PJjPFx2q6RlIQjQCPviOV4pn1hRK0i2xBM4RQ/DU/OH895f13Dcr64QPxABeuaqQFVUdfGf8kV0sD9bzzifRqtmnEn9k4J4m7fnQgd2kxj3NJ1NPHZ1zC52HfD3cY9J1V67VyVk2Uqwq7X2sezUYhrnM/GH+8Lht5xc5yXaYmDHMfsIGYkAseDxSmqpwy9T0XsGYyzL4dXz16iI+3ufhxklpJ00gBuC0RB/aGuqVCfoVjN1111288sorvPPOO7hcrtgcsZSUFOx2O4qisHDhQhYvXkxJSQklJSUsXrwYh8PB9ddfD8AzzzzDjBkzEj45OWvWLJ555hkef/zxw5ala/0vr9dLY2MjmzZtwmKxMGHChLj9nnnmGa666ioyMo4s4m1paaGyspKamuhddtc6arm5ueTm5jJu3DhGjx7NnXfeya9+9SsyMjJ4++23Wbp0Ke+9994R/R+nsv8+L5fvvxWdJ3ffrCxOy3Uc8V3gieDaCalcOyH1qH+/Zz90X6tmS/E+vn4kt7xbyZMHfcH21GMkD7tJxehxYW0bwsDgm6zn+m2+cPQJzxSbxqc3juKMZ8qGsGS9pdg0yheMw3wSBQn98fH1I7n01fLY3KnytsFfbHuYy8wPp6YffscTzLOXF/CXKwqHuhj9W2fsqaeeor29nblz55KXlxf789prr8X2uf/++1m4cCE/+clPOOOMM6iurubjjz/G5XIRCoV46aWXuOaaaxK+/zXXXMNLL71EKHT4hjR9+nSmT5/O+vXreeWVV5g+fTrf/va34/bZvXs3K1as6NdyE++++y7Tp0+PLQ77ve99j+nTp8eGH81mMx988AFZWVlcfvnlTJkyhRdeeIHnn3++1/8v9XbNuBRW3jKa8rvHcVquY6iLM+h63ns1HuWCmqea80c4qfjpBC4r6fvhnvieMYUNPZ7Wk1kgjg/3QYvpbu1c22tqjp0sx4nX+2TR1COau3MyOn+Ek39cNyL2s8w6ceTUE6RN9HuY8nAURWHRokUsWrSo12sWi4Wmpqbev9Tpnnvu4Z577hmwsowZM6bfK5/fcsst3HLLLYfcp6SkhDfeeKNf7ytFKUp0Iv2pqmdPeNMpGozZTAqBARyiBOKGRWxmNW7R3/0yGBtwn5Z7eq0NtbHOz+yC6NIA39QeqBNZzwc9zik4/Fqa0onlqJe2kCSp/3p+fSValf9UkO0wUeke2Jx5ph59/GZVYXSahT2d60kN9P91qqj1hvGFjdgCnV2+qurgkr/2Tk3Vc1FjsyaDscHW85jffcbQTUSXjs4JmSh84sSJOJ3OhH9efvnloS6eJPWbJ6jz8FcNcQmTK49T/swTXdeSBhBd12htjY9//aTmmPIKaj2GGlQF5o/uHtJs8eu9htSkwyv83Q7GPbWrVzqkN/tIsbOh1ocQggeX1xEc4J7PgXTAHTphU5Htbwvxy1UNtB/FMGPPnrGuDCXSyeOE7Bn74IMPCIcT380evKCsJJ0MHlnVwCMr49NElbUEMYQ4YeYsDBZbjy+Nak+Y+X/dR3vQoNYb5qWrio7qPXvOGVMV8B/0pGpFe4jJ2faDf21ACCFi6ai+ibY3BeKerNzdEp8SaEy6hd0tIXY0B/lgj4fF/czbOpie39LCbe8d4OqxKVw5NpnvTkg9ZPovIaKLKxckmwdlvtm8V/ZR3hZiS0OAF6889KRyQwjeK3MzNcdOUYoFS48n/FNkMHbSGZKrx0MPPcSZZ56Jy+UiOzubq666KvbUIkBRURGjRo3ipZdeYs6cOUyePJnbbruNYDCYcDmKxYsXo2naIZN7J1JbW8v111/P2LFjUVWVhQsXDkj5JaknQwh+v7b3XElfWFDtGdghNCEErSd4EuuecdLe1lBsGYTXtved1NgfNg45/7PnMKWmKPgPSja846CcggPpln9UUfC77WxJkNz5ZNWz56hnEmpPMJrntKeSdCvFqRYMQSyP44nqd525a9/c1c7N71bxLx/XHHL/36xpYtSTO3lqffMh9xsoXU9Bvrv78Am+//uLeq75ewWjn9zJnpYgw1zdfSs20zfzxuCbbEjO2PLly7nrrrtYvXp1LK3AvHnz6Ojo/pA/+uijPPbYYzzxxBOsXbuW3NxcLrroorjUBF2ee+457r//fp599tl+lSMYDJKVlcUvfvELpk6dOqDlHwy6IXhsdSNbGwL9flABGLB1VdxBnbuXVPPhHnef++iGYGOdnz+sa2JHU6DP/YQQfFYeTULe9bMQgiZfhD0tQTbX++OG+gDaAjr7WoOxY9AW0I/b2lJbGvzMeq6Mpft6t8O+fLzPgy8cf6ytnb1D2xr7Phb9sbHOz2vb2rj01XKyH9/OdW9U8Pu1TUcUmAkhMEQ04bc/bCRsF7oh2N8WIqQf+ri2+iPsbAqwoc5HWI+eO3/YiBsmDPd4/3UHfXlXJphsv7s5SMavt5H6q6386IMDccNmQgh2NgX4tLz7fIQNEXuazGmJXuKWlic+X/6wwcKPqxn+2+385MMDfFnp7VWfsN77eJS1BFld3cHWhgCvbG2jPWhwxWv7EULQ0BFhyV43emc9gxGDr6t9lLUEE75Xl/aAzsf7PLywpaVX+w3rAs9BQ62BiHHI9zv499fW+HiptJWtDYHDDtP1bAM13u4bhpe2tsYFZxBdSuSSUdGb5E31xx6Q6oZgQ52PP21oZsle91Fd2yDaNlZUdfDkuiY8QR3dEGxpiP+8Pbu5pdf1pEtYF9z/afRBkJ99XNNr6HB3c5CXSlspbfD361rqCxsEO28W2gI6H+5xx37u3qf7/UK6we/XNvFfX9TFrovlbSH+t0cP5PT/202tN8J5hUmMTbdSkm4hpBu9eoiPpz0tQVZUdfRqp4dzDOmx8QR1vq72sbVhYK6jQ+mYEoUPlMbGRrKzs1m+fDlz5sxBCEF+fj4LFy7kgQceAKKBU05ODo888khcGqPly5dzww03UF5ezogRI/jrX/+acA2zwznShONHUv6DHa90SMsrfVzy6v5YSqEJWTZMKqTZLZhVBasq8IUNWoM6TrOKjoohBMIwaPJH2Nc5wXlCThLpVpXCZI16bzSPGgpUuA0KXBqGblDf+QVoN6s0BcCEQb7ThN2ksrzSG5eI9ZapqYxMsbCrJcjWxiAbG0K9ksWeNTyJ0/OdpFshJ0njV6ub2N8WQigqBgouk8EvZufwq9WNtAb0Xklkx6Rb+edpaby2w8O6Wj8aBul2jVa/jgAUTWNkiplaT5DhLgvFqRY+2udBVzTSrArZDpV0mwmzqhAwDDKTrHgCEVQEhiEwAE9YYKBS4NIIhHWa/DrbGwOxVE7/NDoJp1XFHzao8UQoaw0RFAroOooSDbgy7Cb2tEUIC+KOwflFTj6p8HHnaRn85qJcIPrF//r2Nv6208P6Oj92TeAOGkzItDIxy8qedoOiZDPJFsH/zs1jXa2fP25oZnNjmGp3sM+EuRMzLeQ5zTjMKrdMS+eC4hSq2gI8ua6Rd3e5qeuIxKWnSrdrTM6yU+kOIVA4u9DFqko35W0hzKrCyDQL25vDoCh8Z0wSEzJtVHvDrKzysaMlHHeeNAV0EU0CXJBsxqaJWLsDOLswmS8rvbH9/2tODvfOyo6lcvr79lZufrcqrk65DpWFZ2ZwwBPijR1u6n16XBLgSdk2DAFbG4MsPCub362uJ8OusfPH47Cbo5+l/1nRwENf1tJTz8TG5xQk0RbU2doQQEfl26Nd2FVBjTdCjTfMAXc4YWLjH52eTrVX8PaudjQMVv9wNGd1rkivKxopFpiZZ6c5oOPQFAwFZg53sbclwHs9ekMECucUuajzBKn3hmMBUJrdxLgsB75giC31AawmhRn5DsZk2slwmDF0nYr2IGZNoTjFQkmmgw11fv68viHuC15HZWKWjVQLOMwqJlXhgCdMaWMIp0XFH+q+1qRYVe4/J49NtX7+tr2lVxv73vhkfjgllW+/Wo7DrOALi7h0SFeNSWZdrZ/ajgghoVKcrDEpy0pHSLC3LciwZAvFaTYmZZqp84Z5a6ebak84rk1OyLIRiBjMzLcTMlSSbSYcmoFZU+gIGRxwh/FGok8rp1oUXFaFdbV+9rSE0FEZk27hO2NdPLKqMa7sCMGTF+fyz9OiE96X7HXzwlY3a6s7qPXE3xgUptlZfF429d4QH+718Gm5F6PzumdXBecUODgtL9r2mgMCl9XEjvoODnii5y/TobGxPhirU26SibqOSOx8DE+2UOvuDioKU8yoqsbe1lDc5+nAzyaw4ONaXtveTooluqhx15nNcVm5eXIqX1Z4WFXtI82mcdeZmZRkOPAEw1S3B9nVHOTdMjfnFDiJoLK3JYAwDOo6IoxMs6B2poRSDkqqrSoKWU4L4UiEYERgNymk2zQK06w0+AxeLY3vPbSZTfz4jEzM6AxzmdlY72dLQ4BdLWF0A9Ks0R68Gk+YsCEYmWbHaVWJ6Dq+sMFwl5lkq4bFbMKiAkKnqj0SnRNaksw7ZV5WVXnjrntOi4rTZmG4UyPFomDRon8iKPgj0e9imwbJVpUWv84BTwSL2cTYNBN//PawaK5UTqJ0SANtz549lJSUUFpayqRJk444rRLAD37wA3JycvjlL3/JfffdR2NjY9zrR+pYgrGDy3+wXbt2JUwUvnnz5oSJwlevXp0wUfiyZcviegbNRVN4rFTHvG9ln8lle+pKQD3H2BnbFksuK9xxSbW92PhCG0+B0ZQwYW6JUUuJ6M6JVqV0JwEuEN0fyjIllzI1jzP1PbFE4RBN1lylZjJH34GT7gvQGnUUTUoy8/QtCes039hCz3u9k6VOKemZjGpaF6vTOQVJLK4uwG6389vi/extDbK+zk9IF0ddp3MsNWQnmUi2qBzQnfzVXUBBqGbQz5OhWZkb3kxPfdVpuWUqrkh7rE6qAt+ekEvupLN4ecUO/NXdw/+HOk9VjhEU+PZTIJoxKdGL33aRw+t3nMcDz3+EKdDG9Bw7U3Js3Ffq7FWnFKvK0nDxIdveN+HzpCrRgOVY6pTnNNEeMGiIWPhCG8+txUEuddbx+vY23CFjQOpkVhXaUkexvN3V72tEf+s0Vy3njHw7Fe1htrWr/TpPDaZMNlLABP34Xvd61mlKto1fNo3BQYjHSmpxmBU+2++lyitO6LZ3rOeprzpNFVWx74RjqdPNoxXyndGh3r6+c7sShX/44YcnTqLwgSKE4Morr6S1tZUvv/wS6E44Xl1dTX5+fmzfO+64g4qKCj766CMA3G43eXl5rFy5kqlTp7Jp0yZmz55NbW0tycl9LxCZyNEGY4nKf7DjnSi8zRfk430eajxhDBG9O4oYglA4QkfYQEEh12lC0zQ0VUEROnaTSppNQ1GgukOwozGANxhiuMtCqk1DIGgJKui6gUUV0TsWQ5DlMJHe2YtU1R7gwz1earxhRqZZOb84mbXVHaTZFHY1BRmbaWXmMCcum4mWjiDnFTrJcJjY1xpkyb4Ovq7xI3Sd1oBOSBd8daCD/zk/nxynmTv+URGr5+3T01l84TCSzCq6rvPTj6p5bnMrBclmMpMsfKvYxU/PSOOAJ4w7YFCUakYzmdhY6+OH71RQlGrhtmlp+CMwLS+JfKdGrTtEXUeYsNGZ1kXVCIZ1MuzRXgJNgYgAdxgUYRAMG9R7wzy8qhEDhXGZdm6dkkrYiB5Lp1VjmMtCst2MoUdwmFSCusGOpiB+XeGa8alMfmp7bPhs24/GcvnrFZS1hOJ6VoYnmzm/OJkfTEnn5S1N/GVzKwA/Pj2dSblOlu338rdt3b0TU3JsnDHMxb0zM3slAdY0jbU1HWyr91HtCfNumZu9rWHcYVCFQVGKifvOymL+6GSsJg2zFj2+m+p81HVEeGeXG09YcG6RizGpGnOLnLhDBl9Uenlzl5cl+7xYFT2WemhEqoU/XVbIuYVOAqEIe1uDmFQFp0XFHYb1tX4qW/0YAq4cm8KMZ8tivRNW1WB6roO1ncOWXT0rZkXQcyRu5a1jeXNHK6urOshN0hifaeOH0zLY3Rrh4pf3xN3JGyg03juZX62s45erGuK2d/VOPHv5cE7PdTAq3UpAV/j3ZXX4giFqPRHGZ1k5v8jJ33d5WbrPQ1NHtKfk3rMyuXpcKtPykvjpkmoq24I8dlEen1d4+elHNbE69TyvH98wklkFyTy7sYmvq72cP8LJnuYgH5V7qfIYzBuZxA8mpnBukZNqT5gtDQE+Lvfx2tZmbpuexvlFToa5zDT6DRp8BiZ0xmXYiBjRobgVB3x8UeVn/kgHY9OttAd13t/jwR0STMt1cO04J1eOSUFTFUK6QZ1PsL0xQHV7ALOmoBuCTIeJHS1hxmXYeH5TEx91DsXfMjWNoNCwqvDtUUlcPNLF9P/bzb7WELqiccuUFJ66ZBivbW/l1n8ciDt/KoLF5+di1RRcNhNjMx1UtwfY3xZkeUUH03Ns2C0mdBS21HZg0eCfxkVzSjosJvwRWHPATa03zI6mIIGIgapqGCjsavRh1RRGpJpxmlWGpdroCAne3N5CyBAUuMw8Ni8fTdO44MW9lLcGSDKr3HdWFisP+Hjg3DzOf2FP3HkCuGFqJhPSLZw93M7SfR4uK0kmyaLyy69b+GyfmxpPiPmjXPzb7GxOz09CKCorKtwsWl6HN2ywsynAsGQrF41KYVqWmUyHhtOsUtEe5qNyL2cXusi1KxhCMMxlwWFWWFUTZGKWjUtfifai5iSZKE61YDWbuGpsCt8qsvOPMncsKbiOyjkFSSy9fgQQ/R56an0zL25zMyHTyshkjQZfhDS7xqa6AD5dJcUa7TU0aQreoMHkHDsj0uy0+MJk2VVaAzopVo0cpxkUFcPQ41KGdESgLSTQRPR6vb7Wx7bGIC0Bg8k5Dr4z1sllJcnUd0S46OV97GmLcG6hk1SLoCMkmJRtZVKWjTFZDtJsGt5AmEZfhHyXmfqOCIqqEdYFJsVAiOii2IGIQUhoBCI6Hn+YiBD8enV03t+EnCRevnI4JWkW2gM6u5qj7cNpt3CgLYg3FJ1iENQNFEXFaTOjCp0WX4QWfwSHWSXNYebHS2rRhM5zlxfEsquckj1jd911F++//z4rVqxg+PBoupOuYKympoa8vLzYvrfffjtVVVUsWbIEgKeffponn3yS0tLu5NOTJ09mwYIF3HHHHf0qR6Jg7Msvv2T+/Pmxn//4xz9yww03HLb80rH7p7+V816Zh0cuyONfZmbGNeaIEX3CqTjVMujlKvzddmq9EdbfVsKUfj6dl/f4Npo6UyDtXzCePS1Brv77ftxBg2EuM/82O5vbpqUfNq9bW0DnjZ1tTM+19zuLgSEE2xuDZDo0cp3mfv3uoexsCjAyzRLr5j8Sc1/Yw1cHuueMHfjpeC5/fT8bO9ermj3cwVPfHs6UP3X3KveVdPrLSi8XvLSv13bfA5MRCE7/vzJ2NndP4l9wZiaPXZTfa/9DEUIc8qIqRDRp8zu73VxU7OK6CSn8v2V13H1mJuMzT/y8qz11PXUIEPq3yb3qPfmPu2LH87Zp6Tz17ei17z+W1fHwyvinKQc7UXgiNZ4wT69v5vIxyXGLTl/+WjlL9kaDTqdF5Y1ririguP85iwdKV+L1/5qTw7+fE79yQLMvQtHvdxDsvDtJtM+p4G/b23i3zM1vLsonw3HsC0J8780K3tjZzuMX5XP3mZkDUMKjM6RLWyxYsIB3332XL774Ii6Qyc2NzqGpq6uLC8YaGhrilrZ49tln2bZtGyZTdzUMw+CZZ57pdzCWyBlnnBHLgQm9l9Xoq/zSsXvzOyMwBAkDE5OqDEkgBrDhtjHUeMP9DsQgvi6qAucVOdl251iqPWGm59qPeImLVJvGrdOOblFHVVGYlD3wgcG4owg2/vf8POa+GB16+N7EVHKcZtb8c0mst7g/Swkkaiea0rUQpkLpnWP5tNyDqijMHObAcRTLUByuPIqi8IMp6fxgSnd+vkPl0zyR9WyLierdczmInv+elHViBp35LjP/PTe31/bXri7ivTI35xYmkWRWST5BkogHEzyYkeEw8d0JqbxYGu0t729S8W+KY80PfLALi52k2TQmZFoPv/NxNCTBmBCCBQsW8NZbb7Fs2TKKi4vjXi8uLiY3N5elS5fG5oyFQiGWL1/OI488AkBpaSnr1q1j2bJlpKd3X/za2tqYM2cOW7duTTh/qz/sdjujR4/ud/mlY6coCifiIt6ZDhOZR3k31rM+Xf/MdZoHtIfqZDK7IInW+yaioJBk6Q6ODv7yPyPPzrpa/yEDcC1BwHDw4/0XDmGPx8nmcNmMeq723vPf4QF6QnuwOMwq3x3AL/ZjZVYVwobgghHOhK//+lt50eE1m8YZecdn3bxTze3TM2D64fc73oYkGLvrrrt45ZVXeOedd3C5XNTVRcfBU1JSsNvtKIrCwoULWbx4MSUlJZSUlLB48WIcDgfXX389AM888wwzZsxI+PTirFmzeOaZZ3j88ccPW5auni+v10tjYyObNm3CYrEwYcKEoy6/JCXSs/fmBIwzh4TTcvieiL9dU8TjXzfxk0OkeEm0rJLNJI/y0TrcjVDP1d57HvuBWi7nVLXv7nHsaQlxTmHi3JJpdhNPXDJskEslDYYhCcaeeuopIDpPq6fnnnsulqT7/vvvx+/385Of/ITW1lZmzpzJxx9/jMvlIhQK8dJLL8WWvTjYNddcw0MPPcQjjzyCxXLo4ayeT2uuX7+eV155haKiIvbv339M5Zekg/X8gjvVVt0/FsOTLfz6MPO7Eh1PufDl0Ttc+zT3MUx5cCw2zHVq9voerVO5p/xUN2TDlIejKAqLFi1i0aJFvV6zWCw0NfVe0bzLPffcwz333DNgZRmI35Gk+Hk4Q1iQb6BEw2rf0OxEg6LnJPdEegZj5rhgrPvaePW4ZP5wyck5Z06SBpu8XEnSIFHiesaGrhzfRInmjCWaBC0dmeJUCxtvG0PlT8cnfN3cY3S5Z89YzyOeajMNyNNu0uGtr/Ux4emdPPRV/VAXRTpK3+hgbOLEiTidzoR/Xn755aEunnSKURNM4JcGRqLgNhCRwdixmJRtI6+PITNnj2is52hwz2HKFl/8WkzS4f1mTSPnPr+nV+qlw3n860bKWkL85/J6OXJzkupXMHYkCbKFECxatIj8/Hzsdjtz585l27ZtCd/veCb4DofDXHzxxaSnpxMOhxk+fDi/+93v2LRpE5s2beKKK65I+DsPPPAAkydPJikpifz8fH7wgx9QUxOfTDYYDLJgwQIyMzNJSkriiiuu4MCBA/2qg9Q/h8ulN1gihmBH09HlAu0ZL8g5Y0cuGInmj/yiwtvnPomCsZ6TyQMRg/9cVsew32znq6rBzSH7TZRs6/7q6GuYsrZDBmP99a+f1LK62sevVzcefuceWvzdwVtXsnHp5NKvYOxkSvD9//7f/+O1117j6aefZseOHfzsZz/jrrvuwuPxMHr06ITpCXw+Hxs2bOA//uM/2LBhA2+++Sa7d+/uFbgtXLiQt956i1dffZUVK1bg9Xq57LLLeq2+Kw2MX65qIO1XW/nVqobD73yc3bWkmil/2s1LW9v6/buHmjO2orKDD/e4T5ig80ThDuo4H93Kk+uaufDlfbFEyQdLFNxGDMEbO9owL96C69GtPLSygQZfhGvf2H+cS/3N8NT6JmwPbeHfPquNJT3vktJjPa6up4RXVHbw04+6b1zreiQYlw6v52e/wt2/gKqivXv/NTW+Q+wpnaiOaQX+EznBd35+Pr/4xS+46667YtuuuuoqnE4nL7300hG//9q1a5kxYwYVFRUUFhbS3t5OVlYWL774Itdddx0ANTU1FBQU8MEHH3DxxRf3uw5HSwjBE+uauXJMMq0BnUZfhJJ0K5l2U9y6TT21+CNsrIsmbF2y18O6Wh9XjklhcraN8ZlWzh4eXfxQVaLzP1QlmojXYVZi6z91NZlARKAq0X00te/enoghomlMlGgKkLbO9EfukIECeEIGeU5TbEjEYY6mXmr167QEIkz6Y/cK7O9+dwTzR8enujKEQAHqOiJk2LVYeh6AA+4wWxsDTM62sbneT0V7iGk5dsZn2ugIG6gKBCMCq0lBAWo8EVJtGk6LSmGKGSGivS5dde9aIRtg421jmJBl7Twm0SEaQwgMAf6IQUfYwBc2WHXAR0GymZ99XMOuzlXLW++biNOi4Q3pLPqint+uiT6QclqunQfn5HDJKFfseEYMQZMvQqbDhElVEELwXpkbAUzItJGTFD3fqqIQMaLnRCE6Z8qqKXHrdgkh2NcWiqaiybWTnWTCpil8daCDjrBBcaoFh1nFYVLJ7UwE7wsb2Exq3HpSQkSzIOxuCeINGbQGdMZmWJmeY8feOXM+YgjaAzodYQNPyOD17W2k2jQ21/uZmGXj3rOyErYZIQQC2NYY4NJXy6n1xgdgV4xJ5pnLCki1aVS0h9jZFGREqjmunQCxPIyJvHXtCC4r6TtlWntA59P9XpZVeClINqMpCslWNVa34S4zo9IsOC0a7UGdLIcJq6b0WnxWNwTlbSGqPeFYO893mcl2mGL7hnXBF5VetjUGmTXcwWm5djrCBm2BaIJl7aCepwPuMJvr/dz7SS1FKWauHpfC/FHJDE+Ofn7e3e0m065xdkFS3HwuiAa3SeboOa31RnCHdEanWUmxqnHtZHmFl2+93J3R4MIRTp67oiD2Gf3PZXU81LnSftdK8GP/sJN9PXplzKqC5/5JaGq0XXpDBi6Lyt7WEK7O9Go5SSbManwb1Q1BUBfc+f4Bmv0Rzi1MYlyGjSSLijdkUJRiZky6FYdZRev8PHSEDZLM3XXQO9NEPbmuiYJkCxOzbFw8yhV7urPeG+aJdc00+SLkJJn4p3EpTMqyxY51xBC9jl0inqBOjTfM1oYAo9KtjEq14A0btAd0xmRY+XCPh0nZNopSLPjDBjubg+xrDZLrNHNGnh1r5xivEIKb3qnkte3dyeIXzckh1aZx4QgnRSkWgrpge1OADHs0EB6bYYu1n+Rflsaue3efkcHj86LLXwQjBiFd4AsbJFs17GYVvTODiUVTyO/xtOuLpa0sq/CycEYmkzsXtTaEYNUBH6UNASZmWUmyqBS4LJS3h1hR2cEZeXZKMqwEItFr0j1Lo8F4vtPE5zeNojjVEnduazxhNtRFr8OzhjuYkm2PHWd/OJrw3KIpqEr0HHS1Dd0QRAzBrpYgEUOQZjORYu1K6RdtAwcvEt7qjxAxoje+XddEVYm+98Y6P4u+qOfbo1386PSMI1pi53g7pmDsRE7wnZGRwaOPPsqtt94a2/b973+fVatWHXLZioN98sknzJs3j7a2NpKTk/nss8+48MILaWlpIS0tLbbf1KlTueqqq/iv//qvXu9xvHJTLq/0ccmr+9FEfI+cjkqqTcMXDDMu00azL0J7UCeCSiAieuViS5RLr2t7V345kwpJZhWHWaU1pOALRVB7TNcVKBiKihkjtoSDLgQoCmGh9ipjz/yAB5c9w2GizRfqtR0g3Qp/vHQ4l5WksK81yMOrmnmxtPWo6nS47V11UoWB0xwNON1Bo8+yH6pOKErc9lunpZGZZOX/NrbQnKCuI1MtzMyzsq0pyLbGQKyMDhMEwwe9f2fZM2wq7UE9FoDoihatvxAMc5kpSDazszlEc1CgCqNXHscjrVOKNZprMiKUhHW1aAouM3hD3Xkru85fovMxt9BBriP6xTCn0Mk1f6847HlymCDNplHrjSBQUFQVYfRdpztPS+dHp2Wy8OMaPq/swG7R+PKmYoY5zayp8VHa4OeJ9a1cNCqZ/c1+VlV3dB/Hvsp+0HanRaUw2YxQTUR0g45gmNaAjr9z7lrPOjktKpeVuGjs0Pmk0o8wuusazYsabXsuEyR1fl+aVYX2kMAd5ojbXkGKleEpVsKRMFXtYeo7hw4T1WlchhW7xcS6Wn/C85RqVTkrz0ZZa5Aad4iQcfjP07+elcHfd7RT0R6O+zwpPeqKomI2aWBEiBgi1maO5PPUfa2Jbrd2tr1AxOg+7p11tamC4lRL7IbAZ6hx14gsh4bTotEUhHZ/OJqT16JhiGjezv1ug4iuU5hsQgjwhQ1aAkavOvVVdrXzvHZtt5kUvj3KRWGqhce+bkEoiT9PB5+nru2zhzuYlGXhla2t+MLdbQwhuGiEg5AeDUh7no+Dz9Pk3CRCYZ1dzd0JvgUKuS4LdZ7QUV8jDj5Po9Is7G0N9aqTArEgO1FdVQUMRUM3juxablJBM5mIRAz0Ht+5idpez7JfMsLBy/9UGMvMMRS5KY/6URchBPfccw/nnHNObKX7rsVPD04blJOTQ0VFd+Jnt9vNG2+8wcqVKwG48cYbmT17Nr///e/7neC7LxdffDGPPfYYc+bMYdSoUXz66ae88847/RpKDAQC/PznP+f666+Plauurg6LxRIXiEG0jl31P1hZWRm7d3fftRcWFjJ16lS2bt1KZWVlbPuYMWMYO3Ys69ato7Gxe85AVwb5FStWxA33mgunMDbdSlHjWkzoOEwq/ojBcnUcnoCFi40tUA9dD5d/pE7BSYgL2YUCpNs1hKrhGzELd0sTrobteMPRBuzFxhfaeIaLFiaLKjCACDT6XRzQRlMi6ikR3fWtUjIoVQoZZxygQDR3113JpUzN4zSjnCy6y75dK6TJksWM4A5cRO92BLBGHUWTP5l5xjZMRM9VbpKJC8+fy8Nr2iloWMtzf9/EcwfVaY6xM/beETQ+1qaQiYcZxt7Y9l516tSIi7XaaMbSwEQ1OgE2pAsqOus0URygIHhQnZTedSpVCqhSMplt7MZJ9OJmUmElo/CaUpgT7K7TgQ3wijoOPxauNW3ljHwHeU4Tm+sD/Nk7joY2N+0tOxlO9Px11ckRdjO3s04WTcEtrHxGZ518ves00ug8T+1AO+QrGXjMRUzUD5Cn967TbK2CDMMdexIxUZ3wd54nJZkLjW2kmKO9cYGI4FPG4tctzAx39yCqCnyoTMHex3naWlGHw9iLG9i5Gmb3OE+nqwfISTJR5Q6TnpHJS20FjBb1lITqIARTutqeKGSySND2lDw+vSBAS9MW9qyBO1yCPTipDGfyL39+v7tOQFgdxQtbdObpW7io8zxZNYXW3GkkJyWRX/c13pBBSyD6WXtXTMIietQpAJFAZ9sT7l5tryF7GmZPPQX+cghAaym04sLQRjNFa2CCUo87FP38dX2eRoQqe7U9d4/PU2GymUp3OPF5Ata0j2KFO5l5+hYy6L72faGOI6JauZSt+Luin8bEn6dLRqfy0/JiTIE21L17GQuM5fCfp9Ginq0rNzMOGNejThMTnSeRx5n6vl6fp0ZzFt+z7yfo9+ILCxQFVoiRNBFte6aD6uTXLczo0fZSrCramNnsrHOT3bgZOldEOgeNpmEzuTQvQt3OjVR7w+CN1mmPNp4C0cLkSBV0fuc2+l2Eu657bfHXvX2WEYwMVsbVaY+Sy+4E14j9thE4MvPJrN+IGvLTsQN2ABnqqLg6JXcGKMs6rxEXG911guh52nyghZTKnZzbuS3ZZmF/9pnsOVCHed8mzMDFhztP9aMpMWq5+OBruTf+82RWFXaSwy4Ofd1L14KEOq8da3rWqVmnK5fN15bxpCQ5GN+6KRoWBbrr1Nc1outablGjvc+thqX7utezToaLtWI0JUZdwu+ng9veHjWX3eTRvHcLr75dSp4zGhL19Z07c+ZMsrOzY9O0usydOxe73c6HH34Yd57mz5+P3+9POC3qYEfdM3YiJ/iG6BDq7bffzj/+8Q8URWHUqFF861vf4rnnnsPn8/Hyyy/HDZt++OGHnHvuubGfw+Ew1157LZWVlSxbtiwWjL3yyiv88Ic/JBgMxv1/F110EaNGjeLpp5/uVcbj1TOmadEhuXZ/CJdFjQ0H+CKwsznIhhovOUkmgrrAHzZIspmZV+wi1RofpZtMJoQQRCIR2gI6NZ4ItR1hhqXYaPKGyUlSOeAJoykKKTYNi9mEhsBpVnCaVXQhMES0dyIc0YkYBroR7eK2WUwkWTQ0YSA670ismopJi94Nd9VJCMGu5iC7WiO0BHRM6MwpdBLWBaPSLJhMJrwhnYdW1PKbr5tivRbfGpnCOYVJtPiC/MuMbOo7wmQ6TKQ6LNHEzsLAokWPi0VTo8fdMPCH9NgK7boATTOhYsTORzBisLc1TKrDDIZOaYMfp0Xj4lf2YaDwxPwCbpzooj1gxLrBNVXFpGnoegRNUWJDu113R9P+uCM2TFmcamZPm86PT8/gobnZseEKgICu8M7udqraAozPtFKcaiXfZSYkVJp8YTqCEXKdJgqSo3WMoFHeGqDeE2JkupVmXwSrSSEv2UZ7IMK2Bh8f7nGT7TBx3ggXZxe60BDsbQnE8vHZLRomrft8BCMG7qBBSIDTYiIYClPjjdCVB1woGhOybGhCjxu+9oSh0afT5g+R5YgOPZs1BVWNDiF13QxtqvNT6Q6xpTHMxjofH+3pHp4Zl2HlF3PyQRhcNjp6EdtQ5+OMPAdWi5kXNjdzx3vRm5hfXpjHnadn8tcdbu74R2Wvu979P51Itj2+ve9tC/P9t6vYXt8919VpUWkPwcKZWQxLUvj26GRGplljnzPovus1hEBVFMIiOoRv16LDavtaQ7QHddrDClYNsmwKKVaNfJcZm0nBbDZjGAb+UIT3ytzsag6iCxib5eA745JRiQ7F7GsNkm43k+ows6fJT0g3cAd1bCYVq1ljUrYDYURiQ7zBiEFAhw31QcKRMLOGRVdv31zvx2w2sbslhEM1SLFpjEix4LKoJFnNuKzR3sT2gM4/ytpZus+DjsYtU9P5zt/2xnqovA9MxhOGv+1o4/N97QxLNuMJ6jy/pQ1d0bhpUjLbGvx4Qgb7uno/Duq1uGSUi7vPzMRuMXNmrpWQbmBWFfa0BBGKSltQ4A2G8IUN7v+kFotJ4Z3rRlKSYe913UNR8UcEvmCYkCEIhA2cFo1KbzRI9gTCJJlVxmZaMandn7+le9t4ubSVM/MdnJbrYGaBC1WJntdAxGBTnR93SCc9yUqRy0QgolPnjeAJ6YR1gcNqAcPApEaH/20mlYIUC6l2c+wa3xE20BQFi0mjyhOh1h2gzhvGGza4cISLYckWNE0jHA6zZK+H365pYkVVBzoqc4qcfFXhBmDLHWMYmWbtvMYLKtsCNPsiTMq2ETFgZ0uY696ooNbT/T104+RUnvh2EZf+dR9fVUaHRx86P5dRaVZGpNtp90eocQdRFYXiNAvugM7LOzz8amUdLovKvJFO7j0rG1/YYGNDCH8oglmFq8elYDNFv4MCOgRCYRxmFZOqEOhsewYqqZbo58IXNthc72d6npPfr2si1Qwj0yzkJpmxmhTGZkXXsAuFI5S1BClrCdLki3Dp2DScZpWmjmgbsptUwobApytsbfCTaVOYXZAUu95EUGnzRzAMgwPuEFlJJlTAUE0Ewzp2E7HgChQUVSMciaB33vhbNAWzpjL1z3vY0+zj1asLuawkBRianrGjCsYWLFjA22+/zRdffBGXl/FIhylnzJjBunXrUNXuLyDDMDjzzDP5+uuv+1WWvoKxLoFAgObmZvLz8/n5z3/Oe++9x7Zt2/B4PNTXd6/JMmzYsFgqo3A4zHe/+1327dvHZ599RkZGdxqWoxmmlAZWtSfMzqYAI1ItjEob3OSuXXPGHr8on7vPzOzX757xzG4210dvAz3/OhFFUeKCsFNZqz/Cy1vbCBuC26enH3YOx46mACNSLLE5XNWeMCN+vyNuHwUI/fuUPt/DHYzOsyxOtcinWw/yxNom/mVpDclWleZ7e+f4ffzrRu7/tBaAv1xRwA2T0jjgDlH8RLRX44ZJqdx9ZiYZdtMhc4r2pSvgPZV0hAxSf7UVgO0/GktJ+qGvbSHdYPGKBv73q+jcvd/Oy+cnZ/TvmiTBt/+6j6Xl3lg7Hir9GqY8WRJ892Sz2Rg2bBjhcJg33niD7373uwC4XK6EXYddgVhZWRmff/55XCAGcPrpp2M2m1m6dGnsvWpra9m6dSuPPvrogJVb6tswl3nI06wUpfT//+/51aKp8RPiT3VpdlO/gtvxmba4n3vOtS5wmajyRHjuioJDvkeyVSPZeuig71T1o9MzSLdrnFOQOEdiz8ntps6gqec2VVE4I+/Qq/gfyqkWiAHYzd11TjmCdmnRVH4+OzsWjFllLtaj4uq88XMHh3Y1hH4FYydTgu+vv/6a6upqpk2bRnV1NYsWLcIwDO6///4+3zMSifCd73yHDRs28N5776HreqyO6enpWCwWUlJSuPXWW7n33nvJyMggPT2d++67j8mTJ/Otb32rP4dTOgl99P1i1tb6D/kkXl9kOqTjp2f/4gOzc7huQiqpNhloHS2TqnD9IXoJenbodv37SJ4+lPqmKgrvf6+YjpBBdtKRfTXbTCpXjElmV1OQfxqbcpxL+M00JcdGa0AnJ2mIc4KKfiC62kGvP88991xsH8MwxIMPPihyc3OF1WoVc+bMEaWlpUIIIYLBoMjIyBCPPvpowvf/9a9/LTIzM0UwGDyqshQVFcVeX7ZsmRg/frywWq0iIyND3HTTTaK6uvqQ71leXt5nHT///PPYfn6/X9x9990iPT1d2O12cdlll4nKysrDllk6tc18drcw/e9mYfrfzUI3jKEuzjdKgzccO7Z/XN801MX5xvvzhqbY8X57Z5sQQohWfyS27eZ3Koa4hKcWQ15PTnrHtLSFJElH7uy/lLG2xg9A6N8mH9GkTunItPgj5Dy+HYAnLxnGHadlHOY3pGPxl80t3P5+NOvIO98dwbdHJ+MN6aT9Kppt5XsTU3nxysKhLKIknVTk7GFJGiTxw5QyEBtIcgh4cMXNGVN7zxmT9/iS1D8nZDAmE3xL30QyRjh+5HSlwWWOm8Df+XdcpoDBLpEkndyOetHX4+mDDz4gHE6c1+zgBWUl6WQhA4bjRx7bwdVzAn/XU8E9Hw7WDSRJ6ocTMhgrKioa6iJI0oCT8cLxcyouhTCUevaCdeUD7Dn0LhPeS1L/nJDDlJL0TSQDhuNH9owNrp5r5CVa0kJ2jElS/8hgTJIGiYzFjh9NHtxB1TMAMycIxnQ5aUyS+kUGY5I0SGTvzfEjj+3gipvAn+BbRMZiktQ/MhiTpEEihymPH1VOHh9U8SvwJximlMGYJPWLDMYkaZDI3pvjp+fk8YiMBI477XDDlHICvyT1iwzGJGmQyFhscIRlMHbcmRMs+tqTPAWS1D8yGJOkQSJHKQeH7Bk7/nq2ZYe599eIXNpCkvpHBmOSJH2jyGDs+PMGuyfmpdu1Xq/LeXuS1D8yGJOkQaLIgcpBEdZlMHa8pfUIwBIPU8pzIEn9cUKuwC9JknS0ClIsQ12Eb7ypOXZ+d3E+xamJj3WiAE2SpL7JYEySBomcM3Z8Lfl+McsrOvjB5LShLsop4cenZ/b5mgzGJKl/ZDAmSYNEfj0dXxcWu7iw2DXUxZCIT5ckSdLhyTljkiRJ0oBKtPaYJEl9k8GYJEmSNKASpUiSJKlv8iMjSZIkDYjvT0wF4L5Z2UNbEEk6ycg5Y5I0SOQEfumb7vkrCvjdxcNItfVee0ySpL7JnjFJkiRpQCiKIgMxSToKMhiTpEEiO8YkSZKkRGQwJkmDRA5TSpIkSYnIYEySBolMmShJkiQlIoMxSRokMhiTJEmSEpHBmCQNEpk8WZIkSUpEBmOSNEhkz5gkSZKUiAzGJGmQyGBMkiRJSkQGY5I0SOQwpSRJkpSIDMYkaZDInjFJkiQpERmMSdIgkcGYJEmSlIgMxiRpkMhhSkmSJCkRGYxJ0iCRPWOSJElSIjIYk6RBIoMxSZIkKREZjEnSILGZZHJKSZIkqTcZjEnSIHnykmGUpFv4v8uGD3VRJEmSpBOIIoScVSxJkiRJkjRUZM+YJEmSJEnSEDINdQG+6YQQeDyeoS6GJEmSJElDxOVyoSh9zxuWwdhx5vF4SElJGepiSJIkSZI0RNrb20lOTu7zdTln7DiTPWOSJEmSdGo7XM+YDMYkSZIkSZKGkJzAL0mSJEmSNIRkMCZJkiRJkjSEZDAmSZIkSZI0hGQwJkmSJEmSNIRkMHYS+8Mf/kBxcTE2m43TTz+dL7/8cqiLdNJatGgRiqLE/cnNzY29LoRg0aJF5OfnY7fbmTt3Ltu2bYt7j2AwyIIFC8jMzCQpKYkrrriCAwcODHZVTlhffPEFl19+Ofn5+SiKwttvvx33+kAd49bWVm666SZSUlJISUnhpptuoq2t7TjX7sR0uGN+yy239Gr3Z511Vtw+8pj3z0MPPcSZZ56Jy+UiOzubq666il27dsXtI9v6wDqSY36it3UZjJ2kXnvtNRYuXMgvfvELNm7cyLnnnsv8+fOprKwc6qKdtCZOnEhtbW3sT2lpaey1Rx99lMcee4wnnniCtWvXkpuby0UXXRS3bMnChQt56623ePXVV1mxYgVer5fLLrsMXdeHojonnI6ODqZOncoTTzyR8PWBOsbXX389mzZtYsmSJSxZsoRNmzZx0003Hff6nYgOd8wBLrnkkrh2/8EHH8S9Lo95/yxfvpy77rqL1atXs3TpUiKRCPPmzaOjoyO2j2zrA+tIjjmc4G1dSCelGTNmiB/96Edx28aNGyd+/vOfD1GJTm4PPvigmDp1asLXDMMQubm54uGHH45tCwQCIiUlRTz99NNCCCHa2tqE2WwWr776amyf6upqoaqqWLJkyXEt+8kIEG+99Vbs54E6xtu3bxeAWL16dWyfVatWCUDs3LnzONfqxHbwMRdCiJtvvllceeWVff6OPObHrqGhQQBi+fLlQgjZ1gfDwcdciBO/rcuesZNQKBRi/fr1zJs3L277vHnzWLly5RCV6uRXVlZGfn4+xcXFfO9732Pfvn0AlJeXU1dXF3e8rVYr5513Xux4r1+/nnA4HLdPfn4+kyZNkufkCAzUMV61ahUpKSnMnDkzts9ZZ51FSkqKPA99WLZsGdnZ2YwZM4bbb7+dhoaG2GvymB+79vZ2ANLT0wHZ1gfDwce8y4nc1mUwdhJqampC13VycnLitufk5FBXVzdEpTq5zZw5kxdeeIGPPvqIP//5z9TV1XH22WfT3NwcO6aHOt51dXVYLBbS0tL63Efq20Ad47q6OrKzs3u9f3Z2tjwPCcyfP5+XX36Zzz77jF//+tesXbuWCy64gGAwCMhjfqyEENxzzz2cc845TJo0CZBt/XhLdMzhxG/rMjflSezg1ApCiEOmW5D6Nn/+/Ni/J0+ezKxZsxg1ahTPP/98bJLn0RxveU76ZyCOcaL95XlI7Lrrrov9e9KkSZxxxhkUFRXx/vvvc/XVV/f5e/KYH5m7776bLVu2sGLFil6vybZ+fPR1zE/0ti57xk5CmZmZaJrWKxJvaGjodbclHZ2kpCQmT55MWVlZ7KnKQx3v3NxcQqEQra2tfe4j9W2gjnFubi719fW93r+xsVGehyOQl5dHUVERZWVlgDzmx2LBggW8++67fP755wwfPjy2Xbb146evY57IidbWZTB2ErJYLJx++uksXbo0bvvSpUs5++yzh6hU3yzBYJAdO3aQl5dHcXExubm5ccc7FAqxfPny2PE+/fTTMZvNcfvU1taydetWeU6OwEAd41mzZtHe3s6aNWti+3z99de0t7fL83AEmpubqaqqIi8vD5DH/GgIIbj77rt58803+eyzzyguLo57Xbb1gXe4Y57ICdfWj2n6vzRkXn31VWE2m8Uzzzwjtm/fLhYuXCiSkpLE/v37h7poJ6V7771XLFu2TOzbt0+sXr1aXHbZZcLlcsWO58MPPyxSUlLEm2++KUpLS8X3v/99kZeXJ9xud+w9fvSjH4nhw4eLTz75RGzYsEFccMEFYurUqSISiQxVtU4oHo9HbNy4UWzcuFEA4rHHHhMbN24UFRUVQoiBO8aXXHKJmDJlili1apVYtWqVmDx5srjssssGvb4ngkMdc4/HI+69916xcuVKUV5eLj7//HMxa9YsMWzYMHnMj8GPf/xjkZKSIpYtWyZqa2tjf3w+X2wf2dYH1uGO+cnQ1mUwdhJ78sknRVFRkbBYLOK0006Le4xX6p/rrrtO5OXlCbPZLPLz88XVV18ttm3bFnvdMAzx4IMPitzcXGG1WsWcOXNEaWlp3Hv4/X5x9913i/T0dGG328Vll10mKisrB7sqJ6zPP/9cAL3+3HzzzUKIgTvGzc3N4oYbbhAul0u4XC5xww03iNbW1kGq5YnlUMfc5/OJefPmiaysLGE2m0VhYaG4+eabex1Pecz7J9HxBsRzzz0X20e29YF1uGN+MrR1pbMikiRJkiRJ0hCQc8YkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShtD/D17NLmLrkmFUAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 600x120 with 1 Axes>"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -472,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -481,7 +479,7 @@
        "<AxesSubplot:>"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,13 +511,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Anaconda3\\envs\\openep-tutorials\\lib\\site-packages\\traittypes\\traittypes.py:97: UserWarning: Given trait value dtype \"float64\" does not match required type \"float64\". A coerced copy has been created.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dfc1159d056949eab33bfd8f940474cf",
+       "model_id": "eead2731cb3b4176b62668c2f96f57eb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -532,24 +538,24 @@
     }
    ],
    "source": [
+    "mesh.clear_data()\n",
     "plotter = openep.draw.draw_map(\n",
     "    mesh=mesh,\n",
     "    field=case.fields.bipolar_voltage,\n",
     "    add_mesh_kws=dict(cmap='Turbo'),\n",
-    "    plotter=plotter,\n",
     ")\n",
-    "plotter.show()\n"
+    "plotter.show()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "90beb7dc2a914d37aec9d01015ecef1d",
+       "model_id": "6b9cb88a92794b01aa3ba8ff7cfe05cb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -562,26 +568,611 @@
     }
    ],
    "source": [
+    "mesh.clear_data()\n",
     "plotter = openep.draw.draw_map(\n",
     "    mesh=mesh,\n",
     "    field=bipolar_voltage,\n",
     "    add_mesh_kws=dict(cmap='Turbo'),\n",
-    "    plotter=plotter,\n",
     ")\n",
     "plotter.show()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAGaCAYAAADzQmIDAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAACJ1ElEQVR4nO3deXgTVfcH8G+6pQttukBJQaAFClJK2bG1LLJvsoj+FETcEEXBhboAKiqi4vbK8iIgyvIisqiAgGAVZK9F1gKlrKUFLCnYFlro3mR+f5QJSTqTzEwm+/k8D482TSa3bZI5c++55ygYhmFACCGEEOImvBw9AEIIIYQQOVFwQwghhBC3QsENIYQQQtwKBTeEEEIIcSsU3BBCCCHErVBwQwghhBC3QsENIYQQQtwKBTeEEEIIcSs+jh6Avel0Oly9ehXBwcFQKBSOHg4hhBBCBGAYBrdu3UKjRo3g5WV+bsbjgpurV6+iSZMmjh4GIYQQQiS4cuUK7rnnHrP38bjgJjg4GEDtLyckJMTBoyGEEEKIECUlJWjSpIn+PG6OxwU37FJUSEgIBTeEEEKIixGSUkIJxYQQQghxKxTcEEIIIcStUHBDCCGEELdCwQ0hhBBC3AoFN4QQQghxKxTcEEIIIcStUHBDCCGEELficXVuCCH2pdUxOJhThOu3KhAZ7I9uMeHw9qLWJ4QQ26HghhAX58zBQ2qmBjO3ZEFTXKG/LUrlj/eHxWFQfJQDR0YIcWcU3BDiorQ6Bgt2nsfytFzcLK/W325N8CAlUOJ7TGqmBi+uOgrG5P75xRV4cdVRLHqiEwU4hBCboOCGECdkKchIzdRg2oaTuFlWXeexUoMHKbMsfI+ZMTQOs7Zm1QlsAIABoAAwc0sW+sepnWaWiUjnzLOHxDMpGIbh+vxxWyUlJVCpVCguLqbeUsQpWQoy+GZEDCkAqFX+2D+1j6CTDN8x2UdyBUrmHiP0Q2XNhEQktYgQeG/ijGjpkdiLmPM37ZYiRCCtjkF6diE2ZeQhPbsQWp381wVswGB4ogDuzsZsO3EVM7dwz4gYYgBoiitwMKfI4nNqdQzvMdnbZm7JMvp5hTxGiOu3KizfiTgtS6/X1EyNg0ZGPB0tSxEigD2uTi0FDAoA727KRFFp3aUoPkKCh4M5RXVOTqbPzQZK7CyLpccIFRnsL/mxtBTiWEJer7T0SByFghtCLLBXYqyQIENMYAMICx6Ezp4Y3s/aGRd22axbTLikx9NSiONJCYoJsRdaliIeR8zykpQlG6nkXqKJEhg8CJ09MbyfmBkX02t29uv3h8VJuqKnpRDnICUodjR7LC0T50AzN06EptltT+wVvz2vToUGDOFBfrhRWmUxt0Vo8NAtJhxRKn/kF1dwHpNrlkXoY2YMbYNZW08b/Q7VVm5Vp6UQ5yAlKHYkmu3zLBTcOAl649melOUle16dCg8Y4jBp9VHeXUmhgb74dFQ7wa8bby8F3h8WhxdX1T0m3yyL0McMio/CwPgo2YJ2WgpxHlKCYkehmkueh5alnABNs0sndJpZ6vKSPa9O2YABML+UMyQhCoue6AS1yvg5QwN9MaVfKxx5t7/oD+pB8dzHVKv8eT/4hT7G20uBpBYRGNGhMZJaRFg1o+KKSyHuSujr1dEzaPZcWibOg2ZuHIym2aUTM9sl9Yrf3lenbMBg+nOZLuUMio9C/zi1rMuYUo5pi3GYY++lEFoqNk/o69WRbDnbR68P50XBjYPRNLs0YqeZpV7xS1mysZbQgIGdEZGTlGPaYhx87Bls0lKxMPYOcMWy1WwfvT6cGy1LORhNs4snZZrZmit+KUs21pJzKced2GspxJ2WiuXYIWTpGGJer/besWSL2T53en24K5q5cTBX23HgDITOds3ZfhbJLRugW0y41Vf8zn516klsvRTiTkvFcswuyDlD4YjZDrln+9zp9eHOHDpzs2jRIiQkJCAkJAQhISFISkrCb7/9ZvYxe/bsQefOneHv74/mzZtj8eLFdhqtbbBvPL63gALC65V4iu1Z+YLut2BXNsZ8ewDdP9uJ7Vn5Vl/x02yK8xgUH4X9U/tgzYREzBvdAWsmJGL/1D52K6YotLWFI8kxuyDnDIWjZjvknu1zl9eHu3NocHPPPffg008/xeHDh3H48GH06dMHI0aMwKlTpzjvn5OTgyFDhqBHjx44duwY3n77bbzyyitYv369nUcuH1fZceAsUjM1WJaWK+ox7IcnALsvLxHbsGUipzssFcuxQ0jOXUaO3rEk59KyO7w+PIFDl6WGDRtm9PXHH3+MRYsW4cCBA2jbtm2d+y9evBhNmzbF3LlzAQBt2rTB4cOH8eWXX+Lhhx+2x5BtwhV2HDgD9gNSLMOp4v1T+9Dykouz9dKGOywVy7FRQc7NDs6wcUKupWV3eH14AqfJudFqtfjpp59QWlqKpKQkzvukp6djwIABRrcNHDgQS5cuRXV1NXx9fe0xVJugnA7LrGnWaPrhSTvPXJM9irG5UnE6PtbOLmh1DNIu/CvbcznLbIccO/vc4fXhCRwe3Jw8eRJJSUmoqKhAvXr1sHHjRsTFxXHeNz8/Hw0bNjS6rWHDhqipqUFBQQGioup+qFVWVqKyslL/dUlJibw/gIzsuaXWFcnxwZd24V8KHl2UvRI5HbH9X27WzC5wzYxZ+1zuNNvhDq8PT+DwreCtW7dGRkYGDhw4gBdffBFPPfUUsrL4lx4UCuMXDMMwnLezZs+eDZVKpf/XpEkT+QZP7EqOD74Fu7Lx6toMfaKxNUmM1ITPvuyZyOmI7f9ykrpRgS/pV8wxWIbvDx3DQB2idJuNE67++vAEDp+58fPzQ8uWLQEAXbp0waFDhzBv3jx88803de6rVquRn2+8U+b69evw8fFBRAT3jMf06dORkpKi/7qkpIQCHBdlaTpYLE1xBSauOoop/WIxuU+sqCstKuBlf/Ze2nDlpWIpswvmZsZMWZqh4Hp/hAb66mfY3GG2w5VfH57A4TM3phiGMVpGMpSUlITt27cb3fbHH3+gS5cuvPk2SqVSv9Wc/Udck5CdZVLM2XEeyZ8Kn8WhAl6O4YilDVfe/i92dkFMTpu5GQq+90dxWTUAQBVo/FntyrMdrvz6cHcOnbl5++23MXjwYDRp0gS3bt3C2rVrsXv3bqSmpgKonXXJy8vDypUrAQATJ07EggULkJKSggkTJiA9PR1Lly7FmjVrHPljEDsyt7NsxtA4vP3LSdy88yEqRn6JsIRUKuDlOJTIKZ6Y2QWhM16Te7fElP6tOI8h5P0R4OuNr8d3QkFpJc12EJtxaHBz7do1jBs3DhqNBiqVCgkJCUhNTUX//v0BABqNBpcvX9bfPyYmBtu2bcOUKVPw9ddfo1GjRpg/f75LbwMn4vF9YB/MKZIU2BiyFJiI3dJKjfUsE/o7okROaYRuVBA645Xcsr7V7w8vLwVGdGgs6PkIkcKhwc3SpUvNfn/FihV1buvVqxeOHj1qoxERV8H1gW1trgX7wbsiLQdPJ8dYdXV7/VYF5eUIIPZ3RDWhpLMURMoxMybHFnS6GCBycHhCMSFykSvXYtbW0/h230WM6dYU0fWDjD5khT5HbkEp5u44b9N6LK5Oas0aSuQUT0gQKcfMmNxb0OligEilYNi91B6ipKQEKpUKxcXFlFzsZrQ6Bt0/2ynbbipD7Ids/zi12edgr24ZhkF+CXdiPHuf/VP7OP0J2VZX0uzfim8Jw1l+R7b8+e0VnPEFkeyzmQaR1gQZlt6DfH9XsWMknknM+ZuCG+JW2A9JALIGOOyV7LPJ0Qj298G8Py9w3gcAXuvXCnN2nLN4zDUTEp26aKMtr6TTswsx5tsDFu/nyN+RrX5+OY4rNDiSGkRaE3zxvQf5AhVXCXSJ44k5fzvdVnBCrMG3/TVK5Y+Fj3fElH6tJB2X/ZBelpbLGdgAd7e0RtcPFHRMZ26sZ+vt7s5Sjp+PNT+/ueKOcnXq7v7ZToz59oDFgpRSCx9as8VZ7i3o1GWbSEE5N8TtWMrJaK2uJ6q8vFAzhtZeeadnFwq6v7OWmhfSwXnahpMIVvqia0w4jly6IfoKP7egTNBYHPE70uoYTNtwUtJ2f3OzMv3j1JZ/r+tPItjfF4nNuQOK1EwNJq6qu6GCL0/JUUGkLbagO/PFAHE+FNwQt2Ru+yv7wbsiLQeztp6W7Tlnbc3CwHi1y9djEVLM7WZZNcYu/RteCsCw64SQ5ZXUTA3mWli2s9XvSMhyy4Kd582WFODrYG0pQfq1fq0s/17LqzH2u7+Nfo/smPNLKjDjl5O8Y+IKuhzZ00nuLejOejFAnBMFN8QjeXsp8HRyDL7bnyNrOwf2hOfK9VjEXCGbttPSWNjpJLTEPwN5f0daHYMFOy9geVoObpbfDVwMZ1XYAGLJvouCjmn4exJSvG75XzmCx8sGRM/3jMHm4xpBs4xcQZeQQLthiBI6hsGmjDy77jzTB23F5QgP8sON0iqXvBggzomCG+KxzG19lYo94blyPRZrr5AZ8C/bCC3xP6VfrMVK0UITXlMzNZi2gbtydf6d/mKhgb6iC0DWr6fU/7+QvBExx2dfi9/sFR4QsQyDLkvbuxkAFTU6jP3ub/3t9th+LbTzuCtcDBDnRMEN8Wh8QYhUkcH++hNvZY0OX/5fe4CBU5eaNw0UOjcLs7pBqekMAvscvwlMRI6uH8T7PTG7jfhyVFjszyelsvXrP2bgg+FtMSg+SvBsV2iAL4rLq2UvVWDINDjle42r7gR0pj+73LWYTF9fN0orMWn1MUG/A1e4GCDOiYIb4vFMkx9zC8qw5uBl5JeIC3Yigvxwo7SyzrZW9sTrjNu++QKF4e2jsGRvjlUzWvnF5bzPYQnf7JGYwn/sUpGtXCup1D+n0NmuZ5KjMXfHedlmCk0pAHRuFlbndtPXeP0gJV7/6TiAukGdnD3SuP72XgrzP3t4kC9mPNgW6hDnvBggroG2ghMC462vr/aLRdq0PlgzIRHjk6MFH2NUp8aYtPqYy3QLN7ctecneHDzfM6bOdl4xikqr9DMnYgKbKJ78CiG7uGZuydJvvRbT5VoKw+dkZ7v4TsMK1P5ck/vE4uvHOyIsyJfnntaP6cilG5zfM3yNe3kpzAbvcmy/5nt9meZpmSoqrYY6xJ+6bBOrUHBDCAf2RDBjWFssfqITQgPNn4x6t26A9UfzzJ5439mYiY1H/6lT+8QRLAUKDIB1h/7B5w8n4PtnuyE0QPzJOCzQD9M2cO/uMae8WovtWfl1bhdbD8UeW4fZ5zxy6QbeHxYHAHUCHMO8ke1Z+Zi19TSKSq1r8GqOkJ/b1tuvhSaOy/28hLBoWYoQC9gp/QU7z2N5Wq7Rbht2eWHX2X/NHoMBUFhahSk/HgdgPmlTbHVYKdVkBW33Lq/GuGUHoQ5R4rGu92DJneRWoSesv7ILJOWyFJdVY+Kqo3g2ORr949T6n0fsCdmeW4ev36rAiA6NzSaRA+BcUuNizbKVkJ/b1tuvrZ01qx+ktHwnQsyg4IYQAby9FHi1XytM7hOLgzlF2J6Vj2VpuVbko3AnbYotzS+1lL+YK+P8kkp8szcHL4jYlqwOUWL76euCn8OQYTXoZWm5+p9HeNPS2gKBlrZBy4kdGxsIH8guRPrFAgC1M4Bdo8PR64tdgsehvpP3JGa3lJgt07auxWTtzMvrPx3HB8MpkZhIR8tShIjg7aVAt5hw/JZZd9lEDK4cEbGl+a0p5S/linzd4X+w583eZnORFHf+jenWFMXl8iy9sD9P4a1K3pwWQ2sPXYZWx+i3QbPjsgU2l8YwCNielY83fj6OBbuysWDXBYz97m8kzv5TUFA4uXdLrJmQiP1T++CtQW0sLocajgMQvmXa3O9Gju3X1s6aXStxzjw14joouCFEJLkSVQ1zRMQmy4q9vyn2yl3MqetmWTUO3dnezeYiRfH0DzK3lVss9id4b0umoJkPw7wbvj5HcuAKAvgCzqLSKkHHjG1YT59IezCnSPCyHl/fJnPE9oASQ8jry9z3hLyGCTGHlqUIEUnuZMfrtypEJcsmtYgQfX9TUgsYpl8sQHJsfQDm+wcJ7a8lFAOISsK9fquCs97QjtP5WP7XJVnGZFqDxdokWsB4xkPo62xy75aY0r+VpFkWMT2gxLBUPBAAXu0bi7l/nuc9hqXXMCHmUHBDiEhyJ6pGBvuLTpaVY7eLtAKGxic9vv5B3WLCJVX9lUvOv7c56w2N7trU6mNPeqAFusc2qBMEWDOjx5XjIvR1lsTTZFMooT2gxBoUH4Xne8bg2305YAyiG4UCmNAjBjENhM3u0c4pIgUtSxEiUreYcIQH+clyLHWIEt1iwkXvXpFrt8ug+Cjsn9oH7wxpI+h49wlIMNXqGBzILkRFlVbQMW1h7p8XOHOR5lho2GlJWKAvUga05qzBYs1JmKuXltClw9d/Ou6UuSmpmRos2ZtTp66NjgGW7M1BbkGpoONQw0wiBQU3hIjk7aXAyA6NZDlWRY0O27PyLZ7ITBNXxd7fHG8vBZ7tHiMoefXNn82fSFMzNej+2U6MXfo3Kmp0Fo9nT3Jkbswe1Y53lsSw15Q5QUrvOrdx/e6FJkQ7Y/KtkCW6NQcvQx0iz2uYEFMU3BAiQf84tSzHYWu6fLw1C6O7NtGXvjfElbgq924Xby8FPh3VzuL92JYDhidSrY5BenYhZm05JboaMeu+6DD0alVf9ONsoZ7SB+oQ40AlNMAXU/q14v27p2Zq8PqPGWaPq0DtzE9pZd0ZreKyas4AhV06bBjCHzg5Y/KtkJyw/JJKjOlWu0xoix1bxLNRcEOIBOzMibUMa7rM2XEeoYG+UJlcxfPtXpF7t8ug+CgsfqIT1CH8P5fpiZSdqRnz7QEsTcsV9XyG/s69gT3nCgDU9h6yB76nuV1ZAwAYlqDWV2a+WV6NOTvOoftnO3m35OeXVJp9PgZAtZZ7NstcgDIoPgr/ebSDxWNb2y5BTkKX6KLrB9psxxbxbJRQTIgEhrtBAPmaIBaX1XaMHhzfEC0aBCOpRQQSeRJGtToGqgA/vDXoXhTdrkR4kB/UqgDe3S5CKhkPio9CsNIXY5f+zTtG9kS6YOcFzN1xTvYCeey5fXxyNPq0aYjXf8zAtZJKWZ9nSr9YrD10hXd2Ib+kEltO1K1lZFp8UewOqdscszYsc7uDCm6bD5xYzpJ8KyYnLKlFhE12bBHPRsENIRJJ221kHnuS/C3zGoBrWH/0H85qw+YqE3OdFMzd3/TEIvQEuTwtx6aVfzccy8PbQ+PwwfC2mHgniLQWuytpcp9YvPhASyTO3iFqi7lpx2xbNOdkf/+GwWjBLWHBjbMk34qtgGyrHVvEc1FwQ4gVDOuE5BeXY9bW07hRWiXbSZ+rTQO7DGL6HOZaOvDdf+Kqo3W2bAvdCXZTpgrEfG6UVePARfnq5ZjmcRzMKZLUwNJwhsUWMyWRwf6cwaiXgr+jtrXtEuQmpM4N5dMQW6KcG+LS2GTWTRl5Duu2zV51PtTpHnzyULyssxmmuRi2qGRsWovmhoVqugoAgX51d/zYwv7z/+KNn45LeqzpedM0j8PawISd6ZILuzvoRmklZ5Vjc4ENIC1YsOX7x5YVkAmxhGZuiMuS2jTSlgbFR+HZ5GgssyK51pRpsqiclYz5jsGHvQpX2OmCe1laDiprpJ1wF4zpiLAgJW8eh7WBCXvMKJW/1UtT7KhmDI3DrK3mc3hMZ3BMKyVz4cq32p6Vb/P3j60qIBNiCQU3xCWJXZqxp/5xalmDG5a4Tt4VSM8uxG9W1j4JD/I1Wrrx9/VCbGQ9nMgrseq4QkkNbB5oVR9DEszXIpLaNdxwCYhdfrE2J4gNUFQBfhYDJR0DzBjaBvWDlYKCBa6LAL7q0bZ4/1A+DXEECm6Iy7G01GKY8OmIK0SpJ01LxMw0zPr1lKR8ElMjOjTGpoyr+saP5dU6uwU21ugR28Doa76dYmL7a3EtAQ2Kj8JrFvok8XnpgRboYdDKYVNGnqDH1Q9WYkSHxhbvx3cRwNcWwxneP4TIgYIb4nKsbRppa3JdzbNMk0WFBE5yBDYAsNwGM1C25qUAxiVF67+2tHzJteMtSuWP4e2jsPm4xuh2viWgrhISeUMDffH6gNaSlsqE3E9qI09Hv38IkQMFN8TlyNE00tb6x6llaRzJNVNgbheKnDNF5nbnyCks0Bc3DH5PqgAfFJfXSD7ehB4x8POp3SshdPmSLy/krUFtePNFDGeDzl+7LXqcn3K0chC7hdoca7epO0vNHEKkoOCGuBw5r25t5WBOkSwdsblmCvhmG8KD/FBoYaeTITao4AuK7BHYRKn8sefN3jhy6YY+gNAxDMZ+x19E0JwHE6IwfUhtWwqxy5fsLIWQYodcs0FCqUOU+GB4W86cFktLZQxq8224AizTsVobnDhLzRxCpKDghrgcOa9ubcXaE8vk3i2Q3LIBb7Io12xDfnE5pvxoedv0k0nNMDg+infHjD0Nbx8FPx8vo+UPrY6RlLMUFuCDeaM76r+WsnwpZAce32yQJaGBvvh6TCckcnQUN2SpOOSsrafhdefx5sYqNThxhvcPIdaiOjfE5cjdNNIWrDmxRKn8MaV/ayRZOAmysw0P3tkVlP1vqaDnGBwfpT/2oPgozBgaJ2mscth8XMNZW4VtIirGqE73GP2+xC5fskGLaUDBLmGlZmok5bEo7vz7dFQ7JMfWF/S6NPd3YYsvcjUpNRyrpc7xfGMFHP/+IcRaFNwQm7NFoTBnLxBmrxOLYePKBbsuWLx/eJCvfps4WxTwzZ+lFcmTg6a4Asv25+hfE+zPM2eH+J1H/Uw6dgsNMHMLSgUXRzyQXSh6lkut8sfXj3eCKsBP8HtAq2Mwa2sW5/fMPdJwrAAsXgSECmzSSoiroWUpYlO2LLTnzAXCLJWfZ1C31oiQYmyGpCyPFJVWY8q6DAC1f4fOTUNRWsXfzNEePt52Gl/vvoDHutyDJXvF96viW0bpFhMOdYg/8kvMByNrDl5Gl+hwQUtY6RcLBI1pcu8WiG0YjMjg2orDs7YK6+vFvn6tSQY2XG7jW+JSW3h+TyUk34q4BgpuiM3Yo9CeMxcIs+WJRatjMG3DSat2R+UXV+DXk3U7XzvCzbJqfLM3R/TjzM12eXspMKZbU8zZcc7sMfJLKpGeLbSHlbC/T3LLBkhqEYHUTA0mrT4muK8XG/RU1ugEjocfu9xm6SKA7/0j9ETvLgGBM1Y8J9JRcOPhbPXB5OyF9uxF6onFkgU7zwvejcW3G8r+XbjkZ262S6tjUK0VFiRc/PeWoPsltYjA+qP/CEpml9LXiw38hyZYfzI1XJYTexEg9ETvLgGBM1c8J9JQcOPBbPnB5OyF9uxJrtklNhDNL6nAwt2W82tY7hDEmLK080jsVu10Ad3Ho1T+SGweIbjbdbqE/Bz2eL+ekN42w9rdTkJP9O4SENCFmHtyaELx7Nmz0bVrVwQHByMyMhIjR47E2bNnzT5m9+7dUCgUdf6dOXPGTqN2D0J2hljDFQrtOTPTJOxtJ67qE4enrMuQ3HPJXdwsq0b6xUIczCmqk5zL99rmogAQEeSHG2WWiwaO7tpUv8Ns0ROd0DBEafT9hiFKWbuOCyH3bkGhidVVNTpR3emdmZgLMeI6HDpzs2fPHkyaNAldu3ZFTU0N3nnnHQwYMABZWVkICgoy+9izZ88iJCRE/3WDBg3M3JsYsseViisU2nNW1hSI8yQLdl3Agl0XjGYbxWzVZl/ZIzo0EtToNLp+IM8RuL+25Wt7Sr9WaK2ux5nPNbprU1TW6JCeXSh6mVnoif779FyHzMzaYhmdLsTk5Sw5WA4NblJTU42+Xr58OSIjI3HkyBH07NnT7GMjIyMRGhpqw9G5L3ssGdmq0J6zvHHkxv5c27PybdJR3J0ZLoMI6arNUqv8MWNoG8H3Z4MVvuWYayXGyzG2aqAK1AZapvlcuQWlWHPwslECtdhlZqEn8EtFZbIeTwhbLaPThZh8nCkHy6nq3BQXFwMAwsMtn/A6duyIqKgo9O3bF7t27eK9X2VlJUpKSoz+eTp7XKnYotCeYU2XV9dmYMy3B9D9s51WL6E5muHPRYGNeIbLIPnF5YIeM7l3C8wYGodZW09j1tbTFu8fFugrOEmYXY4x9x6wFnuiZfO5lD5emLvjPPJLKo3ux7fMzFd7SugJvFm46SyW+XFay5bL6JZqUrGFNalis3m2TnUQy2mCG4ZhkJKSgu7duyM+Pp73flFRUViyZAnWr1+PDRs2oHXr1ujbty/27t3Lef/Zs2dDpVLp/zVp0sRWP4LLsNeVipyF9pztjSOEkOKFYvJDCD92trFIYG8tX29vTFot/Pd+o6wa27PyRedn9I9T47V+sVAFGBfLY4vnmV/Y4mZ6ohUTcAHmLxKEnujHJUXbLSAQ+/OJ5QoVz52drf9GUigYhnGKjK9JkyZh69at2L9/P+655x5Rjx02bBgUCgU2b95c53uVlZWorLx7NVNSUoImTZqguLjYKGfHk2h1DLp/ttPiktH+qX1k2xZuzVISO16+k4rc45WDkOlZSz+XuwoN8MGTSdGYv1P4ji+hnrk/Gqmn8s0uBalDlAAUFov7GWJfY28NuldfBNGcyb1boryqBhsz8lBUene7d2iAL55JjsHkPi05+3pFqfwR3zgE27Ou8x77hZ4x+uagAJCeXYgx3x6wOKY1ExJRXF7FuaTGvmsWPdEJAPDiqqMAuHeDme6WsnQ/a4n5+azJ73GmJRVXY6+/UUlJCVQqlaDzt1NsBX/55ZexefNm7N27V3RgAwCJiYlYtWoV5/eUSiWUSiXn9zyVpeq5gLxXKtZuhXa1beVCtsj2j1NjRVqOxwU2AFBcUYN71cF45v5mWP7XJYv3n/RACygUwIJd2Rbvu/yvXLzQMwZLzBQE7Bodhi0nxBUvZF9jBbcqLd4XAG8rjOLyaszdcQ6t1fU4ayB1bhaGXl/wL7MDwM9H8nCvOgRqVQC6xYQLXj7OLy7H57+ftbiRYP/UPmaLT7InektFKuUKCOyV8OvMFc+dnTMmZTs0uGEYBi+//DI2btyI3bt3IyYmRtJxjh07hqgoiqzFsNcHkxyc8Y3DR8hOtDd+OgFvxQkUV1jefuyOGAZ4afUxTOkXK+j+3WNru6OvP5onKDl383ENnusRg2/3cQc4YgMbQ3N3nEVooC+Ky6olJQlz7UY0DMiF1MYpLK3Sd39XhygxpltTQc9dVFol6CJhzvZzSG5ZH3ve7I0jl26YPdHbIyCwZ8KvM1c8d2bOmJTt0OBm0qRJWL16NTZt2oTg4GDk59d+6KhUKgQEBAAApk+fjry8PKxcuRIAMHfuXERHR6Nt27aoqqrCqlWrsH79eqxfv95hP4ercpUrFWd84/ARMst0u9IzgxpTaw5ettj7ic3bYGcbJ95ZBjFHU1yB9Ufz5ByqXmmVDqiqrXrMV/nZEnMzjWID9PySSszZcd5swMUuqYXXEzaDbbrFfkSHxmbvb+uAwFY7L4l8nPFv5NCE4kWLFqG4uBgPPPAAoqKi9P/WrVunv49Go8Hly5f1X1dVVeGNN95AQkICevTogf3792Pr1q0YNWqUI34El8d+MI3o0BhJPNVeHc2VdjM4w+yRq8gvqcSYbk3N/l0Nl0cHxUeh773C6lkJTSy2RqCft1WP53qtSA3Qq2ruBlyGDJeZ1SHiju0syfqU8Ov8nPFvJCqhuLi4GBs3bsS+ffuQm5uLsrIyNGjQAB07dsTAgQNx//3323KsshCTkEScB1/yIlD75nGWUu9CE+tIrXmjO0Dp4yW4j5GQmRt7eq1vS8Q0qIfz124JygkyNGNoGzydHGP0gW8p2d/8WGKx7vAV3t+jlGM7U7I+Jfw6P1v/jcScvwUFNxqNBu+99x5++OEHqNVqdOvWDY0bN0ZAQACKioqQmZmJI0eOoFmzZnj//ffx2GOPWf1D2AoFN64rNVODaRtO1mk2GBroi09HtXOKDzhrTk6eiN09YWlHnb12loUF+qK0qgZVAttbhAf54tA7/XEwp0hSUKsOUeKD4W3rBHF8gbw5k3u3wJT+rc3+HqUe29pdLnJx1yKe7sSWfyPZd0u1b98eTz75JA4ePMhbg6a8vBy//PILvvrqK1y5cgVvvPGG+JETYgFXJ+zismqnadQnJjfE04UH+eqXEvnyNtgPyrQLBXbZWabV6VAtom9XUWk1DuYUSa5GnF9SiYmrjmJKv1aIrh+IyGB/9I9Tcyb7W6awmP/C1t1ZnpaLm+XCusoDQNqFAqcIKCjh1/k5y99IUHBz6tQpi72bAgICMGbMGIwZMwb//vuvLIMjtuUqV0FaHYMD2YWYtv4k5/epc69reqhDY7N/K0f02Cqp0Ip+zD9Fpci6WoxWDetJHitXy4T9U/tgRVqOoArKACyeULh+n/WU3rhdaflnNtzaTktBxBUIzrn55ZdfMGzYMHh7W5dE52i0LFXLVdavxZ7g1kxIRLeYcIcFbZ5amE8Kc0sdfLWCnJHUXVPmjgdAXw8p+dOdFgsOhgb44MiMAbyvc77fp5Sxy12kjxChxJy/Be+WeuSRR9C4cWNMnToVZ86csXqQxHFcpZWBlNYE27PyHdp/ytJWcHJ3d1vnZmGc7Sm0OgbTNpx0icAGkDewMTzezC1ZAIAPhsfx3/mOTx9O4A1shJTGlzo+e5bTJ0QMwcHN5cuX9QX32rZti+7du2P58uUoLS215fiIzJyxBwgXc+M0Z1larkODNtoKbh57+h3ePgq9vtjFGYQu2HmeM7fKkxjWwhkUH4XFT3TS96MyVE/pg4WPm59BERpwhwfVPb6Q8RHijAQHN40aNcI777yDc+fOYefOnWjRogVeeeUVREVF4bnnnkN6erotx0lkIrbxn6NImQHhW3myZ9DmDIUEnZla5Y/n77RH4AtCv9l7UdbnVAX4YFTHRrIe017YYHlQfBSOvNsfr/VtiSDl3dSA25U1mLU1y2zgLjTgnvFgW6yZkIh5oztgcu8WosZHiLORVMSvV69e+N///geNRoOvvvoKp0+fRvfu3dG2bVu5x0dk5iqtDMQ8PxvTmItb7BW0WSo46KleeqAF1kxIxJ43e2PzcQ3vzCEDoKxKfFKvOcXlNdhw7Kqsx7QXw2B5e1Y+5v15AaUmCcCa4gpMXHUU205w/4xCA251iL++oGdyS2HFEimYJ87KqgrF9erVQ+/evdG7d2+Ehobi3Llzlh9EHMpVWhmIeX61yh/jk6MF3dfWQZu3lwLD20e5TL6IvXgpanfzHLl0g3KSBDKsui1kmXbS6mOYu/1cndlJKRW+XakqOCFcJAU3ZWVl+N///odevXqhVatWWLduHVJSUpCbmyvz8IjcXOVDS8gMSGiAL3547j7sn9oH/eLUgo5r66AtNVNjtiO1p8r+tzY3b0eW9KaVnkQBYHTXpvj1xFWkZxfigICGmgyAuX+eR+ePthstUwkJuE1L4ztjOX1CxBDVfiEtLQ3Lli3DTz/9hJqaGowaNQrjx49H7969bTlGWdFWcP4qpc62xVPMOC1VBrZHGXnaBm7eCz1j8A0FfhYFKb3h6+1llFQdGuArquieYUsSS9vqX+gZg+lDuHdkuUrJCOIZZG+/AACtWrVCdnY2OnbsiPHjx+Pxxx+HSqWSZcD2RMFNLVf50BIzTkcHbdRXyjwvhfm8KKD2bxUa6IsbZdWy149xBUPbqbH1pDyzW1Eqf+x5szd6fbHLbMAdZSHod5Vin8T9yd5+AQAGDRqE8ePHo3379lYPkDjeoPgo9I9TO/2HlphxDoqP4ixbr7ZT0OboJGxnJ2SjGgNg9qh2AGD36sTOIP2ifAnvmuIKfJ9etzQC1/0O5hTxFlR0lnL6hIghOLiZP3++LcdBHMBVPrTEjNMWQZvQK9fcAqr5ZK1nk6P1f79B8WosT8t19JDsqqi0StbjXSoqE3Q/CsyJuxEc3LAKCwvx3nvvYdeuXbh+/Tp0Op3R94uKqKgTcSw5gzahy2JVNTqs+CtXluf0ZKoAP5fIWwoP8sWI9o2x6XgeikrtW3BQzHJds/BAQfczTbSnpSji6kQHN0888QSys7Mxfvx4NGzYEAoFveCJaxH6wc2XiMkWmzNM2Hx7YyZueHhVXXMUABQWcm4UMG4g6YzYV8knD7XDoPgodI0Ow7ubMi0GOOO7x2DpfvPJ1OFBvoICpVf7xmLun+ctjlOt8se4pGh8tz/HYqK94e5IV8nHI8Qc0cHN/v37sX//fsq9IS5J6Ae3pTYVbBdynQ6YtNo1Gjw6CjvTEODrbbZAn7P9DpXeClRqjUcV7O+N8d2bo7JGh3k7zmHODvNBBqtrdBh8vMC7W0wB4KMR8Zi19bTFQOTlvrG4NyoY0zac5GxTYbhV28/HC+8Pi8OLq47WmfHh2tItNKAnxNmJrnNz7733ory83BZjIcSmxDQMFdqm4t1NmXY5KXeLDrPDs8jDdDI30K+2XYDclYdthR2/aWADACUVWszZcR6vrs0QHNiwgfBbg9pgweiOCPY3vqaMUvlj0ROdMCShkeDaMmw7hin9WiE0wLgnlPrO8dgghE20V6v8zd7PVfrOESKEqDo3AHDo0CFMmzYN7733HuLj4+Hra/zGcvbt1bQV3LnZaq3fUg0a0zo4mzLy8OraDKuf1xOpQ5QY3bUpVvyVK6o2i7sbHK/G3zmFRktP4UG++HBYW0QE++tf8zdKKzFr62nBy0JVNTp8n56LS0VlaBYeiHFJ0fDzqXvdaum9JbSUwZoJiS6xEYG4H5tsBWeFhoaiuLgYffr0MbqdYRgoFApota5xdUacjy3X+sU0DE1qEeHw9hOuLL+k0mJOiCf6LbNu/Zqi0mpMNgmi1SH+GN21CWp0td22kprXR2KLCH0gYhik5BaUYs3By8gvqdQ//rv9OZzvGUuJ9q7Sd44QIUQHN2PHjoWfnx9Wr15NCcVENrZe6xf7wc22fzCX/xAmMAHU2Sl9vFBZo7N8R2IX+SUVRsHh+qN5+mCF6wKgzuMlvmdcpe8cIUKIDm4yMzNx7NgxtG7d2hbjIR5IaPJu/zi15CUqsR/cbG8dc4mYH42Ix7ubTslem8TeKLBxbmyw8nzPGCzZm2Mxx0vqe8ZSQA8AEUF+6NzMdfK/iOcSnVDcpUsXXLlyxRZjIR5KzJKRVFIahlpKxByS0AgfjYiXPCZChGDu/Pt2n+XAxvAx5t4zWh2D9OxCbMrIQ3p2IbQ6xmyzTFZhaRV6fbHLKPmeEGckeubm5Zdfxquvvoo333wT7dq1q5NQnJCQINvgiGewx1q/kJkYri7HlioeD0mIQrs9ITiZVyJ5bIQIIWWTUn5x3Z2tlnLbuFqYGB+TtoUT5yd6t5SXV93JHoVC4TIJxbRbyvnYc5eG3EnLWh2Drh/vcPmlKSKfd4a0QXF5FRbsynb0UBDs74PPRiVgSELta5svt40N+Kf0i0V0/SCEB/rhlbVHcaOshvO4prsLCbEHm+6WyskxX2WTODdnLKsuJHnXtIqqVNb0nuL63R3MKRIU2NRTesPHS4Gb5dwnC+I+IkOUeLZ7DNYfzTObv2IPtypq8NLqo+hztAHGJzfHB5vN17ERWrvHdHchIc5GdHDTrFkzW4yD2IGzllWXumRkzfOJ/UDm+90NiVcLevz/db4HoYF+gk8exDHCAn2tbqMRGexv9jUtlZeF9hXm7DzzL3ae+VeGURijbeHEWQlKKE5PTxd8wNLSUpw6dUrygIhtiKnO6whCq6g6At/vTlNcgaUCu1ZvOq6hwMYFPJkUjdBAX8t35GCalM73mo4I8sOzydFYMyERE3rECDquAhB0X3vbekKDpfsuoop23BEnI2jm5sknn0R0dDQmTJiAIUOGoF69enXuk5WVhVWrVmH58uX4/PPP0bZtW9kHS6Sxx1ZrOQyKj0KfexsKqrZqL+Z+dywvBcAw5q/OKSfHNWh1Os5+TZbwzTCaWwbV6hik/Jhh8dhqg9lVf18fzHOiAol/ZF3DH1nX8PG205jQIwbTh8Q5ekiEABAY3GRlZeGbb77Be++9h7Fjx6JVq1Zo1KgR/P39cePGDZw5cwalpaUYNWoUtm/fjvh42h7rTMRW53UUrqUfvmqr9mLpdwfcXSqQa/mBOJK04F5tZnmXbxlUyGsLAL58pD2SY+tDq2Og1TnnDImOudsUlAIc4gwEBTe+vr6YPHkyJk+ejKNHj2Lfvn3Izc1FeXk52rdvjylTpqB3794ID7c+4ZPIzxXKqjtrN2KurbRcBrVtiIwrxcgvufs7DHeTCsb24OjAkE1aT2oRgQW7Lli8/5B4NcYlRVuVmC/0/VZQWimoMrEz+HZfDl4fcK9DZ1sJASQkFHfq1AmdOnWyxViIjTh7WXVnXjYTupyUeuoa1CFK/VbayGB//JGVj+UCc3I8WaCfN/x8vCQtB8np/WFxSGweAXWI0qhXE5fUU/l4MCEKIzo0lvx8Qt9vF/+9jXl/Wg64bIEN+r58pD1+OnIFv2RcNXt/HQN8n56L8T2a22eAhPCg8NoDSKnOa0/2qFAslGnl1rBAP8GPzS+pxNwd56H08UJxeRUFNgKVVWlxs6waU/rF4skk++/GjDJIWvf2UmBMt6YWH6NjgJdWH7MqEV/I+zI00Bf/3SlvYKNAbef2H567D/NGd8CUfq30Scum9wNqg77k2PoI9hd2LXypqEzG0RIijeiZG+J67L3VWixnWTbjmvoP9vcWfZwPNp+C1NwNT7b20BV8+Uh7rEy/ZPPnCvD1xphuTdA/Tm2U4HswpwiFIpK/rZlRtPS+ZADZZ7PYUX4wvC2SW9bX395aXa/Oa98wjyg1U2Nx1obVLDxQziETIgkFNx6Cr6y6uURIe3GGZTO+nJ9bFeIqbjOAxSUNwk1TXIHvD+TaJVfpk4fi8VCne/RfS81psTYRn+992TBEiYoaaTu3zOF7v5vb1cX33uDipQDGJUXLOmZCpKDgxoNYU53XluxZoZiryjAAi9u9iX2knrpml+dRqwLuPqeIkzeX1MyrVu0y5Hpf6hgGY7/7W/IxTYUG+uLrMZ2Q2CKC9/3OtatLSCkEQxN6xFAyMXEKVgU3FRUV8Pd3TBIqkUZKdV5bs9eyGV+V4dFdmzp0F8rg+IZo1TAE6w5dMdptReRnGiiLPXlz+fHwP3hvWLxVr0/T9+XGY3lWjOgudkSfjmqH5Nj6db5vqR2L0O3qCgXwPEedG2ds90I8g+jgRqfT4eOPP8bixYtx7do1nDt3Ds2bN8eMGTMQHR2N8ePH22KcxM3ZetnM3FbzOTvOWXVsU8FKb9yqFL6c9VvmNfyWeQ2hATSRaktcgbLQk7c55dU62WtEFd2WZ2nT3PtHSDsWoXluXz7SHg93vsfoNmdt90I8g+j5w48++ggrVqzA559/Dj+/uztJ2rVrh++++07UsWbPno2uXbsiODgYkZGRGDlyJM6ePWvxcXv27EHnzp3h7++P5s2bY/HixWJ/DOKEBsVHYf/UPlgzIRHzRnfAmgmJ2D+1j9UfhJa2mstNTGBjiJpq2pYq0LdOvSS5ktTlTnYPDxK+S49LaIAvfnjuPt73j9B2LELz3BqFBhh97eztXoj7Ex3crFy5EkuWLMHYsWPh7X13J0lCQgLOnDkj6lh79uzBpEmTcODAAWzfvh01NTUYMGAASktLeR+Tk5ODIUOGoEePHjh27BjefvttvPLKK1i/fr3YH4U4IXZ6fkSHxkgykx8glFbHYEVajtMXPyO25+/jhf5xxo1O5UpSlzvZ3TAnSAx2S/enD7dDcsv6nO8fIcH+zC1Z0OoYSWUkxByfEFsRHdzk5eWhZcuWdW7X6XSorhaX2Z+amoqnn34abdu2Rfv27bF8+XJcvnwZR44c4X3M4sWL0bRpU8ydOxdt2rTBc889h2effRZffvml2B+FuLnUTA26f7YTs7aelvW4CkoZcEn5JZVYYFIzxtLJW6gbMvcOY8dlTmigL9Qh4hvNiqkrxebDAebr4IjJ07Fn3SriuUQHN23btsW+ffvq3P7TTz+hY8eOVg2muLgYAMy2cUhPT8eAAQOMbhs4cCAOHz7MGVxVVlaipKTE6B+py7R4natfVfFNi5szpV+s2RMKe1WsEljMjDifOTvOGS2JWDp5KwC0axxs8biztso7E+HtpcDw9vwBigK1ScJp08Qv44qtK8XX3ZwvkHKWulXEs4n+lH7//fcxbtw45OXlQafTYcOGDTh79ixWrlyJX3/9VfJAGIZBSkoKunfvbrbxZn5+Pho2bGh0W8OGDVFTU4OCggJERRm/0WbPno2ZM2dKHpcncKbEPzl2V4jdAcPuoJncJxaT+8TiYE4Rtmfl45eMq0btF9R3dlbJnYBM7GvmliwEK31RUFqJyGB/9I9Tm01mVwX4Ycy3B8weU2q9G77Xe2qmBkvuNKLk8nzPGP17U+xzSqkrJaaMhDPUrSJEdHAzbNgwrFu3Dp988gkUCgXee+89dOrUCVu2bEH//v0lD2Ty5Mk4ceIE9u/fb/G+CpN1AYZhOG8HgOnTpyMlJUX/dUlJCZo0aSJ5nO7GmRpWyhVkidkBwzW1ntQiAkktIvDO0Lg6H+a/nhBWpZU4L01xBcYuvVtDhn2N7Z/aBweyC5F+sQBAbe5XYvMIwX9zdiZCaIDO93qfMTQOs7byB+cKAJuPa/DWoDaSctKk1pUSWkbCnnWrCOEjaX594MCBGDhwoGyDePnll7F582bs3bsX99xzj9n7qtVq5OfnG912/fp1+Pj4ICKi7htPqVRCqVTKNlZ34kwNK+UMssRMd6vvnExUAX7YlJFndDIy/TDX6hgU3KLqw+6GfY093zMGm49r9MHGgl0XEKXyR5dmoYKOExnsLzhAN/d6f2n1UbPPY5izImX7ua3rSjl7uxfiGRyaPMAwDF5++WVs3LgRu3fvRkxMjMXHJCUlYcuWLUa3/fHHH+jSpQt8fX1tNVS3JCbxz5aF/+QOsoROd88Y2gZRKn/M2irsZCSlPD9xfuzr7huOZSBNcQW2nMivc7upKJU/bpRWYdJqywG6XKUJrMlZsXVdKWdu90I8g+jgJiwsjHP5R6FQwN/fHy1btsTTTz+NZ555xuKxJk2ahNWrV2PTpk0IDg7Wz8ioVCoEBNRuhZw+fTry8vKwcuVKAMDEiROxYMECpKSkYMKECUhPT8fSpUuxZs0asT+Kx3OWxD85gyytjoFOxyA0wBc3y7l377HT4lEqf0xafcziycja8vzE/T3apQnvUpJpgC5H4UAAyC3gL5khhK3bsThruxfiGUQHN++99x4+/vhjDB48GN26dQPDMDh06BBSU1MxadIk5OTk4MUXX0RNTQ0mTJhg9liLFi0CADzwwANGty9fvhxPP/00AECj0eDy5cv678XExGDbtm2YMmUKvv76azRq1Ajz58/Hww8/LPZH8XhyJf5ZmwQsV5AlZHaFHdXbQ9rg3U2nzF49v73xJHq1iqS+U8QirU4nOECX62JhzcHLmNwnVta2D3JzxnYvxDOIDm7279+Pjz76CBMnTjS6/ZtvvsEff/yB9evXIyEhAfPnz7cY3LCJwOasWLGizm29evXC0aPm16WJZXIk/smRBCxHkCV0dkWt8sfw9lF4f3Omxc7TRaXV6PbJDtyqoMrBxBJhAQZ7ASCH/JJKmy8ZE+KqRNe5+f3339GvX786t/ft2xe///47AGDIkCG4ePGi9aMjNiWlQJchuUqsS6mCakjI1m+2HP2MoW2wZG+OxcCGRYGNexgY1xDqEKXVxfpMsa9NoQEGO7Np6fUeGigsf5BqxRDCTXRwEx4eXiehFwC2bNmiL75XWlqK4GDLha+I44kt0MWSs8S6tUGWkBwGNv9m1tbTtMTkgf44fQ3D7hTFkzPAYVD72kxsHiE4QBfyen/mfsubKwCqFUMIH9HLUjNmzMCLL76IXbt2oVu3blAoFDh48CC2bdumb2C5fft29OrVS/bBEtuQkvgn904ra3ZXCL16Tc8upN1OHophgG/35eIFk+3eQG3QMbx9lL5onpjgNzTQV7+LT8z2Z0uv9/5xaqw9dJl3yRgAwgJ9qVYMITxEBzcTJkxAXFwcFixYgA0bNoBhGNx7773Ys2cP7r//fgDA66+/LvtAiW2JTfyzxU4rqbsrhF+90pyNp9t8XIM9b/bGkUs36rzGOjYNE73d/2ZZtT6AFxugW3q9vz8sDhNX8ecW3iirxvasfNpWTQgHSXVukpOTkZycLPdYiAuxVYl1KbsrhCZGqwKoDpKn0xRX4MilG5yvMcNgY0dWPtYeuoLSKq3FYxoG8GIDdHOv9/5xaoQG+uJmGX9JA3sV2STE1YjOuTFUXl5OTSk9lLVJwHKylMPAACiv1uLjbWdsPhbi/H7L1PA2h/X2UqC4vArL0nIFBTYAkFtQJvcQAdQu/fIFNgB11ybEHNEzN2VlZXjrrbfw448/orCwsM73tVphHwjEtTlLiXW2xk5ljQ6v9WuFNQcvI7/k7pV0aKAvbpRVmz1JEM+yMv0SVqZf4ixZILbpKgDM3XEOrdX19AUf5WpC6yxFNglxRaJnbt58803s3LkTCxcuhFKpxHfffYeZM2eiUaNG+irCxDNI3Wkll9RMDbp/thNjvj2AV9dm3OnWzWBKv1jMG90BPzx3H5Q+Vk1OEjfGVbJAavXgmVuysO3EVVlKI7CouzYh0ikYIZX0DDRt2hQrV67EAw88gJCQEBw9ehQtW7bE999/jzVr1mDbtm22GqssSkpKoFKpUFxcjJCQEEcPxy1YW6FYCr6ifeyzLnqiE1QBfhjz7QGbjoO4NjYfa//UPvD2UmBTRh5eXZsh6VjhQb689ZNMn0cIrY5B9892WswlE3NMQlyZmPO36MvaoqIifYPLkJAQFBXVrvd2794de/fulTBc4urYpMgRHRojqUWEXZaihNTYyS8ut+k4iPMS+hI0zVuxZhbEXGFIKfkx1tZ/IsSTiQ5umjdvjtzcXABAXFwcfvzxRwC1RfxCQ0PlHBshnITW2CkqrbLfoIhTiG8cgjUTEnFm1mCsmZCIJ5OaCXocm7diKVHeWmLzYxy99EuIqxKdUPzMM8/g+PHj6NWrF6ZPn46hQ4fiv//9L2pqavDVV1/ZYoyEGBF6ggivpzS7RZy4n8y8Euw+ew1JLSL0W6xXpl+y+Dh2x5O5RHk+CgDhQX4oFBBMS5kZou7ahIgnOufG1OXLl3H48GG0aNEC7du3l2tcNkM5N64vPbtQUC7NmgmJKC6vwot3CqFRgOMZvBTAmVmD4efjBa2OQfKnfyK/pNLsY8KD/HBgel/43UlAF9JhHri7PPT1450wa2sW5ccQYkM2zblZuXIlKivvflA0bdoUo0aNQps2bWi3lBPQ6hikZxdiU0Yeby0PVyemxg7ftD5xXzoG+N9fuQBqZ2LGdGtq8TFFpVXoOOsP/Y6mQfFR2D+1D9ZMSMS80R2wZkIiFj7eCVE8y0NDEqIoP4YQJyJ65sbb2xsajQaRkZFGtxcWFiIyMtLp69y488yNnDU2nAnXbqztWflmZ2QWPt4RQxIaGR1jRVoOZm09badRE0cK9PXGV4+1x6D4KNE7oBZbaBhrbnnIXd+DhDgDMedv0Tk3DMNAoah79fHPP/9ApVKJPRyRCd/WaLbGhqsmH5o7WXD18WHN2noaXl4K/c/s7aXA1Zv22z1VT+mN25XOHei7s7Jqrf51LzbPxVxLA0vtQSg/hhDnIHjmpmPHjlAoFDh+/Djatm0LH5+7cZFWq0VOTg4GDRqk3z3lrNxx5oath8GXH+BK6/2GV8a5BWWYu+Oc2Vo2NTUMJq89Vuc4hvdhK8eaa0JInJc6RIkRHRphU4bGqPq0Jezrfs+bvdHri12iivOtmZAouscZIcS2bDJzM3LkSABARkYGBg4ciHr16um/5+fnh+joaDz88MPSRkysInRrNNu92FkJTeJkUHvimr7hJG9bBfY+M7dkoc+9DTFzS5bcwyU2Uk/pg2+e6IyC0kqjmY+esZEYu/RvwcdhX/dHLt3AjKFxeGm18OCWWhoQ4toEBzfvv/8+ACA6OhqPPfYY/P0pQdNZuEMPGr5lNT4MgBsW+kWxJ7fv03MlldQnjvH5wwlIjq1f5/aCUvM7nvjsyMrHtsx8UY+hlgaEuDbROTdPPfWULcZBrODqPWikNCsU41KRbbo2E/m90DMGQxK4c8Okvn6XpuWKur+13ewd0Y6EEGJMUHATFhbGmUTMhW3HQOyH3RptqcaGNR/YtiS1WaFQVpZyInYQ4u+DT0e1M9rhZqpbTLjZ/k1yYbdsSwlSaLcUIc5BUHAzd+5cGw+DWMNcVVVXqLFh6+Wy7w9ctunxiXXCg3xxYHo/fQE9Pt5eCjzcqTG+3Zdrk3GEBfpi9qh2+gR0sUGKu+5YJMQVCQpuaCnK+bHF6kw/kNUucNXIlr4nnoUNtT95qJ3FwAaoXe759YS43BkxlAbVicUGKZaaubLJ7XxbzAkh8hKdcwPUbv3+5ZdfcPr0aSgUCsTFxWH48OHw9vaWe3xEBFessaHVMVhzUNzMSmiAL6p1OpRSHRmX1jBEiQ+GtxUceNt6+fJaSSUmrjqK0EBf0UGKu+xYJMRdiA5uLly4gCFDhiAvLw+tW7cGwzA4d+4cmjRpgq1bt6JFixa2GCcRyFKRMWdzMKdIUO2SpJhwnM6/hZvl1bhZbtucC2Iv4oJuWy9fsgENX3kB9j5cQYqtdyxSkjIh4ogObl555RW0aNECBw4cQHh4bYJqYWEhnnjiCbzyyivYunWr7IMk7kvoh316DiWqu5trJeJyUZxpt5/p69aWOxYpSZkQ8UQHN3v27DEKbAAgIiICn376KZKTk2UdHOHmCldxQsfoTCcsYl9ic1HYXYHOULPI9HUrZseimPcvJSkTIo3o4EapVOLWrVt1br99+zb8/PxkGRTh5wpXcWLGaOmkIJaXorYrNHENYnJR2F2BjmyjwVdWQeiOxe1Z+YLfG5SkTIh0lrcomHjwwQfx/PPP4++//wbDMGAYBgcOHMDEiRMxfPhwW4yR3MFexZleubJXcamZGgeN7C6xY2RPCkDdDAwpH9cU2LgmocuTg+KjMKVfrE3HojD5r+ntfGUV2B2LapXxrI5a5Y9FT3QCAFHvDTFJyoQQY6JnbubPn4+nnnoKSUlJ8PX1BQDU1NRg+PDhmDdvnuwDJLVc4SpO6hgHxUfh+Z4x+HZfDhiTS16ltxcqa3Q2HjlxNDHLk5P7xGLNwStmE9FNZ0/EYB+nCvQ1Si4WUlaBb8ciAHT/bKeo94Y92qq4whI3IVKIDm5CQ0OxadMmnD9/HmfOnAHDMIiLi0PLli1tMT5yhytsNZU6xtRMDZbszanzwc8woMDGA0Sp/KHTMdiUkWcUDLAn3fpBSkABFNy+20jzg+G1S0AAdxBj7QSeAoC/jxd+eO4+o+cVcuLn2rGYnl0o+r0hNOCTWifKFZa4CZFKUkJxr169EBsbi9hY204Pk7vEXsU54opMypWmrftKEedXXq016vYdpPSGj5cCxeU1nPdnT8BcRSvlwgDIL6mEl0KBER0aW308Ke8Nofloc3ecQ2t1PVEBCSUqE3cnOuemf//+aNq0KaZNm4bMzExbjIlwELPVNDVTg+6f7cSYbw/g1bUZGPPtAXT/bKfNc3KkbIe1dWE2ofy8aSreUUzrypRWankDG+DuCRgA9rzZG+FBvqKeT8xfWq7aOlLeG2w+mqXAnwHwzsZMVAmc5bS0fAzULpFpKYGNuDDRwc3Vq1fx1ltvYd++fUhISEBCQgI+//xz/PPPP7YYH7mDvYrj+2BWoPaK9kZplcOSjoWO0XCnia0Lswmh9FagSksf5K7C8AR8KLdIdCNNtcofU/q1EnRfuUoViH1vaHUM0rMLUVmjwyOdLM8cFZZWIXH2DkHvb0pUJp5AdHBTv359TJ48GWlpacjOzsZjjz2GlStXIjo6Gn369LHFGAmE7SqaMbQNZm217RUZ+6G7KSMP6dmFRscSMkbTnSbOUOemkgIbl8OegNOzCwXdf2SHRngyqRlmDG2Dna8/gC7RYQgN4J/x4QrErWHuvQHU/jwzhta+N0xnXn8+mifoOYpKqzkvYEzfs/nF5YKO5wwXHoRIJam3FCsmJgbTpk1D+/btMWPGDOzZs0eucREOlppjqgL8bJp0LCQBkW/nk0IBTOgRw1vnxhmWpogrEhaY/pJxVf//H287bbZkgKUt31L1j1PjtX6xWJ6Wy9lCZNbWLBz/5wZncr0YhruuuN6z4UHC6pE5w4UHIVJJDm7S0tLwww8/4Oeff0ZFRQWGDx+OTz75RM6xEQ7mmmNuyhB2hSflikxoAiLfzicdAyzZm4OOTcOMAhxvLwVmDG2Dl1YfEz0mQpKa18f6o3miikBamri01NBTSrI+V5BhSlNcgW/25lgcvzmGFzDF5VWc79kbpVVmj8FXqJAQVyI6uHn77bexZs0aXL16Ff369cPcuXMxcuRIBAYG2mJ8hANfc0xb9bcRWr+mz70NLe584qpzExakFDUeQgAgPMgX129XYnTXJpiz47xVtW2M8QcqUrZP810Y2FJ+cTk+//2spG3yDOSftSLE3kTn3OzevRtvvPEG8vLysHXrVjz++OOSA5u9e/di2LBhaNSoERQKBX755ReLz61QKOr8O3PmjKTndzdSEnpZ5nJphCYg/u+vHEmJirS2T6QoKq3GlHUZmLPjPEIDfaEKFLdrig/b0NM0d0VKhXBHlTooKq2ipV7i0UTP3Pz111+yPXlpaSnat2+PZ555Bg8//LDgx509exYhISH6rxs0aCDbmFyZ0P42pldk205o8O6mTBQZTFcbXo0KDT7m7Dgv6H6mx6tfj2ZuiHWK72wnn9KvFaLrB+L8tdtYsOuCpGNxVQyWWn3b3qUO2CWlcCvfU9M3nKSeVcSliZ65kdPgwYPx0UcfYdSoUaIeFxkZCbVarf/n7e1toxG6Hkv9bUynzmdvy8JLq48aBTZA7QzLxFVH8eGWU7hupsy9obIqraD7GS6LpWZq8PqPGYIeR1xDkJ/9349s0LH20GU8mNAIyS3rW308w1lGqdun7TkraXgBow6xLhn4Rlk1DlwUthONEGdk1W4pR+nYsSMqKioQFxeHd999F7179+a9b2VlJSorK/Vfl5SU2GOIDmUu6djQthNXLSYwLkvLlXVsEUF+6NwsDFodgwU7L2DOjnOyHp84XmmVFg8mROHXE/Zt5GoYYHRuFiZLh3g2OJHa58mWO45Mfz7D3ldaHSOourE56dmFVgeJhDiKSwU3UVFRWLJkCTp37ozKykp8//336Nu3L3bv3o2ePXtyPmb27NmYOXOmnUdqe5Z2bPAlHRs+/t1N9q8wXVhahW6f7ADDMGar0BLXtvPMdYc99/VbFThy6YYsHeLZ4ERqsr7QFgqAuGafM4a2wbikaBy5dAP5xeUoKq1CeD0lVAF+0OoYs0vUwlH9J+K6XCq4ad26NVq3bq3/OikpCVeuXMGXX37JG9xMnz4dKSkp+q9LSkrQpEkTm4/VluRoeHcwR3xlVzFCA3w5a3kAdcvtE/cjdInSFiKD/WVZDmJnGQHLQQrf9mkxQYZa5Y8h8WosFTBbWj9YCT8fLxSXV+Hz38/yfhZw1cUKD/RFkYD3YFJzmrUhrsuhOTdySExMxPnz/ImsSqUSISEhRv9cmZQdG1xsnQvwZGJT0T1/CLGG4W5AOZaDCkur0OuLXUjN1Eiqvs3iy4OLutMGYt7oDlgzIRH7p/ZBvzi1oLGxPeQsfRYMio/C/ql9sGZCov55DrzdD6EWdpaFBvoiUUKhT0KchaCZm7CwMCgUwrLmi4rs24/k2LFjiIpy7+617BJUfkkFZv16SvSODS62rj76/d+XcKOMlp2IfZgGGGKWg8wxLVJprkK4uVlToXlwQmeIOjcLQ68vdgn+LDBdov50VDtMvNN8lMuno9rRTini0gQFN3PnztX/f2FhIT766CMMHDgQSUlJAID09HT8/vvvmDFjhqgnv337Ni5cuLtdMycnBxkZGQgPD0fTpk0xffp05OXlYeXKlfpxREdHo23btqiqqsKqVauwfv16rF+/XtTzuhIhlU1ZYtor2LrtAQU2xJwgpTfKKrWSA4/wID+jHX6mAYY8OSd1AwWhQQoXS3lwlsZtGMAduXTDqlYrg+KjsPiJTvhg8ynkl9zdcKG2UJ2ZEFchKLh56qmn9P//8MMP48MPP8TkyZP1t73yyitYsGABduzYgSlTpgh+8sOHDxvtdGJzY5566imsWLECGo0Gly9f1n+/qqpKX0AwICAAbdu2xdatWzFkyBDBz+lKpFY2FbLkZPghSmmDxN4SY8Jx5PLNOvlXoQE+gEKB4rJqszMXe97sjSOXbpgNMPhmWsQyDRSEBCnWEDJDJEerFWsCNUKcnYJhGFHntnr16iEjIwMtW7Y0uv38+fPo2LEjbt++LesA5VZSUgKVSoXi4mKnzr/R6hh0/2ynpA/lNRMSBX/4ipkZEque0hu3Kx2XWEpc0ws9Y7DkTokCrpkLrnpN5hjuLMwtKMXqvy/j2q27sxVCZ3bmje6AER0aC35ea5nbEZmeXYgx3x6weAwxnwWEODsx52/Ru6UiIiKwceNGvPnmm0a3//LLL4iIoDeRXKRUNpXS8M7w6m17Vr6gujZRKn+UV2t5r65ZFNgQUwrUdojn26atALD5uAZfP94Js7aKz23hYjrTMrlPrNHrXejVnVx5akIbb5qbIbpRWmm2jg81vySeTnRwM3PmTIwfPx67d+/W59wcOHAAqamp+O6772QfoKeSuptJSsM79kM0qUUEusWE15nJCQv0wVNJ0YhpUE//Ybw9K9/qfAbiWdjXirm5YnYJKCzID/un9rHJkgmbcJwisDK2nIGCHGUcUjM1mLT6mMX3HTW/JJ5MdHDz9NNPo02bNpg/fz42bNgAhmEQFxeHtLQ03HfffbYYo0cSe5XopQAWjOlodSKgkHV4rY6BKsAPzyZHY2NGnk3r5RD3oVb5Y3C8WtDs4PVbFaJyW4TOhrDEzozKESjw5dCZ7sgyR0gjztrPAnFLd4S4G0lF/O677z788MMPco+FGBC7lVXHAGFB0pvlCT05cF151lP6oEarQ0WNTvLzE9clZPYuPMhXnwQsJLgRE9xLmQ0ROjMaGuCLTx9uZ3WgILXxpikhQVntZ4GfVeMlxNVJCm6ys7OxfPlyXLx4EXPnzkVkZCRSU1PRpEkTtG3bVu4xeiTD3UxCsR/YYq9iLZ0c2OPx5eTcrqRt354sPMgPhSaNV00VlVbjyKUbkiv98uGbDWEbvy7mmQ0RGjx9PbaTLP2VxDTeNDdbJbXHFSGeRnRws2fPHgwePBjJycnYu3cvPvroI0RGRuLEiRP47rvv8PPPP9tinC5PbMAB3N0S+vbGk4KWftiqpWKuYi1NlT/fMwabj2tsVg+HuKZ3hrRBZIgSkcH+yC8ux5Qfj1t8DLvUJKSOC/veMPe+EbJEM23DSc7ZEKFBVmJzeTZJyBWUSO1xRYinER3cTJs2DR999BFSUlIQHBysv713796YN2+erINzF1wBR3iQLx7q0Bj94tRmA51B8VHoc29DJM7+06homSH2g/hGaSVnoiHfmr6lqXIAFruGE/fSMNgPtyu1KDXTGyos0BfPdo8x2pYsBHvCFVrp11KgLmSJ5mZZNRbsvIBX+8Ua3S42yLKWXEGJ3DNfhLgr0b2lTp48iYceeqjO7Q0aNEBhobAPOU/C1/+lqLQaS9NyMebbA+j+2U5sO6FBenYhNmXkIT27EFqDPZ5+Pl745KH42m20Jsdnv54xNA6ztp42G6jM3JJldFwp282Je5sxtC2e79nc7H1mm5TmZ0+4fGGAYc8nFlfPo/1T+xgFNpb6JgmdDVn+V47R695wDFw9n9Qqf9G1dCyR8jviYk2PK0I8ieiZm9DQUGg0GsTExBjdfuzYMTRubL8CV65AyLQ5ULvW/tJq49wa9gqV3blUWaPDa/1aYc3By8gvqXu1qwrwE72mT+vyxNQr647x1k7hW9709lJgePsos7N8XCdcvt1QQpNvv3ykvYWfptbNsmqzbQjsUaVXzpkia3pcEeIpRAc3jz/+OKZOnYqffvoJCoUCOp0OaWlpeOONN/Dkk0/aYowuy5qZkfw7CZGhgb5GJerVIUpM6ReL6PpBRh/EUsqx07o8McUX2Ezp1wqT+7Tk3UG3xExg83zPGFEnXKHJt1DU7ma6WW45H81cIG/rdgosNigx7efUUEI/J2qdQIh5opelPv74YzRt2hSNGzfG7du3ERcXh549e+L+++/Hu+++a4sxuixrZkbYc4xp751rJZWYu+M8lD5e+j43gLQ1fUtT5YQAtTMLaw9d5vyekNnJzcc1nMtCfIS+bwpuV+KZ5GhB93WuQJ5vQUkcNigb0aGx0WcBIURCcOPr64sffvgB58+fx48//ohVq1bhzJkz+P777+Ht7W2LMbosW3yg8uXPSF3TH921CW9iIiGA8ZKmKSGzk3yP5SMmUJ/cJxahgb689xGay2IPbB6R4bIyAFwruZtHRAiRh+jg5sMPP0RZWRmaN2+ORx55BI8++ihiY2NRXl6ODz/80BZjdFm2mhnhOtmITTRMzdSg+2c7MWfHec7nUCiA/nGRosc2uXdLrJmQiIWPd0SUypmulom1uGZUbFF3pXOzMFiahPBS1N7P20uBT0e143yPOVOCrZCdiaYXLIQQ6UQHNzNnzuTs/F1WVoaZM2fKMih3YRhw2ILpCUPo7g++nSiGdAywPes6gvyEzcaxV8hT+rdCUosIDElohD1v9kaYmatq4lq4ZlRsUXflyKUbvLk/LB1Tez/g7uveNJi2xa4nqcQU8SOEWE90QjHDMFAo6l4FHT9+HOHhjp/6dTZ8OxvkwHXCsJRoKHQHF8tcvRNDDOpeIR+5dAM3yqjvlKszVztFSJuQ0ABf6BgGWh0jaAZFymyQsyfYUmVhQuxLcHATFhYGhUIBhUKBVq1aGQU4Wq0Wt2/fxsSJE20ySFdn+MG7PSsfv2Rc5S3IJ4SlQl3mdn/Ys7YNfVC7PktLO+a2OLNulldj7Hd/C+5+LXSWJ7egtM5YklpE6Ksa/3riqtMEOVRZmBD7EhzczJ07FwzD4Nlnn8XMmTOhUqn03/Pz80N0dDSSkpJsMkhXxVU6PqlFBN4ZGmd0e+GtCry35ZRRiwV2C7g1NTG4nt9WAQdX4z/Tkw9xPUJqpwidnRTa/fpGaSW8FPzb0llzdpxHa3Ww0bGkNNG0B6osTIh9KRiGEZXBtmfPHtx///3w9XXNXIqSkhKoVCoUFxcjJCTEZs/D9SGrDvHHmG5NEV0/UB9sbM/K52jN4IePRsTDywuSP6j5PuRHd22KOTvOyfiTGvvhufvgpVAgv7gcH/6aRctSLu6H8fchOVZY40itjsGB7EJMWn2Ut/YMexLfP7UPb80crl5nQo7F91j2WaTm30jpC8eFHR/AfcHiLPlBhDgrMedv0cGNofLyclRXG3+I2TJgkIM9ghuhH9CmBfpYhh92UvIILH3Iq3ieVw5Ci6oR1zBvdAeM6CC88nh6diHGfHvA4v1+eO4+AEDahQJcvVmOxqEBSGwegTd/PlFnq7QlayYkoltMOLp/tpN35shSUMVH7pkgZ51ZIsQViDl/i04oLisrw1tvvYUff/yRs5eUVissAdVdiUnY5Qsw2MdO23ASwUpfJIoo0CWkdL0tsw8osHEvYnNAhC57Tlh5GGUmyepf784W9VyGzylmN5LQasR8FwlCl9e4OHviMyHuQvRW8DfffBM7d+7EwoULoVQq8d1332HmzJlo1KgRVq5caYsxuhQ5E3ZvllVj7NK/0f2znYILfAn5kKelIhIe5IeGwX5WN3I0JTQYMg1srBEZ7C/7biRb1qWhysKE2J7o4GbLli1YuHAhHnnkEfj4+KBHjx5499138cknn+CHH36wxRhdii0Sdg07ITvi+Yn7KSqtQmt1iH42z5A1xe/s2dLDMACzdjeSVscgPbsQmzLykJ5diAMXC6kuDSEuTPSyVFFRkb4jeEhICIqKat/c3bt3x4svvijv6FyQrVoucO1GstfzW8KXO0Sc297zBVAAUPp4oaJGp7/dmu7SQraGy8E0ALNmNxJXHkxogLANE3QxQYhzEj1z07x5c+Tm5gIA4uLi8OOPPwKondEJDQ2Vc2wuyZ4tF6Q8P3u1qw5RyjLGcYlN8fWYTjIciTgCA6CiRgeljxfGJ0djzYRE7J/ax6rkVr5K2eZ6QIllWn1YbPsRFl+1bqG5Y1SXhhDnJHrm5plnnsHx48fRq1cvTJ8+HUOHDsV///tf1NTU4KuvvrLFGF2Kra9cLV0pmnt+ww/5Y5dv4Ju9ObzH6RVbH3vOF1gcT6emYUhsEYHwIF+jOj3EtVTW6LA0LRddRSS3mtsizZU4q9MxGLv0b0njU4co75RRCOJNwuWrt8M3EyW2WrchqktDiHMTHdxMmTJF//+9e/fGmTNncPjwYbRo0QLt27eXdXCuyt4tF4Q+P/shDwBLzAQ2L/SMwQOtGwoKbtSqAHh7KfDRiHi8tPqYgJ+AODMhS5+AsC3NphWDr9+uRFigr6CEdnWIEv95tAMKbleK2lEkZjeS1OR/Z2rISQjhJjq4MdW0aVM0bdpUjrG4FdMP2dyCUqw5eBn5JZWSjif2SpHvQx4Aun+20+zV6rrD/6B7ywZQhyjNjtdwN82QhEZ44Z+bZmeDiPMTsl1azBZpriBIiA+Gt0VyS2HFA02Zaz9iSGi+jGntJmtykggh9iEouJk/f77gA77yyiuSB+NuTD9kJ/eJtVjBlYvUK0WuD/n0bPO7QIDaLejjlh1EkJK/I7iCYzwdm4YBoODG1aVd+Jd3tkNIHSV29md7Vr7gasOssEBfzB7Vzi6Bg9B8ma8f7wQvLwXVpSHEhQgKbubMmSPoYAqFgoIbM7y9FPDyUogudCfnlaKY3R2lldy1SLgqqrInPeL6FuzKxvqjeZyvOaHF8g5cLLSYzxIe5IdHu9yD/OIKNA4NwP0t6yOxuW3rvhjmCdWvp4Q6RIlrJZVmd1iJKaJJCHEOgoKbnBy6GpeL2K2jM4a2wdPJMbJ9uFq7u+ORTo3xyagE+PkYb7SzZ7dxIl6gn7eownl8VXiFvn6FzBAWlVahV6tIwRWDrcW55TvQVz/jJLVBLSHE+YjeCm6IYRhY0ZrKI4kNLuoHKyV/uJoWJtPqGHSLCbdqS+7PR/PQ83PjislaHYO0C/9KPiaxnf88koA1ExJx8oOB6B8XKfhxfFV4hb5+hX4u5BeXCx6TNfi2fBffSW5WmbwnTLeaE0Jci6SE4pUrV+KLL77A+fPnAQCtWrXCm2++iXHjxsk6OHfE1qEROssh9GRiui33RmkVZm2tu5tlePsoqwvu5ZdU6q/qgbqdy4nzUKsC9DuWMvNKRD2Wqx+T0GJ5QgPootIqUWOSQkieUICvN74e3wkFpeJ2ZxFCnJPo4Oarr77CjBkzMHnyZCQnJ4NhGKSlpWHixIkoKCgw2ipO6jKsQ2Pu2lbM7iihO1I0xRWy7WZiALz+YwZKq3QW70sc56/sAiTH1rdq2dBwKUpoHaXyamGvi/B6SkljEkNonpCXl0JUB3RCiPMSHdz897//xaJFi/Dkk0/qbxsxYgTatm2LDz74gIIbAdg6NNM2nOScRRGz3s+3LdceKLBxfivSc9HuHhUqa6T/rUxnD4UUy0vPLhR0bHWI7Sv8yt1UkxDi/EQHNxqNBvfff3+d2++//35oNMI6V3sCc9Vbgbt1aBbsPI/labmS6mhYU2GVeIbSSi1eXHUUr/VrJfqx5mYPLRXLE7L8KqXruBTWNtUkhLge0cFNy5Yt8eOPP+Ltt982un3dunWIjY2VbWCuTEj1VqB2iv/Vfq3w4gMt8X16Li4VlaFZeCDGJUXX2Y3EhXYoEaHWHrpssSgjF3Ozh+aK5RkuXwGO3YlkTVNNQohrUjAitzutX78ejz32GPr164fk5GQoFArs378ff/75J3788Uc89NBDthqrLEpKSqBSqVBcXIyQkBDZj8+3TMR+hJvuwBAaCBliZ4V+y9RgZfolmX8C4q6m9IvFnB3nBd1XHaLEB8PbWr1bSMrr2xbY9yXAHWjRzihCnJ+Y87fo4AYAjhw5gjlz5uD06dNgGAZxcXF4/fXX0bFjR8mDthdbBjdaHYPun+3knU1hrxD3T+0Dby+F6EAIkF7OnmsstJzlWeaN7gCljxdvrhdrSr9WmNynpWyzKpaWaO3FWQItQog0Ng9u5LJ371588cUXOHLkCDQaDTZu3IiRI0eafcyePXuQkpKCU6dOoVGjRnjrrbcwceJEwc9py+AmPbsQY749YPF+ayYkoltMuKhACLA+eZg9nTzfMwabj2toScvDrJmQqN8WvmDnBSxPyzHK9ZJ6oneW4EUIVxorIcSYmPO3pDo3Wq0WGzduxOnTp6FQKNCmTRuMGDECPj7iDldaWor27dvjmWeewcMPP2zx/jk5ORgyZAgmTJiAVatWIS0tDS+99BIaNGgg6PG2JmZXhtDtqWyNETmShw0Tld8a1IYzmZm4p4ggP+QXlyM9uxDdYsLxar9YTO7T0uoTvSNmQ6wJUIQ21STOhYJSIpbo4CYzMxMjRoxAfn4+WrduDQA4d+4cGjRogM2bN6Ndu3aCjzV48GAMHjxY8P0XL16Mpk2bYu7cuQCANm3a4PDhw/jyyy+dIrgRsytD7PZUscnDUSp/zBjaBmFBSv0HQudmYThy6QY2ZeTh4r+3Me/PC4KPR1xbYWkVpvx4HIBx8GHNiV5Md3CWtScpWlryPPQ3J1KIDm6ee+45tG3bFocPH0ZYWBgA4MaNG3j66afx/PPPIz09XfZBstLT0zFgwACj2wYOHIilS5eiuroavr7S2wrIQcyujIM5RYKOyQZMQoOhQD9vfDuuS51mf6mZGvT6YhctRRGzwYcQWh2DA9mFmLb+pKDu4IbLqtacpKQEU8S10d+cSCW6t9Tx48cxe/ZsfWADAGFhYfj444+RkZEh59jqyM/PR8OGDY1ua9iwIWpqalBQUMD5mMrKSpSUlBj9sxV2+ytwN7+FZbr9lQ2E+K5ZFTCuAyJ0VqisSgsvL0WdwIarrw7xTHx9o4C7/cg2Hv0HS/ddxMZjd/uSAbWvpe6f7cTYpX+bXc40XFZlH8f1GmRPUoa9yrhYaqHA9/MQ10V/c2IN0TM3rVu3xrVr19C2bVuj269fv46WLVvKNjA+CoVxOMDmQ5vezpo9ezZmzpxp83GxLFVv7R+nRnp2Ia7fqsDork0wZ8d5QR2Ju8WEIzTAV1B+jOEsDxX6I1y4+kaZ24nH9iVbsjdH1Gvp+q0KQb2dTGd5TInNUSOuj/7mxBqig5tPPvkEr7zyCj744AMkJiYCAA4cOIAPP/wQn332mdHMiNy7kdRqNfLz841uu379Onx8fBARwf3inj59OlJSUvRfl5SUoEmTJrKOyxRf9dbtWfl1dkixDQYNt+aGBfnioQ6NoQrwg1bHwPvOTMwzyTGYs+Ocxec3nOWhQn/EHDYQtrQTT2pfsshgf1lOUtRCwfPQ35xYQ3Rw8+CDDwIAHn30Uf1sCTt7MmzYMP3XCoUCWq1WrnECAJKSkrBlyxaj2/744w906dKFN99GqVRCqbR9cz5Tprsy+E4exXeCmin9WqG4vAq/ZFxFUWkVlqblYmlarlFOwuQ+LbH8rxzeGiWmlVa1OgZpF/61xY9H3ERksL9NZvcMX4u/nrgq6DHmTlLUQsHz0N+cWEN0cLNr1y7Znvz27du4cOHujp2cnBxkZGQgPDwcTZs2xfTp05GXl4eVK1cCACZOnIgFCxYgJSUFEyZMQHp6OpYuXYo1a9bINiZbEDItv+KvHNzgCFpME+c+HdUOE+9UWuU61oyhcfoCgXIU+yPOz9/XCxUCu3AbCg301Se3y/k6MV1WleMkJVcLBdpS7DqobQaxhqjgpqamBrt378azzz4ry9LO4cOH0bt3b/3X7PLRU089hRUrVkCj0eDy5cv678fExGDbtm2YMmUKvv76azRq1Ajz5893im3g5giZlucKbNjvGeYk9I9TY0q/WN76NLO2ZuH4PzdE50YQ1/Fa31h0jQ5HQWmlfot/t493iK5XxJ7S5Z7WN238KsdJyrBXlZAcNS60pdi1yPE3J55LdIXi4OBgnDx5EtHR0TYakm3ZurcUl00ZeXh1bYbVx5nSrxXWHrpMszEejKtytVbHoPNH2822VOCzZkJt3pyQytqWhAb44uuxnZDYPKLOCUeu3k5SAxQprU6Ic6CglLBsWqG4b9++2L17N55++mmp4/M49YPkyfkRkkxM3BtX8u3BnCJJgQ0A5JdUYHj7RohS+UsOmtkA4dOH2yG5ZX3O+1jaRSj0JMWXrG/u6l2O3VrEcaT8zQkRHdwMHjwY06dPR2ZmJjp37oygoCCj7w8fPly2wbkNeg8SmRkuJVmzrFR0u9Jo+t/cNK4C3H3JhAYoUgMTrvuL2fpLW4pdH7XNIGKJDm5efPFFAMBXX31V53u22CHlDgpuVzp6CMTNGCbfWrNbJDzIDwD/zAoryqQvmT16O8m1HEFbignxPKKDG51O/K4MT0dbFYlcuJJvLSXsmqNWBej/33BmJb+4HEWlVQivp4Q6xDiAscdVtJxl92lLMSGeR1JXcFZFRQX8/ekDwZJuMeFQh/gjv4SuDIl0fDtEvL0UGN4+SnSRPS8F0LlZmNFtzjD9L3eODG0pJsTziO4tpdVqMWvWLDRu3Bj16tXDxYsXAQAzZszA0qVLZR+gO9ielY+KGvsv1wX6edv9OYnthAf5cc5YpGZqsERC9WAdAxy5dEOu4ZnF9qzalGHcq4qLmBwZIcT0fCOEuAfRwc3HH3+MFStW4PPPP4efn5/+9nbt2uG7776TdXDugJ1el7qbxRpKb/qwdifvDm1TJ7CxtrqwPfJM2GabY749gFfXZmDMtwfQ/bOdvM0ybZEjw+YUqVXGM81qlT9tAyfEDYlellq5ciWWLFmCvn37YuLEifrbExIScObMGVkH5+oc3bTyRnmNg56Z2IJhfgzL2urCts4zkZI7Y6scGdpSTIjnEB3c5OXlcXb/1ul0qK62/+yEM6OmlUQubKsEU1JnXuyRZyI1d8aWOTLOkFNECLE90ctSbdu2xb59++rc/tNPP6Fjx46yDMpd0NZSIpebZdXYnpVf53YpMy/2yjORmjtDOTKEEGuJnrl5//33MW7cOOTl5UGn02HDhg04e/YsVq5ciV9//dUWY3RZtLWUyIlvliM8yA9FpVWCjyO2KrBU1uTOyFXRmBDimUQHN8OGDcO6devwySefQKFQ4L333kOnTp2wZcsW9O/f3xZjdFnW1B8hxJSmuAILdp7Hq/1a6W/z9lLgoxHxeGk1d6d4VniQL2Y82LZOzRpbsjZ3hnJkCCFSiW6c6ers3TiTr2EgIVIt5kjCnb0ti7fOjQKOaQyp1THo/tlOi7kzhk1ACSGEj5jzt+icm+bNm6OwsLDO7Tdv3kTz5s3FHs7t8W1BJUSqDzafQtqFAqOaMdOHxGFCjxgoTGIEL0VtPyg5AxuhNWsod4YQ4iiiZ268vLyQn5+PyMhIo9uvXbuGpk2borLSufso2XvmhqXVMViw8wK+2ZuNsirqv0XkE6Xyx/D2UViyN6fODAkbNsg1cyOl35NcPaIIIZ5NzPlbcM7N5s2b9f//+++/Q6VS6b/WarX4888/ER0dLX60HuL3zHzM2XHO0cMgbkhTXMG7JCWlXQEfqf2eKHeGEGJvgmduvLxqV7AUCgVMH+Lr64vo6Gj85z//wYMPPij/KGXkiJmbbSeuYtKaY/Cs7CbibNZMSJRc44XNn+Hb2k35M4QQW7PJzA3bDTwmJgaHDh1C/fr1rRulB6hdijqPOTvOO3oohFhVd0lMzRoqkkcIcTTRW8FzcsQ36PNEqZkafLA5izqBE6dhTd0lW/R7IoQQWxEd3ADAn3/+iT///BPXr1/Xz+iwli1bJsvAXBlfbgIhQoQF+uLRLvdg83GNLO075Gi1YKt+T4QQYguig5uZM2fiww8/RJcuXRAVFQWF6d5TD+foZpnEdXgpAMNd1KEBvngmORqT+8TC20uBtwa10Sfh1g9S4vWfjoueCZRry7Ut+z0RQojcRAc3ixcvxooVKzBu3DhbjMflUbNMIoQCwPzHOuLarQpcKipDs/BAjEuKhp/P3dJTpk0ePxgeh4mrzFciNiVXuwK2Zs2Lq45CAeOClFSzhhDibEQHN1VVVbj//vttMRa3IFfOgekJhLgPdYgSIzo0wse/nTYKhL/bn2M2EBkUH4WFj3fC5DVHwVM3D4DtWi1QvydCiKsQXcRv6tSpqFevHmbMmGGrMdmUrbeCp2cXYsy3ByQ/PsjPG34+XrhRVi3jqIiz6BlbHy0i62F5Wm6d7wktuLftxFW8tPqY5MdbS6tjqGYNIcTubLIVnFVRUYElS5Zgx44dSEhIgK+vr9H3v/rqK7GHdCvWNsssrdKilCoYu6295wuw93wB5/eEFtwbktAIi70UDptBMV0uI4QQZyM6uDlx4gQ6dOgAAMjMzDT6HiUXG+cmECKW0HoxVPWXEEL4iQ5udu3aZYtxuBU2N+HtjZkoKq1y9HCICxKSu0UzKIQQwk10V3AizKD4KByY3hfhQb6W70yICaoXQwgh0gmeuRk1apSg+23YsEHyYNyNn48XPnmonX6JinY/EUuoXgwhhFhPcHBj2AWcCKPVMVAF+OHZ5GhszMhDUendHVCmBdwIceZ6MbRDihDiSgQHN8uXL7flONxOaqamzm6W8CA/jOzQCP3j1OjcLAyzfj2F7w9cduAoiTNx1noxXK/lKCcdKyGEABJ7SxHz+HpLFZVWYVlaLkrKa5BfXI5rJZUOGR9xDL7CjOOTo9EvTu2UsyF8r+X84gq8uOqozWvqEEKIFBTcyExIb6mfj/6Dn4/+Y7cxEceb0q8V1h667FKzH+Zey0Jr8hBCiCNQcCMz6i1FDLEJwpP7tMTkPi1dKm/F0mtZaE0eQgixNwpuZCZXbyni+rgShF0pCBD6WqbXPCHE2VCdG5nlFpQ6egjEhrwUwIQeMYhSGdehCQv0RWigcU0jtcrfpXNShNbaoZo8hBBnQzM3MkrN1GDOjvOOHgaxoQVjOmJIQiNMG9ymzhITAJdadrLEUp80qslDCHFWFNzIhE2+JO7JNPmXr/WBKy07WWLYJ810p5cz1+QhhBBalpIJJRK7ryn9WmH/1D4uu7xkDbZPmtpkGc7Vl9wIIe7N4cHNwoULERMTA39/f3Tu3Bn79u3jve/u3buhUCjq/Dtz5owdR8xtR1a+o4dAbEABYO0hzy60OCg+Cvun9sGaCYmYN7oD1kxI9NhgjxDiGhy6LLVu3Tq89tprWLhwIZKTk/HNN99g8ODByMrKQtOmTXkfd/bsWYSEhOi/btCggT2Gyys1U4OlabkOHQOxDVttd3a1dgbUgZwQ4kocGtx89dVXGD9+PJ577jkAwNy5c/H7779j0aJFmD17Nu/jIiMjERoaaqdRmke5Np7B2u3OhsFMbkEZ1hy8jPwS1ynoRwghrsRhwU1VVRWOHDmCadOmGd0+YMAA/PXXX2Yf27FjR1RUVCAuLg7vvvsuevfuzXvfyspKVFbebXNQUlJi3cBNUK6NZ7BmuzNXbyZT1M6AEELk47Ccm4KCAmi1WjRs2NDo9oYNGyI/nzt/JSoqCkuWLMH69euxYcMGtG7dGn379sXevXt5n2f27NlQqVT6f02aNJH156ACZu4vyortzmxvJksBMLsTaeaWLGipXTwhhFjF4VvBFQrjPAOGYercxmrdujVat26t/zopKQlXrlzBl19+iZ49e3I+Zvr06UhJSdF/XVJSImuAQwXM3J/U7c5C+owZonYGhBAiD4fN3NSvXx/e3t51ZmmuX79eZzbHnMTERJw/z184T6lUIiQkxOifnNhCZ8S1qEOU6Nws1Ox9QgN9sdiKZSKpS5Y0G0gIIdZx2MyNn58fOnfujO3bt+Ohhx7S3759+3aMGDFC8HGOHTuGqCjH5SgYFjqjxQTnxFbS/fKR9igordTvTtqelY/s6ydws7zG6P5Bft54vmcLTO7T0qodTFKDFJoNJIQQ6zh0WSolJQXjxo1Dly5dkJSUhCVLluDy5cuYOHEigNolpby8PKxcuRJA7W6q6OhotG3bFlVVVVi1ahXWr1+P9evXO/LH0Bc6m7bhJG6WVTt0LITb+8PikBxbX/81mwvDFZCWVmnRWl3P6q3ZYoMUamdACCHycGhw89hjj6GwsBAffvghNBoN4uPjsW3bNjRr1gwAoNFocPny3QJqVVVVeOONN5CXl4eAgAC0bdsWW7duxZAhQxz1I+gNio9C/zg1Xlt7FL+eyKdZHCfBtcXaUi6MArWJvf3j1FYFOJZ6M5k+J0DtDAghRA4KhmE86jxcUlIClUqF4uJi2fNvzM0GEPuop/TGq31jUT/YH+oQ7uJ46dmFGPPtAYvHWjMh0erEXvY1AcDs64Lq3BBCiHlizt8O3y3lLrQ6BtM2nKTAxsFuV2pRVqXFQx0b895HaC6MHIm97JKlaZ0bdYgSY7o1RXT9IJeoUEwIIa6EghuZLNh5nvJtnMScHefRWh3MOwsiNBdGrsRedsnSldotEEKIK6PgRgZaHYPl1FvKqZjLmbGUC2OLxF7qzUQIIfbj8K7g7uBgThFultOsjTNhi+FxYbfv8y0hMqDEXkIIcWUU3MiAiq45J/q7EEKIZ6LgRgZUdM058f1dhHRyn7bhJPV4IoQQF0XBjQzYHA5axHAOCphvdimkLcLNsmos2HnBBqMjhBBiaxTcyMBSDgexLwbA6K78zVGFLlct/yuHZm8IIcQFUXAjI1UAbT5zFnN2nEf3z3YiNVNT53tClxFvllXzJiUTQghxXhTcyCA1U4OJq46i2KQBI3Gs/OIKvLjqaJ0Ap1tMOEIDfAUdg5KSCSHE9VBwYyW2MjFxPuyC0swtWUbLS95eCjyTHC3oGJQsTgghroeCGysdyC6kysROjAF3zZvJfWIRGsg/e2MpKZkQQojzouDGSukXCxw9BCKA6fKSt5cCn45qx7nDjTp0E0KIa6Pgxmp08rOFIKW32ZkVsbiWl9imllEq4++pVf5Y9EQn6tBNCCEuirb3WCmpRQQW7KJ6KKZ6xkZg7/lCi/cLC/TBjbK7idihAb54Jjkak/vEAoC+2WT9ICVe/+k4rpVw94PiY6lPFDW1JIQQ90PBjZUSm0cgNNCX8m5MHLl0U9D9Hr+vGbq3bMAbWBg2m/xgeBxeXHUUCkBQgCN0eYmaWhJCiHuhZSkrsbkbxFhplVbQ/RSoDSxGdGiMpBYRZoMQdhlJbbKMFKXyxws9Y2h5iRBCCABAwTCMR5VgLSkpgUqlQnFxMUJCQmQ77rYTGkxecxRU0FacH567D8kt64t6jFbHcC4j8d1OCCHE9Yk5f9OylEyGJERhATripdXHHD0Up1FP6YPblfyFDcMCfZHYXPxyEN8yEi0vEUIIAWhZSjZaHYOwICX63tvA0UNxClEqf3z+cILZ+8we1Y5mVgghhMiOZm5kkJqpwQebTyG/pNLRQ3EKCtQm8Q6Kj8Jir074YHMW8kvu1pmJUvnrv08IIYTIjYIbK7F9pTyFQgGYy9IKC/TF7FHt9IELbbUmhBBibxTcWMHT+krNGNoG45KisWj3BSxPy8XN8rvb3w3r05gGLpQLQwghxJ4ouLGCp/WVqh+shJ+PF17t1wqT+8TSbAwhhBCnRMGNFTytr5RhCwOajSGEEOKsKLiximfMVFhqYUAIIYQ4E9oKbgVPmLmgDtmEEEJcDQU3VmD7SrkT0/iFWhgQQghxNbQsZQVvLwU+GdkOL612/a3gbEyzYExHhAUpKVGYEEKIy6LgxkphQX6OHoIs1FRYjxBCiJug4MZK129VWL6TkwoP8sVDHRqjX5yaZmgIIYS4DQpurGS4PdoVTO7dErEN69GSEyGEELdFwY2VusWEIzzID0WlVY4eiiDJLet7xC4vQgghnot2S1nJ20uBkR0aOXoYgoQH+lKtGkIIIW6PghsZ9I9TO3oIgnw0sh0tQxFCCHF7FNzIoFtMOKJUzp1780LPGAxJoJ1QhBBC3B8FNzLw9lLg/WFxTtmMISzQBwsf74jpQ+IcPRRCCCHELiihWCaD4qOw6IlOmLbhpFN0Cm8WEYBPR7WnHVGEEEI8jsNnbhYuXIiYmBj4+/ujc+fO2Ldvn9n779mzB507d4a/vz+aN2+OxYsX22mklg2Kj8KRd/tjSr9YhAY4ti3DJyMTkNQiggIbQgghHsehwc26devw2muv4Z133sGxY8fQo0cPDB48GJcvX+a8f05ODoYMGYIePXrg2LFjePvtt/HKK69g/fr1dh45P28vBV7t1wpHZvTHmgmJmDe6A6b0a2XXJavQQF8k0nZvQgghHkrBMAzjqCe/77770KlTJyxatEh/W5s2bTBy5EjMnj27zv2nTp2KzZs34/Tp0/rbJk6ciOPHjyM9PV3Qc5aUlEClUqG4uBghISHW/xAC/ZqRh8lrM+zyXIup0SUhhBA3I+b87bCZm6qqKhw5cgQDBgwwun3AgAH466+/OB+Tnp5e5/4DBw7E4cOHUV3NnedSWVmJkpISo3+OcO1Wpc2fQwFg4eMdKbAhhBDi0RwW3BQUFECr1aJhw4ZGtzds2BD5+fmcj8nPz+e8f01NDQoKCjgfM3v2bKhUKv2/Jk2ayPMDiHSpqMzmz/H1450wJME1CgoSQgghtuLwhGKFwjgbhWGYOrdZuj/X7azp06ejuLhY/+/KlStWjliaZuGBNj3+f8d0pDo2hBBCCBwY3NSvXx/e3t51ZmmuX79eZ3aGpVarOe/v4+ODiAjuBFqlUomQkBCjf44wLinaZsce3z0aw9rTjA0hhBACODC48fPzQ+fOnbF9+3aj27dv347777+f8zFJSUl17v/HH3+gS5cu8PV17NZrS/x8vPBscrTsx+0fF4kZD7aV/biEEEKIq3LoslRKSgq+++47LFu2DKdPn8aUKVNw+fJlTJw4EUDtktKTTz6pv//EiRNx6dIlpKSk4PTp01i2bBmWLl2KN954w1E/gijvDWuLZhEBsh1v/qMd8O2TXWU7HiGEEOIOHFqh+LHHHkNhYSE+/PBDaDQaxMfHY9u2bWjWrBkAQKPRGNW8iYmJwbZt2zBlyhR8/fXXaNSoEebPn4+HH37YUT+CaHve7IOnl/+N3We5E6CFmvdYBwzv2FimURFCCCHuw6F1bhzBUXVuTM3cdBLL07mLFVrSPy6SZmwIIYR4FJeoc+Pp3h/RDn3vbSD6ceO7R1NgQwghhJhBwY0DLX26m6gA579jOlLyMCGEEGIBBTcOtvTpbpjQI8bsfUIDfbH4iU603ZsQQggRgHJunERVjQ4r0nLw+6l8lFRUITLYH+3vCUNybH0kNqfu3oQQQjybmPM3BTeEEEIIcXqUUEwIIYQQj0XBDSGEEELcCgU3hBBCCHErFNwQQgghxK1QcEMIIYQQt0LBDSGEEELcCgU3hBBCCHErFNwQQgghxK34OHoA9sbWLCwpKXHwSAghhBAiFHveFlJ72OOCm1u3bgEAmjRp4uCREEIIIUSsW7duQaVSmb2Px7Vf0Ol0uHr1KoKDg6FQWNevqaSkBE2aNMGVK1eolYOD0d/COdDfwXnQ38I50N9BPgzD4NatW2jUqBG8vMxn1XjczI2XlxfuueceWY8ZEhJCL1onQX8L50B/B+dBfwvnQH8HeViasWFRQjEhhBBC3AoFN4QQQghxKxTcWEGpVOL999+HUql09FA8Hv0tnAP9HZwH/S2cA/0dHMPjEooJIYQQ4t5o5oYQQgghboWCG0IIIYS4FQpuCCGEEOJWKLghhBBCiFuh4MYKCxcuRExMDPz9/dG5c2fs27fP0UPyOHv37sWwYcPQqFEjKBQK/PLLL44ekkeaPXs2unbtiuDgYERGRmLkyJE4e/aso4flkRYtWoSEhAR90bikpCT89ttvjh6Wx5s9ezYUCgVee+01Rw/FI1BwI9G6devw2muv4Z133sGxY8fQo0cPDB48GJcvX3b00DxKaWkp2rdvjwULFjh6KB5tz549mDRpEg4cOIDt27ejpqYGAwYMQGlpqaOH5nHuuecefPrppzh8+DAOHz6MPn36YMSIETh16pSjh+axDh06hCVLliAhIcHRQ/EYtBVcovvuuw+dOnXCokWL9Le1adMGI0eOxOzZsx04Ms+lUCiwceNGjBw50tFD8Xj//vsvIiMjsWfPHvTs2dPRw/F44eHh+OKLLzB+/HhHD8Xj3L59G506dcLChQvx0UcfoUOHDpg7d66jh+X2aOZGgqqqKhw5cgQDBgwwun3AgAH466+/HDQqQpxHcXExgNqTKnEcrVaLtWvXorS0FElJSY4ejkeaNGkShg4din79+jl6KB7F4xpnyqGgoABarRYNGzY0ur1hw4bIz8930KgIcQ4MwyAlJQXdu3dHfHy8o4fjkU6ePImkpCRUVFSgXr162LhxI+Li4hw9LI+zdu1aHD16FIcOHXL0UDwOBTdWUCgURl8zDFPnNkI8zeTJk3HixAns37/f0UPxWK1bt0ZGRgZu3ryJ9evX46mnnsKePXsowLGjK1eu4NVXX8Uff/wBf39/Rw/H41BwI0H9+vXh7e1dZ5bm+vXrdWZzCPEkL7/8MjZv3oy9e/finnvucfRwPJafnx9atmwJAOjSpQsOHTqEefPm4ZtvvnHwyDzHkSNHcP36dXTu3Fl/m1arxd69e7FgwQJUVlbC29vbgSN0b5RzI4Gfnx86d+6M7du3G92+fft23H///Q4aFSGOwzAMJk+ejA0bNmDnzp2IiYlx9JCIAYZhUFlZ6ehheJS+ffvi5MmTyMjI0P/r0qULxo4di4yMDApsbIxmbiRKSUnBuHHj0KVLFyQlJWHJkiW4fPkyJk6c6OiheZTbt2/jwoUL+q9zcnKQkZGB8PBwNG3a1IEj8yyTJk3C6tWrsWnTJgQHB+tnNVUqFQICAhw8Os/y9ttvY/DgwWjSpAlu3bqFtWvXYvfu3UhNTXX00DxKcHBwnZyzoKAgREREUC6aHVBwI9Fjjz2GwsJCfPjhh9BoNIiPj8e2bdvQrFkzRw/Noxw+fBi9e/fWf52SkgIAeOqpp7BixQoHjcrzsCURHnjgAaPbly9fjqefftr+A/Jg165dw7hx46DRaKBSqZCQkIDU1FT079/f0UMjxG6ozg0hhBBC3Arl3BBCCCHErVBwQwghhBC3QsENIYQQQtwKBTeEEEIIcSsU3BBCCCHErVBwQwghhBC3QsENIYQQQtwKBTeEELeQm5sLhUKBjIwMRw/FrHHjxuGTTz6xy3N17doVGzZssMtzEeJMKLghxIXl5+fj5ZdfRvPmzaFUKtGkSRMMGzYMf/75Z537fvLJJ/D29sann35a53srVqyAQqHQ/2vYsCGGDRuGU6dOAYDR97j+GVYh/vXXX/HAAw8gODgYgYGB6Nq1q0OqRe/evRsKhQI3b960+3PzOXHiBLZu3YqXX35Z8jHWr18Pb29vXL58mfP79957L1555RUAwIwZMzBt2jTodDrJz0eIK6LghhAXlZubi86dO2Pnzp34/PPPcfLkSaSmpqJ3796YNGlSnfsvX74cb731FpYtW8Z5vJCQEGg0Gly9ehVbt25FaWkphg4diqqqKmg0Gv2/uXPn6u/L/ps3bx4A4L///S9GjBiB+++/H3///TdOnDiB0aNHY+LEiXjjjTds+vtwBQsWLMD//d//ITg4WPIxhg8fjoiICPzvf/+r8720tDScPXsW48ePBwAMHToUxcXF+P333yU/HyEuiSGEuKTBgwczjRs3Zm7fvl3nezdu3DD6evfu3Uzjxo2ZqqoqplGjRsyePXuMvr98+XJGpVIZ3bZ582YGAHPixAmL92UYhrl8+TLj6+vLpKSk1Pne/PnzGQDMgQMHOH+WadOmMffdd1+d29u1a8e89957DMMwjFarZWbOnMk0btyY8fPzY9q3b8/89ttv+vvm5OQwAJhjx47p/9/w31NPPcUwDMP89ttvTHJyMqNSqZjw8HBm6NChzIULF4yeNy0tjWnfvj2jVCqZzp07Mxs3btQfm3Xq1Clm8ODBTFBQEBMZGck88cQTzL///sv587HjDw0NZX799Vej25s1a8bMmjWLGTduHBMUFMQ0bdqU+eWXX5jr168zw4cPZ4KCgpj4+Hjm0KFD+sekpKQwzZs3Z3Q6ndGxnn32WaZz585Gtz399NPMuHHjeMdFiDuimRtCXFBRURFSU1MxadIkBAUF1fl+aGio0ddLly7FmDFj4OvrizFjxmDp0qVmj3/z5k2sXr0aAODr6ytoTD///DOqq6s5Z2heeOEF1KtXD2vWrOF87NixY/H3338jOztbf9upU6dw8uRJjB07FgAwb948/Oc//8GXX36JEydOYODAgRg+fDjOnz9f53hNmjTB+vXrAQBnz541ml0qLS1FSkoKDh06hD///BNeXl546KGH9Es3t27dwrBhw9CuXTscPXoUs2bNwtSpU42Or9Fo0KtXL3To0AGHDx9Gamoqrl27hkcffZT393PixAncvHkTXbp0qfO9OXPmIDk5GceOHcPQoUMxbtw4PPnkk3jiiSdw9OhRtGzZEk8++SSYO60Ax48fj4sXL2LPnj36Y5SWluLHH3/Uz9qwunXrhn379vGOixC35OjoihAi3t9//80AYDZs2GDxvsXFxUxgYCCTkZHBMAzDHDt2jAkMDGSKi4v191m+fDkDgAkKCmICAwP1sx3Dhw+vczy+mZuJEydy3s5KSEhgBg8ebPb7H374of7r6dOnM127dtV/3ahRI+bjjz82ekzXrl2Zl156iWEY45kbhmGYXbt2MQDqzGKZun79OgOAOXnyJMMwDLNo0SImIiKCKS8v19/n22+/NTr2jBkzmAEDBhgd58qVKwwA5uzZs5zPs3HjRsbb27vObEuzZs2YJ554Qv+1RqNhADAzZszQ35aens4AYDQajf62++67j3nyySf1Xy9btowJCAio8/Nu2rSJ8fLyYrRardnfAyHuhGZuCHFBzJ0reIVCYfG+q1evRvPmzdG+fXsAQIcOHdC8eXOsXbvW6H7BwcHIyMjAkSNHsHjxYrRo0QKLFy+Wdczmxjt27Fj88MMP+vuuWbNGP2tTUlKCq1evIjk52egxycnJOH36tKhxZGdn4/HHH0fz5s0REhKCmJgYANAn6J49exYJCQnw9/fXP6Zbt25Gxzhy5Ah27dqFevXq6f/de++9+uNzKS8vh1Kp5PwdJCQk6P+/YcOGAIB27drVue369ev628aPH4+ff/4Zt27dAgAsW7YMo0aNqjNrFxAQAJ1Oh8rKSjO/FULcCwU3hLig2NhYKBQKQSf2ZcuW4dSpU/Dx8dH/O3XqVJ2lKS8vL7Rs2RL33nsvXnjhBYwbNw6PPfaY4DG1atUKxcXFuHr1ap3vVVVV4eLFi4iNjeV9/OOPP45z587h6NGj+Ouvv3DlyhWMHj3a6D6mgYGlgInLsGHDUFhYiG+//RZ///03/v77b/0Y+Y7JBpMsnU6HYcOGISMjw+jf+fPn0bNnT87nrV+/PsrKyvTPY8hw6Y99bq7bDHc9jR49GgqFAuvWrcOFCxewf//+OktSQO0SZmBgIAICAvh/KYS4GQpuCHFB4eHhGDhwIL7++muUlpbW+T67/fnkyZM4fPgwdu/ebXQS3rt3Lw4dOoTMzEze55gyZQqOHz+OjRs3ChrTww8/DB8fH/znP/+p873FixejtLQUY8aM4X38Pffcg549e+KHH37ADz/8gH79+ulnLEJCQtCoUSPs37/f6DF//fUX2rRpw3k8Pz8/AIBWq9XfVlhYiNOnT+Pdd99F37590aZNG9y4ccPocffeey9OnDhhNNNx+PBho/t06tQJp06dQnR0NFq2bGn0jysHCqidMQOArKws3t+BGMHBwfi///s/LF++HMuWLUPz5s3xwAMP1LlfZmYmOnXqJMtzEuIqKLghxEUtXLgQWq0W3bp1w/r163H+/HmcPn0a8+fPR1JSEoDaROJu3bqhZ8+eiI+P1//r3r07kpKSzCYWh4SE4LnnnsP7779fZ+aCS9OmTfH5559j7ty5eOedd3DmzBlkZ2fjq6++wltvvYXXX38d9913n9ljjB07FmvXrsVPP/2EJ554wuh7b775Jj777DOsW7cOZ8+exbRp05CRkYFXX32V81jNmjWDQqHAr7/+in///Re3b99GWFgYIiIisGTJEly4cAE7d+5ESkqK0eMef/xx6HQ6PP/88zh9+jR+//13fPnllwDuzqBMmjQJRUVFGDNmDA4ePIiLFy/ijz/+wLPPPmsUTBlq0KABOnXqVCdAs8b48ePx119/YdGiRXj22Wc5Z7H27duHAQMGyPachLgEB+b7EEKsdPXqVWbSpElMs2bNGD8/P6Zx48bM8OHDmV27djGVlZVMREQE8/nnn3M+9j//+Q9Tv359prKykjdJ+NKlS4yPjw+zbt06/W1892Vt2rSJ6dGjBxMUFMT4+/sznTt3ZpYtWybo57lx4wajVCqZwMBA5tatW0bfM9wK7uvra3YrOOvDDz9k1Go1o1Ao9FvBt2/fzrRp04ZRKpVMQkICs3v3bgYAs3HjRv3j0tLSmISEBMbPz4/p3Lkzs3r1agYAc+bMGf19zp07xzz00ENMaGgoExAQwNx7773Ma6+9Vidh2NDixYuZxMREo9uaNWvGzJkzx+g20/Fw/Wys1q1bM15eXsyVK1fqfO+ff/5hfH19Ob9HiDtTMIyASzJCCPFgP/zwA5555hkUFxdblbtSUVGB1q1bY+3atfrZNVt68803UVxcjCVLltj8uQhxJj6OHgAhhDiblStXonnz5mjcuDGOHz+OqVOn4tFHH7U6Kdff3x8rV65EQUGBTCM1LzIykipDE49EMzeEEGLi888/x8KFC5Gfn4+oqCiMHDkSH3/8MQIDAx09NEKIABTcEEIIIcSt0G4pQgghhLgVCm4IIYQQ4lYouCGEEEKIW6HghhBCCCFuhYIbQgghhLgVCm4IIYQQ4lYouCGEEEKIW6HghhBCCCFuhYIbQgghhLiV/wd/4upDmrsLbgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "corr = plt.scatter(\n",
+    "    case.fields.bipolar_voltage,\n",
+    "    bipolar_voltage,\n",
+    ")\n",
+    "plt.xlabel('CARTO voltage (mV)')\n",
+    "plt.ylabel('Interpolated voltage (mV)')\n",
+    "corr.axes.set_aspect('equal')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0, 0.5, 'Interpolated voltage (mV)')"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkIAAAG2CAYAAACTTOmSAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAABGW0lEQVR4nO3deXhV1b3/8c8OmZgSZgjIFEHmIAaRMFMUCv4YKveWVgQEbJteECUXFbDoxSnWSxWpCqUCimLBNoCgiFAlYRAogSCDDA4gFBNTQBMImHH9/rCcyzEBsg7nZDjn/Xqe8zycddbe+7uyD/DN2mt/t2OMMQIAAAhAQeUdAAAAQHkhEQIAAAGLRAgAAAQsEiEAABCwSIQAAEDAIhECAAABi0QIAAAELBIhAAAQsEiEAABAwCIRAgAAAavCJEKJiYlyHEcPPvjgVfulpKQoNjZW4eHhio6O1oIFC8omQAAA4HcqRCK0a9cuLVy4UDExMVftd+zYMQ0ZMkS9e/dWWlqaZs6cqSlTpigpKamMIgUAAP6k3BOh8+fPa/To0frzn/+s2rVrX7XvggUL1KxZM82dO1ft2rXTfffdpwkTJmjOnDllFC0AAPAnweUdwKRJk3TnnXfq9ttv11NPPXXVvtu3b9fAgQPd2gYNGqRFixYpPz9fISEhxbbJzc1Vbm6u631RUZHOnj2runXrynEc7wwCAAD4lDFG586dU+PGjRUU5L15nHJNhJYvX649e/Zo165dpeqfkZGhhg0burU1bNhQBQUFOn36tKKiooptk5iYqNmzZ3slXgAAUL5OnjypG264wWv7K7dE6OTJk3rggQe0YcMGhYeHl3q7H8/iGGNKbL9kxowZSkhIcL3PyspSs2bN1EtDFKziM0gAAKDiKVC+tmqdatas6dX9llsitHv3bmVmZio2NtbVVlhYqM2bN+ull15Sbm6uqlSp4rZNo0aNlJGR4daWmZmp4OBg1a1bt8TjhIWFKSwsrFh7sEIU7JAIAQBQKfww7+H1ZS3llggNGDBA+/fvd2sbP3682rZtq0ceeaRYEiRJcXFxWrt2rVvbhg0b1LVr1xLXBwEAAFxNuSVCNWvWVMeOHd3aqlevrrp167raZ8yYoVOnTmnp0qWSpPj4eL300ktKSEjQr371K23fvl2LFi3SX/7ylzKPHwAAVH7lfvv81aSnp+vEiROu9y1bttS6deuUnJysm2++WU8++aTmzZunkSNHlmOUAACgsnLMpdXGASI7O1uRkZHqp+GsEQIAoJIoMPlK1jvKyspSRESE1/ZboWeEAAAAfIlECAAABCwSIQAAELBIhAAAQMAiEQIAAAGLRAgAAAQsEiEAABCwSIQAAEDAIhECAAABi0QIAAAELBIhAAAQsEiEAABAwCIRAgAAAYtECAAABCwSIQAAELBIhAAAQMAiEQIAAAGLRAgAAAQsEiEAABCwSIQAAEDAIhECAAABi0QIAAAELBIhAAAQsEiEAABAwCIRAgAAAYtECAAABCwSIQAAELBIhAAAQMAiEQIAAAGLRAgAAAQsEiEAABCwSIQAAEDAIhECAAABi0QIAAAELBIhAAAQsMo1EZo/f75iYmIUERGhiIgIxcXF6f33379i/+TkZDmOU+x1+PDhMowaAAD4i+DyPPgNN9ygZ599Vq1atZIkvf766xo+fLjS0tLUoUOHK2535MgRRUREuN7Xr1/f57ECAAD/U66J0NChQ93eP/3005o/f7527Nhx1USoQYMGqlWrlo+jAwAA/q7CrBEqLCzU8uXLlZOTo7i4uKv27dKli6KiojRgwABt2rTpqn1zc3OVnZ3t9gIAAJAqQCK0f/9+1ahRQ2FhYYqPj9eqVavUvn37EvtGRUVp4cKFSkpK0sqVK9WmTRsNGDBAmzdvvuL+ExMTFRkZ6Xo1bdrUV0MBAACVjGOMMeUZQF5enk6cOKHvvvtOSUlJevXVV5WSknLFZOjHhg4dKsdxtGbNmhI/z83NVW5urut9dna2mjZtqn4armAnxCtjAAAAvlVg8pWsd5SVleW2Tvh6lesaIUkKDQ11LZbu2rWrdu3apRdffFF/+tOfSrV99+7d9eabb17x87CwMIWFhXklVgAA4F/K/dLYjxlj3GZwriUtLU1RUVE+jAgAAPircp0RmjlzpgYPHqymTZvq3LlzWr58uZKTk7V+/XpJ0owZM3Tq1CktXbpUkjR37ly1aNFCHTp0UF5ent58800lJSUpKSmpPIcBAAAqqXJNhL755huNGTNG6enpioyMVExMjNavX6877rhDkpSenq4TJ064+ufl5WnatGk6deqUqlatqg4dOui9997TkCFDymsIAACgEiv3xdJlLTs7W5GRkSyWBgCgEvHVYukKt0YIAACgrJAIAQCAgEUiBAAAAhaJEAAACFgkQgAAIGCRCAEAgIBFIgQAAAIWiRAAAAhYJEIAACBgkQgBAICARSIEAAACFokQAAAIWCRCAAAgYJEIAQCAgEUiBAAAAhaJEAAACFgkQgAAIGCRCAEAgIBFIgQAAAIWiRAAAAhYJEIAACBgBZd3AAAqEMfydyNT5Js4AKCMMCMEAAACFokQAAAIWCRCAAAgYJEIAQCAgEUiBAAAAhaJEAAACFgkQgAAIGCRCAEAgIBFQUVUPhT98x1+VgACDDNCAAAgYJEIAQCAgEUiBAAAAhaJEAAACFjlmgjNnz9fMTExioiIUEREhOLi4vT+++9fdZuUlBTFxsYqPDxc0dHRWrBgQRlFCwAA/E25JkI33HCDnn32WaWmpio1NVU/+clPNHz4cB08eLDE/seOHdOQIUPUu3dvpaWlaebMmZoyZYqSkpLKOHIAAOAPHGOMKe8gLlenTh397//+ryZOnFjss0ceeURr1qzRoUOHXG3x8fH65JNPtH379lLtPzs7W5GRkeqn4Qp2QrwWN8oQt88DQMApMPlK1jvKyspSRESE1/ZbYdYIFRYWavny5crJyVFcXFyJfbZv366BAwe6tQ0aNEipqanKz88vizABAIAfKfeCivv371dcXJy+//571ahRQ6tWrVL79u1L7JuRkaGGDRu6tTVs2FAFBQU6ffq0oqKiim2Tm5ur3Nxc1/vs7GzvDgAAAFRa5T4j1KZNG+3du1c7duzQb3/7W40bN06ffvrpFfs7juP2/tKVvR+3X5KYmKjIyEjXq2nTpt4LHuXDFNm9POEE2b0q6jEAAFdV7v+6hoaGqlWrVuratasSExPVuXNnvfjiiyX2bdSokTIyMtzaMjMzFRwcrLp165a4zYwZM5SVleV6nTx50utjAAAAlVO5Xxr7MWOM26Wsy8XFxWnt2rVubRs2bFDXrl0VElLywuewsDCFhYV5PU4AAFD5leuM0MyZM7VlyxYdP35c+/fv16OPPqrk5GSNHj1a0g+zOWPHjnX1j4+P11dffaWEhAQdOnRIixcv1qJFizRt2rTyGgIAAKjErGaEsrKytGrVKlfycuHCBdWvX19dunTRoEGD1KNHD6uDf/PNNxozZozS09MVGRmpmJgYrV+/XnfccYckKT09XSdOnHD1b9mypdatW6epU6fq5ZdfVuPGjTVv3jyNHDnS6rgAAABSKesIpaen67HHHtOyZcvUqFEjdevWTU2aNFHVqlV19uxZHThwQLt371bz5s31+OOPa9SoUWURu0eoI4RSKYtaRdRDAoBS81UdoVLNCHXu3Fljx47VP/7xD3Xs2LHEPhcvXtTq1av1/PPP6+TJk1yuAgAAFV6pZoT+9a9/qX79+qXeqW3/ssSMEEqFGSEAqFDKtbJ0/fr1tXr1ahUWFpZqpxU1CQIAALhcqRdL/8d//Ifq1auncePGafz48Wrbtq0v4wLKl+Xsi1Oliv0hSvmLhd+xnAlzgkoulnol/vJz9eQ7Zcv6Z+VJYU8f/13yl/PNDHH5KfVP/sSJE7r//vu1atUqdejQQb169dKSJUuUk5Pjy/gAAAB8ptSJUOPGjfXoo4/q6NGj+uijj3TjjTdqypQpioqK0n333Vfqp78DAABUFB4VVOzbt69ef/11paen6/nnn9ehQ4fUq1cvdejQwdvxAQAA+Mx1PWKjRo0a6t+/v44fP67Dhw/r6NGj3ooLAADA5zyaEbpw4YJef/119e3bVzfddJNWrFihhIQEHT9+3MvhAQAA+I7VjNC2bdu0ePFi/fWvf1VBQYHuuusu/f3vf1f//v19FR8AAIDPlDoRuummm/TFF1+oS5cu+v3vf6+7775bkZGRvowNAADAp0qdCP30pz/VxIkT1blzZ1/GAwAAUGZKnQjNmzfPl3EAlZonRd0CtXCcrwskBoWGWvWXpKL8ArtjhNjfZ1KUl2fVv0yKHVZA/vI9t0aBxHJj/bf5zJkzeuyxx7Rp0yZlZmaqqMj95J09e9ZrwQEAAPiSdSJ0zz336IsvvtDEiRPVsGFDOY7db3cAAAAVhXUitHXrVm3dupW1QgAAoNKzvqjctm1bXbx40RexAAAAlCnrROiVV17Ro48+qpSUFJ05c0bZ2dluLwAAgMrC+tJYrVq1lJWVpZ/85Cdu7cYYOY6jwkBd8Q8AACod60Ro9OjRCg0N1VtvvcViaQAAUKlZJ0IHDhxQWlqa2rRp44t4AAAAyox1ItS1a1edPHmSRAi4TraF48qkAKNtUT4PisCZImPV37ZAYpkU5LM8F2XCg3Nh/Z2yPHdlwpNCkhQvxGWsE6H7779fDzzwgB566CF16tRJISEhbp/HxMR4LTgAAABfsk6ERo0aJUmaMGGCq81xHBZLAwCASsc6ETp27Jgv4gAAAChz1olQ8+bNfREHAABAmSvVKrPt27eXeoc5OTk6ePCgxwEBAACUlVIlQmPHjtUdd9yht99+W+fPny+xz6effqqZM2eqVatW2rNnj1eDBAAA8IVSXRr79NNP9ac//UmPPfaYRo8erZtuukmNGzdWeHi4vv32Wx0+fFg5OTm66667tHHjRnXs2NHXcQMAAFw3xxhjVRhiz5492rJli44fP66LFy+qXr166tKli/r37686der4Kk6vyc7OVmRkpPppuIKdkGtvAFQQ/lJHyPYYQSF2Sxk9Gbd1baPwMOtjFFXAh1WXSR0hX9fsoY5QwCgw+UrWO8rKylJERITX9mu9WPqWW27RLbfc4rUAAJROWRQKLIukwwm2/AXE9j8tD/5jdILsjlEmSU1ZFLe0PX+eJB2+HgdJDa6TB99qAAAA/0AiBAAAAhaJEAAACFgkQgAAIGBdVyL0/fffeysOAACAMmedCBUVFenJJ59UkyZNVKNGDX355ZeSpFmzZmnRokVW+0pMTNStt96qmjVrqkGDBhoxYoSOHDly1W2Sk5PlOE6x1+HDh22HAgAAApx1IvTUU0/ptdde03PPPafQ0FBXe6dOnfTqq69a7SslJUWTJk3Sjh07tHHjRhUUFGjgwIHKycm55rZHjhxRenq669W6dWvboQAAgABnXUdo6dKlWrhwoQYMGKD4+HhXe0xMjPWszPr1693eL1myRA0aNNDu3bvVp0+fq27boEED1apVy+p4AAAAl7OeETp16pRatWpVrL2oqEj5+fnXFUxWVpYklapCdZcuXRQVFaUBAwZo06ZNV+yXm5ur7OxstxcAAIDkwYxQhw4dtGXLFjVv3tyt/a9//au6dOnicSDGGCUkJKhXr15XfVZZVFSUFi5cqNjYWOXm5uqNN97QgAEDlJycXOIsUmJiombPnu1xXEBFYfs4hKCqVX0UyWXyC3x+iLKofmz9iI3LlgWUVpGPf1a23w9PeFRJ3PoxHmXwmBfgMtaJ0OOPP64xY8bo1KlTKioq0sqVK3XkyBEtXbpU7777rseBTJ48Wfv27dPWrVuv2q9NmzZq06aN631cXJxOnjypOXPmlJgIzZgxQwkJCa732dnZatq0qcdxAgAA/2H9q9PQoUO1YsUKrVu3To7j6LHHHtOhQ4e0du1a3XHHHR4Fcf/992vNmjXatGmTbrjhBuvtu3fvrs8++6zEz8LCwhQREeH2AgAAkDyYEZKkQYMGadCgQdd9cGOM7r//fq1atUrJyclq2bKlR/tJS0tTVFTUdccDAAACi0eJkLdMmjRJb731lt555x3VrFlTGRkZkqTIyEhV/ff6hhkzZujUqVNaunSpJGnu3Llq0aKFOnTooLy8PL355ptKSkpSUlJSuY0DAABUTtaJUO3ateU4TrF2x3EUHh6uVq1a6d5779X48eOvua/58+dLkvr16+fWvmTJEt17772SpPT0dJ04ccL1WV5enqZNm6ZTp06patWq6tChg9577z0NGTLEdigAACDAOcYYq9slXnjhBT399NMaPHiwunXrJmOMdu3apfXr12vq1Kk6duyY3njjDf3xj3/Ur371K1/F7bHs7GxFRkaqn4Yr2Akp73CAUquId42ZsrhrrMCyLIcnd41Z3g0VFGI/me7zu8aCiv+C6m1lc9eY3R183DUWOApMvpL1jrKysry63tf6b/PWrVv11FNPuRVTlKQ//elP2rBhg5KSkhQTE6N58+ZVyEQIAADgEutfnT744APdfvvtxdoHDBigDz74QJI0ZMgQ1zPIAAAAKirrGaE6depo7dq1mjp1qlv72rVrXRWhc3JyVLNmTe9ECPyY7aWPijp1bjkOJ9juUq7Jy7PqL9lf+rCNyRNBNWpY9S/8d4V6K5bnwpPLXLaXrqx/tmXwPXc8KSR58aLlQewvbQLXwzoRmjVrln77299q06ZN6tatmxzH0T/+8Q+tW7dOCxYskCRt3LhRffv29XqwAAAA3mSdCP3qV79S+/bt9dJLL2nlypUyxqht27ZKSUlRjx49JEn//d//7fVAAQAAvM2jOkI9e/ZUz549vR0LAABAmbqugooXL14s9sR5HmEBAAAqC+tVaRcuXNDkyZPVoEED1ahRQ7Vr13Z7AQAAVBbWidBDDz2kjz76SK+88orCwsL06quvavbs2WrcuLHrMRgAAACVgfWlsbVr12rp0qXq16+fJkyYoN69e6tVq1Zq3ry5li1bptGjR/siTgAAAK+znhE6e/as6ynxEREROnv2rCSpV69e2rx5s3ejAwAA8CHrGaHo6GgdP35czZs3V/v27fX222+rW7duWrt2rWrVquWDEIEfqagFEi3ZFtizfeaWJ8+FqmJZvNCTZ405ls/pKjp/3m7/ls+2kjwoVlkGz9yy5UlM1s/18qBIpzU/+fuNysN6Rmj8+PH65JNPJEkzZsxwrRWaOnWqHnroIa8HCAAA4CvWM0KXP1qjf//+Onz4sFJTU3XjjTeqc+fOXg0OAADAl6xnhJYuXarc3FzX+2bNmumuu+5Su3btuGsMAABUKh5dGssq4aGG586d0/jx470SFAAAQFmwToSMMXKc4os8//nPfyoyMtIrQQEAAJSFUq8R6tKlixzHkeM4GjBggIKD/2/TwsJCHTt2TD/96U99EiQAAIAvlDoRGjFihCRp7969GjRokGpcdpttaGioWrRooZEjR3o9QAAAAF8pdSL0+OOPS5JatGihUaNGKTw83GdBAQAAlAXr2+fHjRvniziAgGNbzM62IJ/jQf0+U2RXzM62OKIkGV8X5XOslz5aF6u0LcDoCeuYPCjYaArtzoVnx7Ar9BgUGmrVv8iDop5lgsKQlUap/hWrXbt2iQukS3LpkRsAAAAVXakSoblz5/o4DAAAgLJXqkSIy2EAAMAf2V/g1w+3y69evVqHDh2S4zhq3769hg0bpio+fqggAACAN1knQp9//rmGDBmiU6dOqU2bNjLG6OjRo2ratKnee+893Xjjjb6IEwAAwOusb6+YMmWKbrzxRp08eVJ79uxRWlqaTpw4oZYtW2rKlCm+iBEAAMAnrGeEUlJStGPHDtWpU8fVVrduXT377LPq2bOnV4MDAADwJesZobCwMJ07d65Y+/nz5xVqWf8BAACgPFknQv/v//0//frXv9bOnTtljJExRjt27FB8fLyGDRvmixgBAAB8wvrS2Lx58zRu3DjFxcUpJOSH6qoFBQUaNmyYXnzxRa8HCJQLy+rETlDpCo5elzKoVOsE2Y3btmrwvw9i2d+yArcH58LYDqOKB9Wrc3Pt+tv+bD2oqG3Lk/NtW43aulI0FZxxnawToVq1aumdd97RZ599psOHD8sYo/bt26tVq1a+iA8AAMBnPFos3bdvX7Vu3VqtW7f2RUwAAABlwnou9Y477lCzZs00ffp0HThwwBcxAQAAlAnrROjrr7/Www8/rC1btigmJkYxMTF67rnn9M9//tMX8QEAAPiMdSJUr149TZ48Wdu2bdMXX3yhUaNGaenSpWrRooV+8pOfWO0rMTFRt956q2rWrKkGDRpoxIgROnLkyDW3S0lJUWxsrMLDwxUdHa0FCxbYDgMAAMA+Ebpcy5YtNX36dD377LPq1KmTUlJSrLZPSUnRpEmTtGPHDm3cuFEFBQUaOHCgcnJyrrjNsWPHNGTIEPXu3VtpaWmaOXOmpkyZoqSkpOsZCgAACEAePXRVkrZt26Zly5bpb3/7m77//nsNGzZMzzzzjNU+1q9f7/Z+yZIlatCggXbv3q0+ffqUuM2CBQvUrFkzzZ07V5LUrl07paamas6cORo5cqRHYwEAAIHJOhGaOXOm/vKXv+jrr7/W7bffrrlz52rEiBGqVq3adQeTlZUlSW6P7/ix7du3a+DAgW5tgwYN0qJFi5Sfn++qbXRJbm6uci+r35GdnX3dcQIAAP9gnQglJydr2rRpGjVqlOrVq+e1QIwxSkhIUK9evdSxY8cr9svIyFDDhg3d2ho2bKiCggKdPn1aUVFRbp8lJiZq9uzZXosTlVBZFJorsiv6J0lBlo+kMQX5dvuvUcOqvySZ7+2K/jnhYdbHKMq5YLeBbcE8J+TafX68Sahd0T8VWBb984Tl99aj4pZlwPrvBgUSUcasE6GPP/7YF3Fo8uTJ2rdvn7Zu3XrNvo7jXjnWGFNiuyTNmDFDCQkJrvfZ2dlq2rTpdUYLAAD8gcdrhLzp/vvv15o1a7R582bdcMMNV+3bqFEjZWRkuLVlZmYqODhYdevWLdY/LCxMYWH2v7UCAAD/5/trBldhjNHkyZO1cuVKffTRR2rZsuU1t4mLi9PGjRvd2jZs2KCuXbsWWx8EAABwNeWaCE2aNElvvvmm3nrrLdWsWVMZGRnKyMjQxYsXXX1mzJihsWPHut7Hx8frq6++UkJCgg4dOqTFixdr0aJFmjZtWnkMAQAAVGLlmgjNnz9fWVlZ6tevn6KiolyvFStWuPqkp6frxIkTrvctW7bUunXrlJycrJtvvllPPvmk5s2bx63zAADAWrmuEbq0yPlqXnvttWJtffv21Z49e3wQEQAACCSlSoRq165d4h1ZJTl79ux1BQQAAFBWSpUIXariLElnzpzRU089pUGDBikuLk7SD0UOP/jgA82aNcsnQQIAAPiCY0pzfeoyI0eOVP/+/TV58mS39pdeekl///vftXr1am/G53XZ2dmKjIxUPw1XsAeF1xAYnCqWBfY8KNrohNhdmXYsCzB6wuTlWfWvkDEFe3DF3+6fQRVddkOHr9gWSLT+znpwDKA8FZh8JesdZWVlKSIiwmv7tf7X+4MPPtBPf/rTYu2DBg3S3//+d68EBQAAUBasE6G6detq1apVxdpXr15dYkFDAACAisp6Dnn27NmaOHGikpOTXWuEduzYofXr1+vVV1/1eoAAAAC+Yp0I3XvvvWrXrp3mzZunlStXyhij9u3ba9u2bbrtttt8ESMAAIBPeFRH6LbbbtOyZcu8HQsAAECZ8qiy9BdffKHf/e53uvvuu5WZmSlJWr9+vQ4ePOjV4AAAAHzJOhFKSUlRp06dtHPnTiUlJen8+fOSpH379unxxx/3eoAAAAC+Yp0ITZ8+XU899ZQ2btyo0MtqiPTv31/bt2/3anAAAAC+ZL1GaP/+/XrrrbeKtdevX19nzpzxSlDAVdkWLzRFvonjOo9hWygwqGYNq/5F585b9ffkGOaCB4UFS/m4Hlf3quFW/U2OfUymIN96G1+zLZBIcUTAM9YzQrVq1VJ6enqx9rS0NDVp0sQrQQEAAJQF60To7rvv1iOPPKKMjAw5jqOioiJt27ZN06ZN09ixY30RIwAAgE9YJ0JPP/20mjVrpiZNmuj8+fNq3769+vTpox49euh3v/udL2IEAADwCes1QiEhIVq2bJmefPJJ7dmzR0VFRerSpYtat27ti/gAAAB8xnpG6IknntCFCxcUHR2t//iP/9DPf/5ztW7dWhcvXtQTTzzhixgBAAB8wjoRmj17tqt20OUuXLig2bNneyUoAACAsmCdCBlj5JRw++snn3yiOnXqeCUoAACAslDqNUK1a9eW4zhyHEc33XSTWzJUWFio8+fPKz4+3idBAgAA+EKpE6G5c+fKGKMJEyZo9uzZioyMdH0WGhqqFi1aKC4uzidBAgAA+EKpE6Fx48ZJklq2bKkePXooJCTEZ0EBV+ME2VUmluP776ptFWBJckIsb9ostKteHVQr8tqdih3DrjqxU72a9SGKvsu2O4Yx1sewZV2V2ba6OYAKy/r2+b59+7r+fPHiReXnu5emj4iIuP6oAAAAyoD1rzUXLlzQ5MmT1aBBA9WoUUO1a9d2ewEAAFQW1onQQw89pI8++kivvPKKwsLC9Oqrr2r27Nlq3Lixli5d6osYAQAAfML60tjatWu1dOlS9evXTxMmTFDv3r3VqlUrNW/eXMuWLdPo0aN9EScAAIDXWc8InT17Vi1btpT0w3qgs2fPSpJ69eqlzZs3ezc6AAAAH7JOhKKjo3X8+HFJUvv27fX2229L+mGmqFatWt6MDQAAwKesE6Hx48frk08+kSTNmDHDtVZo6tSpeuihh7weIAAAgK9YrxGaOnWq68/9+/fX4cOHlZqaqhtvvFGdO3f2anAAAAC+ZJ0I/VizZs3UrFkzb8SCQGVZnM4JtiuQ6ISHWfWXJJOXZ3eMquHWx3DCLOOyLdpYZFeAUZJ10UaTm2t/DEtF31sew9iP25OCmLZMkV1hSNvCocayJqRHArWQpAffKVQepUqE5s2bV+odTpkyxeNgAAAAylKpEqEXXnihVDtzHIdECAAAVBqlSoSOHTvm6zgAAADK3HVd8DXGyJTBAxEBAAB8waNEaOnSperUqZOqVq2qqlWrKiYmRm+88Yb1fjZv3qyhQ4eqcePGchxHq1evvmr/5ORkOY5T7HX48GFPhgEAAAKc9V1jzz//vGbNmqXJkyerZ8+eMsZo27Ztio+P1+nTp91ur7+WnJwcde7cWePHj9fIkSNLvd2RI0fcnnJfv359qzEAAABIHiRCf/zjHzV//nyNHTvW1TZ8+HB16NBB//M//2OVCA0ePFiDBw+2DUENGjSgijUAALhu1pfG0tPT1aNHj2LtPXr0UHp6uleCupYuXbooKipKAwYM0KZNm67aNzc3V9nZ2W4vAAAAyYMZoVatWuntt9/WzJkz3dpXrFih1q1bey2wkkRFRWnhwoWKjY1Vbm6u3njjDQ0YMEDJycnq06dPidskJiZq9uzZPo2rsrAtRChJptCySpsHhceCQkPtDmEZk11Zuh8ERdS02yDMbgwesS3AmHPB/hhV7H43Mp4UbbRVBsXsbIsdlk2BPd8XebRGYUH4IcdY3vaVlJSkUaNG6fbbb1fPnj3lOI62bt2qDz/8UG+//bZ+9rOfeRaI42jVqlUaMWKE1XZDhw6V4zhas2ZNiZ/n5uYq97Lqt9nZ2WratKn6abiCHfvEoDKrsIlQmF1VZtuYgqpXs+oveVCN2l8SoYICq+5F53Psj2Fbvbog3/4YlipiImRb7dr67ypQyRSYfCXrHWVlZbmtE75e1pfGRo4cqZ07d6pevXpavXq1Vq5cqXr16ukf//iHx0nQ9ejevbs+++yzK34eFhamiIgItxcAAIDk4bPGYmNj9eabb3o7Fo+kpaUpKiqqvMMAAACVkEeJUGFhoVatWqVDhw7JcRy1a9dOw4cPV3Cw3e7Onz+vzz//3PX+2LFj2rt3r+rUqaNmzZppxowZOnXqlJYuXSpJmjt3rlq0aKEOHTooLy9Pb775ppKSkpSUlOTJMAAAQICzToQOHDig4cOHKyMjQ23atJEkHT16VPXr19eaNWvUqVOnUu8rNTVV/fv3d71PSEiQJI0bN06vvfaa0tPTdeLECdfneXl5mjZtmk6dOqWqVauqQ4cOeu+99zRkyBDbYQAAANgvlu7evbsaNGig119/XbVr15Ykffvtt7r33nuVmZmp7du3+yRQb8nOzlZkZCSLpUuJxdKlxGLp0mOxdKmwWBpw56vF0tYzQp988olSU1NdSZAk1a5dW08//bRuvfVWrwUGAADga9Z3jbVp00bffPNNsfbMzEy1atXKK0EBAACUBesZoWeeeUZTpkzR//zP/6h79+6SpB07duiJJ57Q73//e7fKzX51q7pjlzM6QfZl/Hw9te3J/u3H4fsicLaXupxIy+KIkmRZ5NEjjuXP9rJ6WKUSZP9MZXPhouUGlpeUZH+py/p7a/l39YeDlEGhQMu4uNQFlA3rNUJBl/3j6vz7H/JLu7j8veM4KqyAf5E9XiPkB4mQJ/9BeDIO62NYrl2yXb8TsImQ7boXSea7LLv+HnxnTV6eb4/hJ4kQVZwBdxVmjdC1nu0FAABQWVglQgUFBUpOTtaECRPUtGlTX8UEAABQJqzmaoODgzVnzpwKeckLAADAlvXF9EtPewcAAKjsrNcIDR48WDNmzNCBAwcUGxur6tWru30+bNgwrwUHAADgS9aJ0G9/+1tJ0vPPP1/ss4p6pxgAAEBJrBOhoiJu6QQAAP7Bg4Ib/+f777/3VhwAAABlznpGqLCwUM8884wWLFigb775RkePHlV0dLRmzZqlFi1aaOLEib6Is9Ipk6qwtkUeLR/iKNlXAQ4qg0KETrWqdhuURXFE24rMkmT7YNcCu++UOXfebv+STL7dQ1c9eSCq9QNO7Q/g2/1LFbdoIwBr1n+bn376ab322mt67rnnFHrZfzCdOnXSq6++6tXgAAAAfMk6EVq6dKkWLlyo0aNHq8plMwwxMTE6fPiwV4MDAADwJetE6NSpUyU+Zb6oqEj5+fbT5AAAAOXFOhHq0KGDtmzZUqz9r3/9q7p06eKVoAAAAMqC9WLpxx9/XGPGjNGpU6dUVFSklStX6siRI1q6dKneffddX8QIAADgE9YzQkOHDtWKFSu0bt06OY6jxx57TIcOHdLatWt1xx13+CJGAAAAn7CeEZKkQYMGadCgQd6OBQAAoExZzwhFR0frzJkzxdq/++47RUdHeyUoAACAsmA9I3T8+PESnyeWm5urU6dOeSUolJJtgTbj+CaOywXbTzIGNW5k1b+oZrjd/rMuWPWXpIIGkVb9g//lQZHAQsvzl5tn19/4uHChp3xdWNCDYodOkN3fjTIpmAqgTJT6f601a9a4/vzBBx8oMvL//qMoLCzUhx9+qBYtWng1OAAAAF8qdSI0YsQIST88YX7cuHFun4WEhKhFixb6wx/+4NXgAAAAfKnUidClp863bNlSu3btUr169XwWFAAAQFmwXtBx7NgxX8QBAABQ5jy6ff7DDz/Uhx9+qMzMTNdM0SWLFy/2SmAAAAC+Zp0IzZ49W0888YS6du2qqKgoOU4Z3IkEAADgA9aJ0IIFC/Taa69pzJgxvogHAACgzFgX3MjLy1OPHj18EQsAAECZsp4Ruu+++/TWW29p1qxZvoin4vJ1EThJTpUqVv1NkWXBPA8KzVWpWc3uEBE1rY9RWKu6Vf+CmqFW/YND7H6ukhT8nV0RxqIaVa2PEZR51qq/bRE/k2dZgFGy/o5YfwfLggd/Vw31EYGAZZ0Iff/991q4cKH+/ve/KyYmRiEhIW6fP//8814LDgAAwJesE6F9+/bp5ptvliQdOHDA7TMWTgMAgMrEOhHatGmTL+IAAAAoc/aLRgAAAPxEqWeE7rrrrlL1W7lyZakPvnnzZv3v//6vdu/erfT0dK1atcr1TLMrSUlJUUJCgg4ePKjGjRvr4YcfVnx8fKmPCQAAcEmpE6HLnzbvLTk5OercubPGjx+vkSNHXrP/sWPHNGTIEP3qV7/Sm2++qW3btum//uu/VL9+/VJtDwAAcLlSJ0JLlizx+sEHDx6swYMHl7r/ggUL1KxZM82dO1eS1K5dO6WmpmrOnDkkQgAAwFqlWiO0fft2DRw40K1t0KBBSk1NVX5+fonb5ObmKjs72+0FAAAgefjQ1fKSkZGhhg0burU1bNhQBQUFOn36tKKiooptk5iYqNmzZ1//wW2LEXpS1M2yOJ0TZFeuICg8zKq/JDm17S6Jmgi74oiSVFTV7mtYGGZ3LqpctM/3C2rbFZIM/vyU9TFMfoFd/4vf2/W3LMAoSabILibb7+APx/Dx719lUPwUgP+oVDNCUvFaRcaYEtsvmTFjhrKyslyvkydP+jxGAABQOVSqGaFGjRopIyPDrS0zM1PBwcGqW7duiduEhYUpLMx+JgQAAPi/SjUjFBcXp40bN7q1bdiwQV27di32qA8AAIBrKddE6Pz589q7d6/27t0r6Yfb4/fu3asTJ05I+uGy1tixY1394+Pj9dVXXykhIUGHDh3S4sWLtWjRIk2bNq08wgcAAJVcuV4aS01NVf/+/V3vExISJEnjxo3Ta6+9pvT0dFdSJEktW7bUunXrNHXqVL388stq3Lix5s2bx63zAADAI465tNo4QGRnZysyMlL9NFzBjsXltDK4a8z2GNZ3jVWtatVfkpw6taz6e3LXmO0dWvnV7fL30O/yrPpLkixvhqqQd40VlFxS4qrb+PjORU+O4cEBfLt/AOWiwOQrWe8oKytLERERXttvpVojBAAA4E0kQgAAIGCRCAEAgIBVqeoIlSfbtRBOcLj1MWzXdDjBdiUDnKr2Mama3bqiCy3sH857Psruaxica7fGpEqu/ZqRsK/O2G0QGmp9DNvVNeaC3Th8vhbH02OwhgdABcKMEAAACFgkQgAAIGCRCAEAgIBFIgQAAAIWiRAAAAhYJEIAACBgkQgBAICARSIEAAACFgUVS8vygaimsND+ELYFEkPt+hfc2MSqvySdi7Z7IGp2C/uHcAZfsOtf7bRdQb6QsxftDiBJQb7/HaEo+7xVf+vvlAeFC50qVewO4cH3HAAqEmaEAABAwCIRAgAAAYtECAAABCwSIQAAELBIhAAAQMAiEQIAAAGLRAgAAAQsEiEAABCwKKhYWpbF6WyLI0qSEx5mt0Hzxlbds1rbFUeUpIJRZ636X/gmwvoYtXbb/ayqf3nOqn9Qxmmr/pJkLnhQhNH2GAX5dv2LjI8iuewYFEgEEGCYEQIAAAGLRAgAAAQsEiEAABCwSIQAAEDAIhECAAABi0QIAAAELBIhAAAQsEiEAABAwArYgopOlSpynCql7x8aarX/oNq1LCOSTB27YoTpfWtb9f9/E7dY9ZekJxscsOofvfrX1seon5Zj1T/o60yr/ibPrnChJ9sU5X5vfQwAQPljRggAAAQsEiEAABCwSIQAAEDAIhECAAABq9wToVdeeUUtW7ZUeHi4YmNjtWXLlRf0Jicny3GcYq/Dhw+XYcQAAMBflGsitGLFCj344IN69NFHlZaWpt69e2vw4ME6ceLEVbc7cuSI0tPTXa/WrVuXUcQAAMCflGsi9Pzzz2vixIm677771K5dO82dO1dNmzbV/Pnzr7pdgwYN1KhRI9erSpXS3wYPAABwSbklQnl5edq9e7cGDhzo1j5w4EB9/PHHV922S5cuioqK0oABA7Rp0yZfhgkAAPxYuRVUPH36tAoLC9WwYUO39oYNGyojI6PEbaKiorRw4ULFxsYqNzdXb7zxhgYMGKDk5GT16dOnxG1yc3OVm5vrep+dne29QQAAgEqt3CtLO47j9t4YU6ztkjZt2qhNmzau93FxcTp58qTmzJlzxUQoMTFRs2fP9l7ApRVkP9mW3q+uVf+Yuw9a9f95rV1W/SWp1fKpVv1vWn7e+hjOgS+s+hdZ7r/oogdVn43tUcqAY/mdqohjAIAKptwujdWrV09VqlQpNvuTmZlZbJboarp3767PPvvsip/PmDFDWVlZrtfJkyc9jhkAAPiXckuEQkNDFRsbq40bN7q1b9y4UT169Cj1ftLS0hQVFXXFz8PCwhQREeH2AgAAkMr50lhCQoLGjBmjrl27Ki4uTgsXLtSJEycUHx8v6YfZnFOnTmnp0qWSpLlz56pFixbq0KGD8vLy9OabbyopKUlJSUnlOQwAAFBJlWsiNGrUKJ05c0ZPPPGE0tPT1bFjR61bt07NmzeXJKWnp7vVFMrLy9O0adN06tQpVa1aVR06dNB7772nIUOGlNcQAABAJeYYY0x5B1GWsrOzFRkZqf5V7lKwE1Lq7ZzQUKvjBNWtYxuavh7R3Kp/zGi7xdLToj6w6i9JP1tpt1i6VRkslrbFYmkAqPwKTL6S9Y6ysrK8usyl3B+xAQAAUF5IhAAAQMAiEQIAAAGr3AsqlhenShU5TumfURYUUdNq/1//zG69jyRd7G23vmbnSbtjjF+cYNVfktq8/5VV/6Kz31ofw+TlW25gufbFk7UyFXE9Dmt+AMDrmBECAAABi0QIAAAELBIhAAAQsEiEAABAwCIRAgAAAYtECAAABCwSIQAAELBIhAAAQMAK2IKKprBQxqJoXlGjelb7r55uX/wuZH11q/61D12w6h989IhVf0kqOnfOrn9+gfUxKmShwIoYEwDA65gRAgAAAYtECAAABCwSIQAAELBIhAAAQMAiEQIAAAGLRAgAAAQsEiEAABCwSIQAAEDACtiCik5wsBwnpNT9g77Nttp/SI5dcURJitzzL6v+Rf/82qp/QV6eVX8AAPwdM0IAACBgkQgBAICARSIEAAACFokQAAAIWCRCAAAgYJEIAQCAgEUiBAAAAhaJEAAACFgBW1CxKC9fRY5F/xvqWe0//Oscy4gkk3naqn8RBRIBALguzAgBAICARSIEAAACFokQAAAIWCRCAAAgYJEIAQCAgFXuidArr7yili1bKjw8XLGxsdqyZctV+6ekpCg2Nlbh4eGKjo7WggULyihSAADgb8o1EVqxYoUefPBBPfroo0pLS1Pv3r01ePBgnThxosT+x44d05AhQ9S7d2+lpaVp5syZmjJlipKSkso4cgAA4A8cY4wpr4PfdtttuuWWWzR//nxXW7t27TRixAglJiYW6//II49ozZo1OnTokKstPj5en3zyibZv316qY2ZnZysyMlL9nJ8p2AkpfbBxMaXvKykox77Gj/NFyQnglRSeP299DAAAKqMCk69kvaOsrCxFRER4bb/lVlAxLy9Pu3fv1vTp093aBw4cqI8//rjEbbZv366BAwe6tQ0aNEiLFi1Sfn6+QkKKJza5ubnKzc11vc/KypL0ww/USsH3Vt2DCi33L8kxdslToe0YAACopAr0w/953p6/KbdE6PTp0yosLFTDhg3d2hs2bKiMjIwSt8nIyCixf0FBgU6fPq2oqKhi2yQmJmr27NnF2rfqXcnmZ7lzlUVnAADgC2fOnFFkZKTX9lfuj9hwHPfnXBhjirVdq39J7ZfMmDFDCQkJrvffffedmjdvrhMnTnj1B1nRZWdnq2nTpjp58qRXpxQrOsbNuAMB42bcgSArK0vNmjVTnTp1vLrfckuE6tWrpypVqhSb/cnMzCw263NJo0aNSuwfHBysunXrlrhNWFiYwsLCirVHRkYG1BfokoiICMYdQBh3YGHcgSVQxx0U5N37vMrtrrHQ0FDFxsZq48aNbu0bN25Ujx49StwmLi6uWP8NGzaoa9euJa4PAgAAuJpyvX0+ISFBr776qhYvXqxDhw5p6tSpOnHihOLj4yX9cFlr7Nixrv7x8fH66quvlJCQoEOHDmnx4sVatGiRpk2bVl5DAAAAlVi5rhEaNWqUzpw5oyeeeELp6enq2LGj1q1bp+bNm0uS0tPT3WoKtWzZUuvWrdPUqVP18ssvq3Hjxpo3b55GjhxZ6mOGhYXp8ccfL/FymT9j3Iw7EDBuxh0IGLd3x12udYQAAADKU7k/YgMAAKC8kAgBAICARSIEAAACFokQAAAIWH6ZCL3yyitq2bKlwsPDFRsbqy1btly1f0pKimJjYxUeHq7o6GgtWLCgjCL1LptxJycny3GcYq/Dhw+XYcTXb/PmzRo6dKgaN24sx3G0evXqa27jD+fbdtz+cL4TExN16623qmbNmmrQoIFGjBihI0eOXHO7yn6+PRm3P5zv+fPnKyYmxlU0MC4uTu+///5Vt6ns51qyH7c/nOuSJCYmynEcPfjgg1ft541z7neJ0IoVK/Tggw/q0UcfVVpamnr37q3Bgwe73YZ/uWPHjmnIkCHq3bu30tLSNHPmTE2ZMkVJSUllHPn1sR33JUeOHFF6errr1bp16zKK2DtycnLUuXNnvfTSS6Xq7y/n23bcl1Tm852SkqJJkyZpx44d2rhxowoKCjRw4EDl5ORccRt/ON+ejPuSyny+b7jhBj377LNKTU1VamqqfvKTn2j48OE6ePBgif394VxL9uO+pDKf6x/btWuXFi5cqJiYmKv289o5N36mW7duJj4+3q2tbdu2Zvr06SX2f/jhh03btm3d2n7zm9+Y7t27+yxGX7Ad96ZNm4wk8+2335ZBdGVDklm1atVV+/jL+b5cacbtj+c7MzPTSDIpKSlX7OOP57s04/bH822MMbVr1zavvvpqiZ/547m+5Grj9rdzfe7cOdO6dWuzceNG07dvX/PAAw9csa+3zrlfzQjl5eVp9+7dGjhwoFv7wIED9fHHH5e4zfbt24v1HzRokFJTU5Wfn++zWL3Jk3Ff0qVLF0VFRWnAgAHatGmTL8OsEPzhfF8PfzrfWVlZknTVBzD64/kuzbgv8ZfzXVhYqOXLlysnJ0dxcXEl9vHHc12acV/iL+d60qRJuvPOO3X77bdfs6+3zrlfJUKnT59WYWFhsYe2NmzYsNjDWi/JyMgosX9BQYFOnz7ts1i9yZNxR0VFaeHChUpKStLKlSvVpk0bDRgwQJs3by6LkMuNP5xvT/jb+TbGKCEhQb169VLHjh2v2M/fzndpx+0v53v//v2qUaOGwsLCFB8fr1WrVql9+/Yl9vWnc20zbn8515K0fPly7dmzR4mJiaXq761zXq6P2PAVx3Hc3htjirVdq39J7RWdzbjbtGmjNm3auN7HxcXp5MmTmjNnjvr06ePTOMubv5xvG/52vidPnqx9+/Zp69at1+zrT+e7tOP2l/Pdpk0b7d27V999952SkpI0btw4paSkXDEp8JdzbTNufznXJ0+e1AMPPKANGzYoPDy81Nt545z71YxQvXr1VKVKlWKzIJmZmcWyxksaNWpUYv/g4GDVrVvXZ7F6kyfjLkn37t312WefeTu8CsUfzre3VNbzff/992vNmjXatGmTbrjhhqv29afzbTPuklTG8x0aGqpWrVqpa9euSkxMVOfOnfXiiy+W2NefzrXNuEtSGc/17t27lZmZqdjYWAUHBys4OFgpKSmaN2+egoODVVhYWGwbb51zv0qEQkNDFRsbq40bN7q1b9y4UT169Chxm7i4uGL9N2zYoK5duyokJMRnsXqTJ+MuSVpamqKiorwdXoXiD+fbWyrb+TbGaPLkyVq5cqU++ugjtWzZ8prb+MP59mTcJals57skxhjl5uaW+Jk/nOsrudq4S1IZz/WAAQO0f/9+7d271/Xq2rWrRo8erb1796pKlSrFtvHaObdaWl0JLF++3ISEhJhFixaZTz/91Dz44IOmevXq5vjx48YYY6ZPn27GjBnj6v/ll1+aatWqmalTp5pPP/3ULFq0yISEhJi//e1v5TUEj9iO+4UXXjCrVq0yR48eNQcOHDDTp083kkxSUlJ5DcEj586dM2lpaSYtLc1IMs8//7xJS0szX331lTHGf8+37bj94Xz/9re/NZGRkSY5Odmkp6e7XhcuXHD18cfz7cm4/eF8z5gxw2zevNkcO3bM7Nu3z8ycOdMEBQWZDRs2GGP881wbYz9ufzjXV/Lju8Z8dc79LhEyxpiXX37ZNG/e3ISGhppbbrnF7TbTcePGmb59+7r1T05ONl26dDGhoaGmRYsWZv78+WUcsXfYjPv3v/+9ufHGG014eLipXbu26dWrl3nvvffKIerrc+nW0R+/xo0bZ4zx3/NtO25/ON8ljVeSWbJkiauPP55vT8btD+d7woQJrn/P6tevbwYMGOBKBozxz3NtjP24/eFcX8mPEyFfnXPHmH+vLAIAAAgwfrVGCAAAwAaJEAAACFgkQgAAIGCRCAEAgIBFIgQAAAIWiRAAAAhYJEIAACBgkQgB8AvHjx+X4zjau3dveYdyVWPGjNEzzzxTJse69dZbtXLlyjI5FlBZkQgBlVhGRobuv/9+RUdHKywsTE2bNtXQoUP14YcfFuv7zDPPqEqVKnr22WeLffbaa6/JcRzXq2HDhho6dKgOHjwoSW6flfS69957Xft699131a9fP9WsWVPVqlXTrbfeqtdee81XP4IrSk5OluM4+u6778r82Feyb98+vffee7r//vs93kdSUpKqVKmiEydOlPh527ZtNWXKFEnSrFmzNH36dBUVFXl8PMDfkQgBldTx48cVGxurjz76SM8995z279+v9evXq3///po0aVKx/kuWLNHDDz+sxYsXl7i/iIgIpaen6+uvv9Z7772nnJwc3XnnncrLy1N6errrNXfuXFffS69LT8b+4x//qOHDh6tHjx7auXOn9u3bp1/84heKj4/XtGnTfPrzqAxeeukl/ed//qdq1qzp8T6GDRumunXr6vXXXy/22bZt23TkyBFNnDhRknTnnXcqKytLH3zwgcfHA/zedT0IBEC5GTx4sGnSpIk5f/58sc++/fZbt/fJycmmSZMmJi8vzzRu3NjtOXTGGLNkyRITGRnp1rZmzRojyezbt++afY0x5sSJEyYkJMQkJCQU+2zevHlGktmxY0eJY5k+fbq57bbbirV36tTJPPbYY8YYYwoLC83s2bNNkyZNTGhoqOncubN5//33XX2PHTtmJJm0tDTXn1XCc9jef/9907NnTxMZGWnq1Klj7rzzTvP555+7HXfbtm2mc+fOJiwszMTGxppVq1a59n3JwYMHzeDBg0316tVNgwYNzD333GP+9a9/lTi+S/HXqlXLvPvuu27tzZs3N08++aQZM2aMqV69umnWrJlZvXq1yczMNMOGDTPVq1c3HTt2NLt27XJtk5CQYKKjo01RUZHbviZMmGBiY2Pd2u699163B1UCcMeMEFAJnT17VuvXr9ekSZNUvXr1Yp/XqlXL7f2iRYv0y1/+UiEhIfrlL3+pRYsWXXX/3333nd566y1JUkhISKli+tvf/qb8/PwSZ35+85vfqEaNGvrLX/5S4rajR4/Wzp079cUXX7jaDh48qP3792v06NGSpBdffFF/+MMfNGfOHO3bt0+DBg3SsGHD9NlnnxXbX9OmTZWUlCRJOnLkiNusVU5OjhISErRr1y59+OGHCgoK0s9+9jPX5aNz585p6NCh6tSpk/bs2aMnn3xSjzzyiNv+09PT1bdvX918881KTU3V+vXr9c033+jnP//5FX8++/bt03fffaeuXbsW++yFF15Qz549lZaWpjvvvFNjxozR2LFjdc8992jPnj1q1aqVxo4dK/PvR0NOnDhRX375pVJSUlz7yMnJ0dtvv+2aDbqkW7du2rJlyxXjAgJeeWdiAOzt3LnTSDIrV668Zt+srCxTrVo1s3fvXmOMMWlpaaZatWomKyvL1WfJkiVGkqlevbqpVq2aaxZl2LBhxfZ3pRmh+Pj4EtsviYmJMYMHD77q50888YTr/YwZM8ytt97qet+4cWPz9NNPu21z6623mv/6r/8yxrjPCBljzKZNm4ykYrNjP5aZmWkkmf379xtjjJk/f76pW7euuXjxoqvPn//8Z7d9z5o1ywwcONBtPydPnjSSzJEjR0o8zqpVq0yVKlWKzeI0b97c3HPPPa736enpRpKZNWuWq2379u1GkklPT3e13XbbbWbs2LGu94sXLzZVq1YtNt533nnHBAUFmcLCwqv+HIBAxYwQUAmZf88MOI5zzb5vvfWWoqOj1blzZ0nSzTffrOjoaC1fvtytX82aNbV3717t3r1bCxYs0I033qgFCxZ4NearxTt69GgtW7bM1fcvf/mLazYoOztbX3/9tXr27Om2Tc+ePXXo0CGrOL744gvdfffdio6OVkREhFq2bClJrsXHR44cUUxMjMLDw13bdOvWzW0fu3fv1qZNm1SjRg3Xq23btq79l+TixYsKCwsr8WcQExPj+nPDhg0lSZ06dSrWlpmZ6WqbOHGi/va3v+ncuXOSpMWLF+uuu+4qNhtYtWpVFRUVKTc39yo/FSBwkQgBlVDr1q3lOE6pkoDFixfr4MGDCg4Odr0OHjxY7PJYUFCQWrVqpbZt2+o3v/mNxowZo1GjRpU6pptuuklZWVn6+uuvi32Wl5enL7/8Uq1bt77i9nfffbeOHj2qPXv26OOPP9bJkyf1i1/8wq3Pj5OIayVXJRk6dKjOnDmjP//5z9q5c6d27tzpivFK+7yUeF5SVFSkoUOHau/evW6vzz77TH369CnxuPXq1dOFCxdcx7nc5ZcfLx27pLbL7/76xS9+IcdxtGLFCn3++efaunVrscti0g+XUatVq6aqVate+YcCBDASIaASqlOnjgYNGqSXX35ZOTk5xT6/dMv4/v37lZqaquTkZLf/sDdv3qxdu3bpwIEDVzzG1KlT9cknn2jVqlWlimnkyJEKDg7WH/7wh2KfLViwQDk5OfrlL395xe1vuOEG9enTR8uWLdOyZct0++23u2ZCIiIi1LhxY23dutVtm48//ljt2rUrcX+hoaGSpMLCQlfbmTNndOjQIf3ud7/TgAED1K5dO3377bdu27Vt21b79u1zm0FJTU1163PLLbfo4MGDatGihVq1auX2KmnNlvTDTJwkffrpp1f8GdioWbOm/vM//1NLlizR4sWLFR0drX79+hXrd+DAAd1yyy1eOSbgj0iEgErqlVdeUWFhobp166akpCR99tlnOnTokObNm6e4uDhJPyyS7tatm/r06aOOHTu6Xr169VJcXNxVF01HRETovvvu0+OPP15sRqQkzZo103PPPae5c+fq0Ucf1eHDh/XFF1/o+eef18MPP6z//u//1m233XbVfYwePVrLly/XX//6V91zzz1unz300EP6/e9/rxUrVujIkSOaPn269u7dqwceeKDEfTVv3lyO4+jdd9/Vv/71L50/f161a9dW3bp1tXDhQn3++ef66KOPlJCQ4Lbd3XffraKiIv3617/WoUOH9MEHH2jOnDmS/m9mZtKkSTp79qx++ctf6h//+Ie+/PJLbdiwQRMmTHBLvC5Xv3593XLLLcWSuesxceJEffzxx5o/f74mTJhQ4uzYli1bNHDgQK8dE/A75bg+CcB1+vrrr82kSZNM8+bNTWhoqGnSpIkZNmyY2bRpk8nNzTV169Y1zz33XInb/uEPfzD16tUzubm5V1wA/dVXX5ng4GCzYsUKV9uV+l7yzjvvmN69e5vq1aub8PBwExsbaxYvXlyq8Xz77bcmLCzMVKtWzZw7d87ts8tvnw8JCbnq7fOXPPHEE6ZRo0bGcRzX7fMbN2407dq1M2FhYSYmJsYkJycbSWbVqlWu7bZt22ZiYmJMaGioiY2NNW+99ZaRZA4fPuzqc/ToUfOzn/3M1KpVy1StWtW0bdvWPPjgg8UWQ19uwYIFpnv37m5tzZs3Ny+88IJb24/jKWlsl7Rp08YEBQWZkydPFvvsn//8pwkJCSnxMwA/cIwpxa96ABDAli1bpvHjxysrK+u61tp8//33atOmjZYvX+6atfOlhx56SFlZWVq4cKHPjwVUVsHlHQAAVDRLly5VdHS0mjRpok8++USPPPKIfv7zn1/3guPw8HAtXbpUp0+f9lKkV9egQQMqegPXwIwQAPzIc889p1deeUUZGRmKiorSiBEj9PTTT6tatWrlHRoALyMRAgAAAYu7xgAAQMAiEQIAAAGLRAgAAAQsEiEAABCwSIQAAEDAIhECAAABi0QIAAAELBIhAAAQsEiEAABAwPr/19T7tUCnbN0AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "bins = np.linspace(0, 4, 41)\n",
+    "corr = plt.hist2d(\n",
+    "    x=case.fields.bipolar_voltage,\n",
+    "    y=bipolar_voltage,\n",
+    "    bins=bins,\n",
+    ")\n",
+    "plt.xlabel('CARTO voltage (mV)')\n",
+    "plt.ylabel('Interpolated voltage (mV)')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "exclude = np.logical_or(\n",
+    "    np.isnan(bipolar_voltage),\n",
+    "    np.isnan(case.fields.bipolar_voltage),\n",
+    ")\n",
+    "r, p = scipy.stats.pearsonr(bipolar_voltage[~exclude], case.fields.bipolar_voltage[~exclude])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.868535653295952"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r  # Pearson correlation coefficient between CARTO voltages and interpolated voltages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load an openCARP dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case = openep.load_opencarp(\n",
+    "    points='C:/Users/Paul/Documents/software/development/openep-misc/examples/data/pig21_endo_coarse.pts',\n",
+    "    indices='C:/Users/Paul/Documents/software/development/openep-misc/examples/data/pig21_endo_coarse.elem',\n",
+    "    fibres=None,\n",
+    "    scale_points=1e-3,  # convert micrometres to mm\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Currently, there is no electrical data in this case. We can add unipolar electrograms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First load the data with numpy\n",
+    "unipolar_egm = np.loadtxt('C:/Users/Paul/Documents/software/development/openep-misc/examples/data/pig21_endo_coarse_phie.dat')\n",
+    "\n",
+    "# Add the egms to the case\n",
+    "case.add_unipolar_electrograms(\n",
+    "    unipolar=unipolar_egm,\n",
+    "    add_bipolar=True,  # also calculate bipolar egms from unipolar egms\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualise electrical on the surface mesh\n",
+    "We have loaded unipolar egms and determined bipolar egms from them. Now we can visualise this electrical data on the surface mesh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bipolar_voltage = case.electric.bipolar_egm.voltage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd31cad474574405ac582791a95ad1c4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(VBox(children=(HTML(value='<h3></h3>'), Dropdown(description='Colormap:', options={'BrBG':…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mesh = case.create_mesh()\n",
+    "plotter = openep.draw.draw_map(\n",
+    "    mesh=mesh,\n",
+    "    field=bipolar_voltage,\n",
+    "    add_mesh_kws=dict(cmap='Turbo', clim=[0, 10]),  # set the min and max voltage to 0 and 10 mV respectively\n",
+    ")\n",
+    "plotter.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load a CVI workspace and stack of DICOMS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_directory = pathlib.Path('C:/Users/Paul/Documents/software/development/cvi42_to_mesh/cvi42_to_mesh/_datasets/')\n",
+    "cvi_workspace = data_directory / 'cvi42wsx_workspaces' / 'IHD001.cvi42wsx'\n",
+    "dicoms_directory = data_directory / 'dicoms' / 'IHD001'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epi_mesh, endo_mesh, dicoms_data = openep.load_circle_cvi(\n",
+    "    filename=cvi_workspace,\n",
+    "    dicoms_directory=dicoms_directory,\n",
+    "    return_dicoms_data=True,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>slice_location</th>\n",
+       "      <th>phase_encode</th>\n",
+       "      <th>datetime</th>\n",
+       "      <th>dicom_path</th>\n",
+       "      <th>dicom_id</th>\n",
+       "      <th>slice_thickness</th>\n",
+       "      <th>basal_slice</th>\n",
+       "      <th>pixel_spacing_x</th>\n",
+       "      <th>pixel_spacing_y</th>\n",
+       "      <th>upsample_factor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>56</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142817</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.172053503312281364121...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>64</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142817</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.327507644213058969518...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>72</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142822</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.318223274812269669624...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>80</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142822</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.158673170114156499083...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>88</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142827</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.187757150513143713742...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>96</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142827</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.344654518012187299908...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>104</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142832</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.184797745122824342103...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>112</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142832</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.294259932120461315333...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>120</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142837</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.240128468811107296042...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>128</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142837</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.387727528911111086018...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>136</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142842</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.179640207711685752107...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>144</td>\n",
+       "      <td>COL</td>\n",
+       "      <td>20100927142842</td>\n",
+       "      <td>C:/Users/Paul/Documents/software/development/c...</td>\n",
+       "      <td>1.3.6.1.4.1.9590.100.1.2.260462601011868143712...</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>1.875</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   slice_location phase_encode        datetime  \\\n",
+       "0              56          COL  20100927142817   \n",
+       "0              64          COL  20100927142817   \n",
+       "0              72          COL  20100927142822   \n",
+       "0              80          COL  20100927142822   \n",
+       "0              88          COL  20100927142827   \n",
+       "0              96          COL  20100927142827   \n",
+       "0             104          COL  20100927142832   \n",
+       "0             112          COL  20100927142832   \n",
+       "0             120          COL  20100927142837   \n",
+       "0             128          COL  20100927142837   \n",
+       "0             136          COL  20100927142842   \n",
+       "0             144          COL  20100927142842   \n",
+       "\n",
+       "                                          dicom_path  \\\n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "0  C:/Users/Paul/Documents/software/development/c...   \n",
+       "\n",
+       "                                            dicom_id  slice_thickness  \\\n",
+       "0  1.3.6.1.4.1.9590.100.1.2.172053503312281364121...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.327507644213058969518...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.318223274812269669624...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.158673170114156499083...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.187757150513143713742...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.344654518012187299908...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.184797745122824342103...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.294259932120461315333...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.240128468811107296042...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.387727528911111086018...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.179640207711685752107...              8.0   \n",
+       "0  1.3.6.1.4.1.9590.100.1.2.260462601011868143712...              8.0   \n",
+       "\n",
+       "   basal_slice  pixel_spacing_x  pixel_spacing_y  upsample_factor  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  \n",
+       "0         True            1.875            1.875                4  "
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dicoms_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Voxelise a surface mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case = openep.load_openep_mat(DATASET_2)\n",
+    "mesh = case.create_mesh()\n",
+    "voxel_grid = openep.mesh.voxelise(\n",
+    "    mesh=mesh,\n",
+    "    thickness=2,  # either a float or an array of floats (one per node in the mesh)\n",
+    "    edge_length=1.0,  # sets the resolution (mm) of the grid\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Anaconda3\\envs\\openep-tutorials\\lib\\site-packages\\traittypes\\traittypes.py:97: UserWarning: Given trait value dtype \"float32\" does not match required type \"float64\". A coerced copy has been created.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a5a0068202734e2aa1b1cfefa685dffe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Scene(background_color='#4c4c4c', camera={'position': [119.9725943786629, 39.972594378662905, 264.972594378662…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plotter = pyvista.Plotter()\n",
+    "plotter.add_mesh(mesh, pickable=False)\n",
+    "plotter.add_mesh_clip_plane(\n",
+    "    voxel_grid,\n",
+    "    cmap='Greys',\n",
+    "    clim=[0, 1],\n",
+    "    interpolate_before_map=False,\n",
+    "    show_scalar_bar=False,\n",
+    ")\n",
+    "plotter.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract the myocardium from the voxelised grid\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "voxel_grid = openep.mesh.voxelise(\n",
+    "    mesh=mesh,\n",
+    "    thickness=2,  # either a float or an array of floats (one per node in the mesh)\n",
+    "    edge_length=1.0,  # sets the resolution (mm) of the grid\n",
+    "    extract_myocardium=True,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9aeb48f16b7b41fdba88fef9ae305f5f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(VBox(children=(HTML(value='<h3>Filled</h3>'), Dropdown(description='Colormap:', options={'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "voxel_grid.plot()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.7 ('openep-tutorials')",
    "language": "python",
    "name": "python3"
   },
@@ -599,7 +1190,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "0a4359d27a983cff32fcf095f4547555a5a1033eff1494389832674483dda890"
+    "hash": "3677f6f3ac8167cdf158173e66f9a83d16cfd449037c01afb05ac0b318fa102f"
    }
   }
  },

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -26,32 +26,12 @@
    "metadata": {},
    "source": [
     "# Load a case\n",
-    "We will load a .mat file that was created using OpenEP MATLAB and then take a look at the data stored in the case"
+    "We will load a `.mat` file that was created using OpenEP-MATLAB and then take a look at the data stored in the case"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/usr/local/Caskroom/miniconda/base/envs/openep-tutorials/lib/python3.9/site-packages/openep/_datasets/OpenEP-MATLAB/openep_dataset_2.mat'"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "DATASET_2  # DATASET_2 is simply a path to a .mat file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,8 +42,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Look at the surface data\n",
-    "The nodes and triangle data are stored in `case.points` and `case.indices` respectively"
+    "Note, `DATASET_2` is simply a path to a `.mat` file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/data/KCL/Paul/miniconda3/envs/openep-tutorials/lib/python3.9/site-packages/openep/_datasets/OpenEP-MATLAB/openep_dataset_2.mat\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(DATASET_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Look at the surface data\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "openep_dataset_2.mat( nodes: (14383, 3) indices: (16942, 3) fields: ('bipolar_voltage', 'unipolar_voltage', 'local_activation_time', 'impedance', 'force', 'thickness', 'cell_region', 'longitudinal_fibres', 'transverse_fibres', 'pacing_site') )\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(case)  # The surface mesh has 14383 nodes, 16942 triangles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The nodes and triangle data of the surface mesh are stored in `case.points` and `case.indices` respectively"
    ]
   },
   {
@@ -174,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,14 +212,110 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>Header</th><th>Data Arrays</th></tr><tr><td>\n",
+       "<table>\n",
+       "<tr><th>PolyData</th><th>Information</th></tr>\n",
+       "<tr><td>N Cells</td><td>16942</td></tr>\n",
+       "<tr><td>N Points</td><td>14383</td></tr>\n",
+       "<tr><td>X Bounds</td><td>-7.584e+01, 6.374e+01</td></tr>\n",
+       "<tr><td>Y Bounds</td><td>-1.300e+02, -3.585e+01</td></tr>\n",
+       "<tr><td>Z Bounds</td><td>7.937e+01, 1.712e+02</td></tr>\n",
+       "<tr><td>N Arrays</td><td>2</td></tr>\n",
+       "</table>\n",
+       "\n",
+       "</td><td>\n",
+       "<table>\n",
+       "<tr><th>Name</th><th>Field</th><th>Type</th><th>N Comp</th><th>Min</th><th>Max</th></tr>\n",
+       "<tr><td><b>Data</b></td><td>Points</td><td>float64</td><td>1</td><td>3.600e-02</td><td>4.614e+00</td></tr>\n",
+       "<tr><td>Normals</td><td>Points</td><td>float32</td><td>3</td><td>-1.000e+00</td><td>1.000e+00</td></tr>\n",
+       "</table>\n",
+       "\n",
+       "</td></tr> </table>"
+      ],
+      "text/plain": [
+       "PolyData (0x7ff36d10de80)\n",
+       "  N Cells:\t16942\n",
+       "  N Points:\t14383\n",
+       "  X Bounds:\t-7.584e+01, 6.374e+01\n",
+       "  Y Bounds:\t-1.300e+02, -3.585e+01\n",
+       "  Z Bounds:\t7.937e+01, 1.712e+02\n",
+       "  N Arrays:\t2"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
-    "openep.draw.draw_map(\n",
+    "plotter = openep.draw.draw_map(\n",
     "    mesh=mesh,\n",
-    "    \n",
-    ")"
+    "    field=case.fields.bipolar_voltage,\n",
+    "    add_mesh_kws=dict(cmap='Turbo'),\n",
+    ")  # creates a pyvista.Plotter\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0de72c38b594e28bd05fcb088049b72",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(VBox(children=(HTML(value='<h3></h3>'), Dropdown(description='Colormap:', options={'BrBG':…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plotter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1498a7df83724fb5871bf3b733c83415",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(VBox(children=(HTML(value='<h3>Data</h3>'), Dropdown(description='Colormap:', options={'Br…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mesh.plot()"
    ]
   },
   {
@@ -302,27 +427,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mesh = case.create_mesh()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "793a1063721448e687109dd17073b8fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAACDCAYAAADBExzWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAABUJ0lEQVR4nO3deXxU9b34/9c5Z/bMZN8hCQHCvrqAiCJqRanr1Vpbl2qvW1ul5apXe2+/98q993dxaatdtNr2qnWt2rrWBcUFFAHZIewBQhKy7zOT2c/5/P6YZJIhEyAQEpDP8/HgATlzMnw+53zmzPt8Pp/zeStCCIEkSZIkSZI0JNShLoAkSZIkSdKpTAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSdJx8bftbWyu9w91MSTphKfIROGSJEnSQFtR2cH5L+0FIPzvU4a4NJJ0YpM9Y5I0iF4sbaXod9tZX+sb6qJI0nG1uUH2iEnSkZLBmCQNon/+RxU13gg/fLdqqIvyjSSE4NlNLXxS7hnqokg9GHIARpIOyTTUBZCkU5EvYgx1Eb5RXtvWxoulrdw0OY07PziARVNoumcidrO83xwqSo9/e4IGKTZtyMoiSSc6GYxJ0hAwZEfBgLrxnUoAPtoX7REL6YIVVR1cNNI1lMU6pQX17kbeFtRlMHacCSHwhAySrfI4n4zkbaMkDQE5anP8bW8KDHURTmltAT3hv6Xj42cf15Dx622sk/NRT0oyGJOkIRCRXWPHXVlLaKiLcEp7c2d77N/tMhg77p5a3wzA/3xZP8QlkY6GDMYkaQjIOWMDxx9OfCzLWoKDXBKpp53N3ce/LSiDscGytSHA3UuqafVHhrooUj/IYEw6LiKGkE9QHUJHSAZjA6XBl/hLZ0Odn1e3tQ5yaaRE5DDl8dVzudBKd5g/bmjmzg8ODGGJpP6SwZg04Fr8EcY9tZNZz+1Bl8NxMT0DMF0elgFT1R5OuL0toHPTO1XypuAE0BaQNx/HU0eC3uG3drmHoCTS0ZLBmDTglu7zUtEeZkOdn9JGOYm6y11L5J3q8VDh7j03rOeyCl7ZCznoDk7s0i6HKY+rZn/i4ysT7Jw8ZDAmDbhdzd0BWFW7nETd5eWtbUNdhJPW/rYQIT1xUFXe2ruNjcu0xv7dKofIBt3BHeJymPL48gQTfzb299FrLJ14+hWMPfTQQ5x55pm4XC6ys7O56qqr2LVrV9w+QggWLVpEfn4+druduXPnsm3btoTvt3jxYjRN4+GHH+5XoWtra7n++usZO3YsqqqycOHCXvvMnTsXRVF6/bn00ksP+d5vvvkmF198MZmZmSiKwqZNm3rtU1dXx0033URubi5JSUmcdtpp/P3vf+9XHb7JNvZIDPzVgcF9zPr17W2c98IeqhL0lgyEZl+Et3a29/tpSHmHevS+quqg5A87ueSV8oSvb0yQiHpMencwJntljo47qNPcx3y8w9EPau8NHcd/MnkwYuANnZrn2tNHvd/d3Z5wu3Ti6Vcwtnz5cu666y5Wr17N0qVLiUQizJs3j46Ojtg+jz76KI899hhPPPEEa9euJTc3l4suugiPp3d6kueee47777+fZ599tl+FDgaDZGVl8Ytf/IKpU6cm3OfNN9+ktrY29mfr1q1omsa11157yPfu6Ohg9uzZhwwQb7rpJnbt2sW7775LaWkpV199Nddddx0bN27sVz0Gwom4RMKOpu6nqL6qiraNWm+Yz3qkqPnF57WYF2/h/bLueQ3VnjA//EcVzkdKMS/ewtl/KSPQz6cOb3i7kpUHfPzrJ7XHWIvEvvtmBd99s4KHv2ro1+81+XpfLOVcpiPz/JYWAL6s6uj1WkfI4MvK+O02k0JxqiX280AOUwYjBtsaA7ScAk+qzf7LHgp+t6PPgGzVgQ5WHehI2I4P/tjubD626QpCCP6yuYUHl9clvOaFdcHw3+0g7VfbsD20hW2d0yMaOyKsru7dbo6lHG0Bnb9ua2XZfu9h9//Nmkbm/3Ufv17dQLDzoBzqxuzVba1c8OJeShPk9XxrZzvX/n0/td7evV19tfG3dh59MLa2xseHe+LnnX1a7uHLSi/727pvdoUQvLWzHfvDW1iwpDq2PRgxaPZFCOkG7qDeZ73bAzpPr2/mopf3cu3f9x/xNV83BIuW1/FC5/XhZKeIY7hlb2xsJDs7m+XLlzNnzhyEEOTn57Nw4UIeeOABIBo45eTk8Mgjj3DnnXfGfnf58uXccMMNlJeXM2LECP76178yZ86cfpdh7ty5TJs2jd/85jeH3O83v/kN//mf/0ltbS1JSUmHfd/9+/dTXFzMxo0bmTZtWtxrTqeTp556iptuuim2LSMjg0cffZRbb72133U4Ws2+CNP+vJvvTkhl/mgXhoiuPO6yqNR6w7QFDKo9YarcIXxhg7KW6N9Tc2xkJ5nJtGu4rCrPbmohJ8lMfUeYM/IdnJHnwKRCjSdCilUl12kmxarismj4Igab6/28V+ahxR/BEDDMZea0PDuZdhPtQZ1frW6MK+d9Z2XFts0tSuLv14wg87Fob+kwl5n9C8bzj93tXP33il51nJJt4+EL8rCbVOo7wqyp8bG+1k9a52reG+r8JJlVpuTYyHWa+e2aptjv+h6YTI03jE1TyEoysaHOz+oDPv6+o43ythBOi8p1E1I5a3gSmQ6N3c1BLJqKzaTgNKtUuMN8tt+LN6iTbNOwm1T+uKE59v6/v3gYigJ2k4LDrNLQEaEjbKAqoBvgDulUtIUJRAwq3dE5dD39bEYmz21uoSTdynmFSZw/wklxqoUvKjv4VrGLWm+Y0oYADrOKP2xgUhUOuEPYTCqaGh2aeHlrK6k2jUBEYDerdIR0zKpCrtPMuYVJnJZrp8mvs6Kqg2FOE2l2E7oQfFXZQb0vwvlFTiZk2jBrCq2BCC1+HZOqcKQihiCsC7KSTGQ5TFg0hRpPmNaAji9sEIgI/BGDNTU+hIDxmTam5tgYlWbFG9LZ2xqizhsh1aaRZFaxmhQ0RUFTwaQqBCOCez+pif1//3NeLhcWO1my18Pu5iCf7vfQeFCgm2bT+MvlBVz5t/0APHf5cG6cnB57vaEjwivbWnmptJVaT4TpuXbMGtx5WgY1nghra3w4zCpmTSHNphHWBXvbQizd56G+s4fHYVa4eUo6cwqTcFk09rYGURWFPa1Brh2fyrQcG56QQWlDgGpPGEMIdBE9XhFDoBvRz2qzP0JQF1g0BVUBq6aSnWRiYqaNVJtGUDf4orKD8rYQFk2hoi1EyBC0B3SGJ5sJRAS6EBSlWBjuMqN1njt3MHr8S9KtuCwaI1It5DpN7GoOsrbGx7paH2XNIcyawph0KxOzrNjNKmFdENIFvojB419HP0v3npXFHdPTaQno7GwKoijw9PpmVld393pfPNLFvrYg5xQk8dt5w3hlWys/+qD7i9lmUmj4l+70VPvbQpQ2+KnxRmLXmv2dUxrynWYafBF8YYOx6VZCuuDNne3s6lyqZGy6lV+cm82141NRFZj5bBmb6uODvbOGOfjsxlE4HikFop/Rl68qZNbwJE7/v93UeCNMy7ExuyCJB87Oxhsy+NXqRr6s9BKMCPJcZhbNyeHB5fWsqYnWc0Kmle1N8culXDraxcY6P4UpFi4Y4aQoxcLcoiTcIYPfrmnipdLeT/PaTQo/nJrO7IIkluz1oCjR4/ePMjevbmuL7bfqh6NZUdWBpiicU5DEjGfLALBqCovPz6PBF2Zsho3zi5KY+ufduBMMVSrA2ltLmJpjp84bZn97CENAZXuo8xqo0dgRIaAbOEwqVZ4wFW0hFAWWVUSD2MnZNuaNdLGiqoOve5zza8en8OzlBdz3SW3cdXHnj8cS0gXnvbA3borA+Awr105I5fpJqYxKi/Zc72gKcMYzZYQOeqKpINlMcaqFjrDBeYVJnJnvwKQq/KPMTW6SiXS7xiflXj4pjwbEt01L58E5OezvrFdYF+xqDhLSBQIYmWoh2aqhKLC7Ocj/bWwhzaZxxdhkfGGDZIvGg3NyYp+foXBMwdiePXsoKSmhtLSUSZMmsW/fPkaNGsWGDRuYPn16bL8rr7yS1NRUnn/++di2H/zgB+Tk5PDLX/6S++67j8bGxrjXj9SRBmOTJ09m1qxZ/OlPfzqi9z1UMHbJJZdgMpl44YUXSE1N5fXXX+e2225j8+bNjBo1qtd7GYaBYXR/UBRFQdM0dD3+bkFVVVRVJRKJvxPta/vTG1v5l6W1aCL+y0jv7PDUMI5su6KBEAm3K8JARRx2u0DBUFRUYaD02G6gIBQ1roz/Pjub/++rRoSiYhI6628r4fLX9lPtCaOjUpRq4UBb/MX1RK/TobbrqKAoJ915OlnqZNFUTstPYlWVFwVBvtPEG9eOYOZzexGKSqpZ8If5w/i6xsfr29qp8+knfJ2+Secp32mixhthfkkyNpOJPS1+SnsMLR+vOhWmmKlsD8dtH5VmYW/nHMNv+nm6oiSZdztHHgazTv8+O5vFXzUcsk52k0IocoR1HaTztPSGkcwaHu2o6es7V9M0FEVJuB1A1/WE2xXl8EHeUeemFEJwzz33cM455zBp0iQgOpcKICcnJ27fnJwcKiq6ez3cbjdvvPEGK1euBODGG29k9uzZ/P73vyc5Ofloi9SnNWvWsHXrVp555pkBeb/XXnuN6667joyMDEwmEw6Hg7feeithIAZQVlbG7t27Yz8XFhYydepUtm7dSmVlZWz7mDFjGDt2LOvWraOxsbt3aerUqRQWFrJixYq44d7vzJhB5pUFLPvkY1p9QQIRgQLsTZmMbrIyo2Mj2UkmVEXBooJjwrnsa/QwvHkzjb4IAjCbTFRkz8DT2sj0yF72t4XITTLjwUpZ6hT8TTXM1A7gDup4QgatajIF409jjKjF0laF06zijwhqtAz+Up/FyGAlBaKZcRlWar1h1oWyKVPyOM0oJ4to2dd/CcOVAqqUTM42drP4L1uZFDKYBDx800WMH5HPhx9+iNsfYuUBH/vbQ6y1jKcwM5lZvo24rCpdc7mHnXYebq+f+m2rsWgKmXYTpc1h/hqaSCYeZhh7Y8fLp9hoyp7OOFMLZ6gHqPGEafLplAUdlFpLuDi5nXTfAUK6IBARhJzZjJs0hbS2vQSbawkbgk31fsqUXMqUPL6TUoMt2EYwYiAAb/pozGl5DG/ejCniR1HAZdFoSBvH07sEFxrbMNH9Yf1CHcel4zKZ6tlIrTdMky9Ce9DgI3UKdkLMFTtJtmhEDIFmMrHMMhWTv5UrHJVEDEGVO4wXGzPPmcNYrYWm8h20BXQiBuj2VPY6x1K2ezeT1HqKUy2EDYHblkWdcyQjAvvJDDVR6w3TETZocQxDZI6g2LMTU6AtVkZv2mgCzhzSajeiRbrvitszJxC2p5JWtRoMnaBu0B4wKE+dTE6qk5KWdZhUhYghUBUYd9YFWEWIPRtW0uzX8YYMFFWjYdhM6hsamKOWYxjRu1jdZKchZzomTy1GbVnssf1GXKzVRjNRbWC2o4k8pxmnWeWM8cWsMVJwV+6kQDSTHFDZtGIPo4WDMiWPksBeXnprEwDTgVKlgHpTFvPVvYx0RD8Hu1uCrFFH0aIk8z3rTjKsxMofGH4aDoed1KqvyU0ykWbXqHaH+dI6jX2NHsZ7t5Jmj15KazoM3hGTY20vyazitKhgcVCfPY1kfwPp7ftQlc4nPpPSsBVPxV9bjq09ugxHR9hgZySN5cFhTOEAM51uUm0a/rBBcn4xeSNKCO7fjKe1GU2Fak+E1pSRGMm5ZNZvQov40I3ovK0q1zh2BBxMaV9PuPMLJNNhInXcDPJTnVj2rcQTMmgL6BiAt+gsrEaIA6WrY8OBiqqx3DKNPNycrZRjUsFhUglodsyjzqSl7gBjwxU0+XXK20Kx8zRa1FMi6jg/zcnnbi8VuzMoVQuZbFRysWhGU6KBNBmFOPNHktKwjYC7BbtZxWVR0fLGUKmkkV67ESXsJ8thIifJxJeimGfK6PV5unDuXK6bmsODz7xBrTcCrTAeaBo2k+217cwxdkIzjAZyXVamnfst/nvJztg1Is9poigrlc+V8ewp389kURV77551Ot/ZzOyCJDwhg22hFFZGhjM2VIG3qbsHt+sacWNGLfNzI4QNwbpaP43OYiyZ+VRsXIldBGJtbI06iiaSE14j/Fi42NhCklnltFw7+9tDvKlPYkSSQVbDlti+ETQ+1qaQiYdZYi9Xm1LRaafNsPKFNp7hooWZWjUCsGgKblMy+51jmWZqoCBcQ9gAb0gnmJRD9qgJJDXvQXXXUd8RYV9biDIll3OnT2RiYDf7q+vZ3x5CF7DXUsRN507g408/x0mA9V/CxcAadRSv3ziNbSs/JdUC+1pDbGsK8EFkDP5ItE4AmXYTs4Y7uPmay1i9v5U3l3xKeVuIiVk2zCYTpamn425uJKlhO4LoaAoWB8vUcZg99ZSEKgh3ttWu83Rpehs5gWocJhVVVWizZrGBAor85YxUWgjpAqtJRaQX8rtyJ6cZ5Wz5qpy2ZPMhv3NnzpxJdnZ2bJpWl7lz52K32/nwww/paf78+fj9flyuw+fIPeqesbvuuov333+fFStWMHz4cABWrlzJ7NmzqampIS8vL7bv7bffTlVVFUuWLAHg6aef5sknn6S0tDS2z+TJk1mwYAF33HFHv8pxJD1jd955JytXroz7/15++eW4YdMPP/yQc889N/bzoXrGFixYwJo1a1i8eDGZmZm8/fbbPP7443z55ZdMnjy51/9/vHrGDo7ShRCx94a+o/SDt5tMJoQQCbcfXPa+tieqk24IHvyygS+qfPxpfh5/2tDMnzZEx/cT3WUtODODRy8q6HXnoRsCi9nUrzpVdxg0doQpcmlsbQigqQpn5juwW829yr6tMUBxuh2nWTlsnZyPlGKg8Ot5w/nx9NS4//NQ5+l/vqznze0tlLeFYgmUhaKy7+7x5Di6p24GIwYOq5mOkIFZMeK6zY/mPB3cxo5X2+u5HQ59np5Y28jPP6vj1asLuWp8xmHr5Hyk+3P79W3jGJFsIsncfVwUReHJ9a3869IDKAgmZtl48pJhzHlxH0JRybEDIvpU5ag0KzdPzWDhWdkII/p/hnXBVa/vR9VU3v/+SIwjbGOH2t7si2BSDJyW7qTN/f08KapKIBTBonXX9VjOU0V7iGEuMyb18NeIDTVeZv9lDwDeByb32fZu/aCGv5a28NuL8rj9tAwWr6iP9or06J3wPjCZj/e5eaG0naABp+dYuXVqOllJpqOu07paP3d/UEFJmoV/npbBzGEOHNboF+m9H1fxh3XRYbOzhjn45KYS/m9TCwuXRIOrf56Wxu8uHo7JZGJPS4APd7cxLdfOWcMcKIqCyWSi0RvixS3NTM2xc16RE0MILObe146en6eIbrC1McDjqxuYNzqVG6ek92pLXXXa3uDFHTA4I99BY0eEuz6q5Z+nZ/Cd16OB4fYfjaUg2Rz9DBuCqvYAw13mWA9L13l6fFUd//55Xez9u3qR8pNU9t49nhWVXpZVdDCzwMWYdAtFyfH9L0d6Le+5vet8lLcG2dUS5JxCF6l2M7b/7Z4znWHXeOd7ozgjP6nX+dvcGOQ/Pq/js3I335+Ywp8uLTjk91ZX26v3BHFZVKwmNWHZ9c4pAEk2S7++c+e/up/l5e08c/lwrpuQFneeBrNn7KiCsQULFvD222/zxRdfUFxcHNt+pMOUM2bMYN26dahq95eQYRiceeaZfP311/0qy+GCMZ/PR15eHv/93//Nz372s9h2j8dDfX13Dq9hw4Zht9tjP/cVjO3du5fRo0ezdetWJk6cGNv+rW99i9GjR/P000/3q/ynkrAuYnM4AL4/MZVPyrvn/Gy9cwxjM2xDVbwjYl4cvZt76cpCrpuY2u/fH/abbTR01vfVfyrkmvH9f4+TXdcxtJsU3Pf3vnnpa3+A8L9PSbjPk+uaWPhxtGfizHw7j12Uz7nPR7/YHr4gl3vPyj7WYp9yvqz0kp1kOuRnsuvcZNo1av9lIutqfcx6bk/cPn2ds+Ol2hPmf1fU809jU7hoZLRH4u1d7Vz7RnR0puXeibis2qHeYsgs3efBFza4cmzKEe2vG4IXS1u5/f34NQxL0i1s/9G441HEPp37/B5WV/tQleh83aGcf9Uf3/n7ft7Z7eaJS4Zx52kZQ1aOfg1TCiFYsGABb731FsuWLYsLxACKi4vJzc1l6dKlsWAsFAqxfPlyHnnkEQBKS0tZt24dy5YtIz29e1JtW1sbc+bMYevWrbFhz4Hw+uuvEwwGufHGG+O2u1yuI+o6PJjPFx2q6RlIQjQCPviOV4pn1hRK0i2xBM4RQ/DU/OH895f13Dcr64QPxABeuaqQFVUdfGf8kV0sD9bzzifRqtmnEn9k4J4m7fnQgd2kxj3NJ1NPHZ1zC52HfD3cY9J1V67VyVk2Uqwq7X2sezUYhrnM/GH+8Lht5xc5yXaYmDHMfsIGYkAseDxSmqpwy9T0XsGYyzL4dXz16iI+3ufhxklpJ00gBuC0RB/aGuqVCfoVjN1111288sorvPPOO7hcrtgcsZSUFOx2O4qisHDhQhYvXkxJSQklJSUsXrwYh8PB9ddfD8AzzzzDjBkzEj45OWvWLJ555hkef/zxw5ala/0vr9dLY2MjmzZtwmKxMGHChLj9nnnmGa666ioyMo4s4m1paaGyspKamuhddtc6arm5ueTm5jJu3DhGjx7NnXfeya9+9SsyMjJ4++23Wbp0Ke+9994R/R+nsv8+L5fvvxWdJ3ffrCxOy3Uc8V3gieDaCalcOyH1qH+/Zz90X6tmS/E+vn4kt7xbyZMHfcH21GMkD7tJxehxYW0bwsDgm6zn+m2+cPQJzxSbxqc3juKMZ8qGsGS9pdg0yheMw3wSBQn98fH1I7n01fLY3KnytsFfbHuYy8wPp6YffscTzLOXF/CXKwqHuhj9W2fsqaeeor29nblz55KXlxf789prr8X2uf/++1m4cCE/+clPOOOMM6iurubjjz/G5XIRCoV46aWXuOaaaxK+/zXXXMNLL71EKHT4hjR9+nSmT5/O+vXreeWVV5g+fTrf/va34/bZvXs3K1as6NdyE++++y7Tp0+PLQ77ve99j+nTp8eGH81mMx988AFZWVlcfvnlTJkyhRdeeIHnn3++1/8v9XbNuBRW3jKa8rvHcVquY6iLM+h63ns1HuWCmqea80c4qfjpBC4r6fvhnvieMYUNPZ7Wk1kgjg/3QYvpbu1c22tqjp0sx4nX+2TR1COau3MyOn+Ek39cNyL2s8w6ceTUE6RN9HuY8nAURWHRokUsWrSo12sWi4Wmpqbev9Tpnnvu4Z577hmwsowZM6bfK5/fcsst3HLLLYfcp6SkhDfeeKNf7ytFKUp0Iv2pqmdPeNMpGozZTAqBARyiBOKGRWxmNW7R3/0yGBtwn5Z7eq0NtbHOz+yC6NIA39QeqBNZzwc9zik4/Fqa0onlqJe2kCSp/3p+fSValf9UkO0wUeke2Jx5ph59/GZVYXSahT2d60kN9P91qqj1hvGFjdgCnV2+qurgkr/2Tk3Vc1FjsyaDscHW85jffcbQTUSXjs4JmSh84sSJOJ3OhH9efvnloS6eJPWbJ6jz8FcNcQmTK49T/swTXdeSBhBd12htjY9//aTmmPIKaj2GGlQF5o/uHtJs8eu9htSkwyv83Q7GPbWrVzqkN/tIsbOh1ocQggeX1xEc4J7PgXTAHTphU5Htbwvxy1UNtB/FMGPPnrGuDCXSyeOE7Bn74IMPCIcT380evKCsJJ0MHlnVwCMr49NElbUEMYQ4YeYsDBZbjy+Nak+Y+X/dR3vQoNYb5qWrio7qPXvOGVMV8B/0pGpFe4jJ2faDf21ACCFi6ai+ibY3BeKerNzdEp8SaEy6hd0tIXY0B/lgj4fF/czbOpie39LCbe8d4OqxKVw5NpnvTkg9ZPovIaKLKxckmwdlvtm8V/ZR3hZiS0OAF6889KRyQwjeK3MzNcdOUYoFS48n/FNkMHbSGZKrx0MPPcSZZ56Jy+UiOzubq666KvbUIkBRURGjRo3ipZdeYs6cOUyePJnbbruNYDCYcDmKxYsXo2naIZN7J1JbW8v111/P2LFjUVWVhQsXDkj5JaknQwh+v7b3XElfWFDtGdghNCEErSd4EuuecdLe1lBsGYTXtved1NgfNg45/7PnMKWmKPgPSja846CcggPpln9UUfC77WxJkNz5ZNWz56hnEmpPMJrntKeSdCvFqRYMQSyP44nqd525a9/c1c7N71bxLx/XHHL/36xpYtSTO3lqffMh9xsoXU9Bvrv78Am+//uLeq75ewWjn9zJnpYgw1zdfSs20zfzxuCbbEjO2PLly7nrrrtYvXp1LK3AvHnz6Ojo/pA/+uijPPbYYzzxxBOsXbuW3NxcLrroorjUBF2ee+457r//fp599tl+lSMYDJKVlcUvfvELpk6dOqDlHwy6IXhsdSNbGwL9flABGLB1VdxBnbuXVPPhHnef++iGYGOdnz+sa2JHU6DP/YQQfFYeTULe9bMQgiZfhD0tQTbX++OG+gDaAjr7WoOxY9AW0I/b2lJbGvzMeq6Mpft6t8O+fLzPgy8cf6ytnb1D2xr7Phb9sbHOz2vb2rj01XKyH9/OdW9U8Pu1TUcUmAkhMEQ04bc/bCRsF7oh2N8WIqQf+ri2+iPsbAqwoc5HWI+eO3/YiBsmDPd4/3UHfXlXJphsv7s5SMavt5H6q6386IMDccNmQgh2NgX4tLz7fIQNEXuazGmJXuKWlic+X/6wwcKPqxn+2+385MMDfFnp7VWfsN77eJS1BFld3cHWhgCvbG2jPWhwxWv7EULQ0BFhyV43emc9gxGDr6t9lLUEE75Xl/aAzsf7PLywpaVX+w3rAs9BQ62BiHHI9zv499fW+HiptJWtDYHDDtP1bAM13u4bhpe2tsYFZxBdSuSSUdGb5E31xx6Q6oZgQ52PP21oZsle91Fd2yDaNlZUdfDkuiY8QR3dEGxpiP+8Pbu5pdf1pEtYF9z/afRBkJ99XNNr6HB3c5CXSlspbfD361rqCxsEO28W2gI6H+5xx37u3qf7/UK6we/XNvFfX9TFrovlbSH+t0cP5PT/202tN8J5hUmMTbdSkm4hpBu9eoiPpz0tQVZUdfRqp4dzDOmx8QR1vq72sbVhYK6jQ+mYEoUPlMbGRrKzs1m+fDlz5sxBCEF+fj4LFy7kgQceAKKBU05ODo888khcGqPly5dzww03UF5ezogRI/jrX/+acA2zwznShONHUv6DHa90SMsrfVzy6v5YSqEJWTZMKqTZLZhVBasq8IUNWoM6TrOKjoohBMIwaPJH2Nc5wXlCThLpVpXCZI16bzSPGgpUuA0KXBqGblDf+QVoN6s0BcCEQb7ThN2ksrzSG5eI9ZapqYxMsbCrJcjWxiAbG0K9ksWeNTyJ0/OdpFshJ0njV6ub2N8WQigqBgouk8EvZufwq9WNtAb0Xklkx6Rb+edpaby2w8O6Wj8aBul2jVa/jgAUTWNkiplaT5DhLgvFqRY+2udBVzTSrArZDpV0mwmzqhAwDDKTrHgCEVQEhiEwAE9YYKBS4NIIhHWa/DrbGwOxVE7/NDoJp1XFHzao8UQoaw0RFAroOooSDbgy7Cb2tEUIC+KOwflFTj6p8HHnaRn85qJcIPrF//r2Nv6208P6Oj92TeAOGkzItDIxy8qedoOiZDPJFsH/zs1jXa2fP25oZnNjmGp3sM+EuRMzLeQ5zTjMKrdMS+eC4hSq2gI8ua6Rd3e5qeuIxKWnSrdrTM6yU+kOIVA4u9DFqko35W0hzKrCyDQL25vDoCh8Z0wSEzJtVHvDrKzysaMlHHeeNAV0EU0CXJBsxqaJWLsDOLswmS8rvbH9/2tODvfOyo6lcvr79lZufrcqrk65DpWFZ2ZwwBPijR1u6n16XBLgSdk2DAFbG4MsPCub362uJ8OusfPH47Cbo5+l/1nRwENf1tJTz8TG5xQk0RbU2doQQEfl26Nd2FVBjTdCjTfMAXc4YWLjH52eTrVX8PaudjQMVv9wNGd1rkivKxopFpiZZ6c5oOPQFAwFZg53sbclwHs9ekMECucUuajzBKn3hmMBUJrdxLgsB75giC31AawmhRn5DsZk2slwmDF0nYr2IGZNoTjFQkmmgw11fv68viHuC15HZWKWjVQLOMwqJlXhgCdMaWMIp0XFH+q+1qRYVe4/J49NtX7+tr2lVxv73vhkfjgllW+/Wo7DrOALi7h0SFeNSWZdrZ/ajgghoVKcrDEpy0pHSLC3LciwZAvFaTYmZZqp84Z5a6ebak84rk1OyLIRiBjMzLcTMlSSbSYcmoFZU+gIGRxwh/FGok8rp1oUXFaFdbV+9rSE0FEZk27hO2NdPLKqMa7sCMGTF+fyz9OiE96X7HXzwlY3a6s7qPXE3xgUptlZfF429d4QH+718Gm5F6PzumdXBecUODgtL9r2mgMCl9XEjvoODnii5y/TobGxPhirU26SibqOSOx8DE+2UOvuDioKU8yoqsbe1lDc5+nAzyaw4ONaXtveTooluqhx15nNcVm5eXIqX1Z4WFXtI82mcdeZmZRkOPAEw1S3B9nVHOTdMjfnFDiJoLK3JYAwDOo6IoxMs6B2poRSDkqqrSoKWU4L4UiEYERgNymk2zQK06w0+AxeLY3vPbSZTfz4jEzM6AxzmdlY72dLQ4BdLWF0A9Ks0R68Gk+YsCEYmWbHaVWJ6Dq+sMFwl5lkq4bFbMKiAkKnqj0SnRNaksw7ZV5WVXnjrntOi4rTZmG4UyPFomDRon8iKPgj0e9imwbJVpUWv84BTwSL2cTYNBN//PawaK5UTqJ0SANtz549lJSUUFpayqRJk444rRLAD37wA3JycvjlL3/JfffdR2NjY9zrR+pYgrGDy3+wXbt2JUwUvnnz5oSJwlevXp0wUfiyZcviegbNRVN4rFTHvG9ln8lle+pKQD3H2BnbFksuK9xxSbW92PhCG0+B0ZQwYW6JUUuJ6M6JVqV0JwEuEN0fyjIllzI1jzP1PbFE4RBN1lylZjJH34GT7gvQGnUUTUoy8/QtCes039hCz3u9k6VOKemZjGpaF6vTOQVJLK4uwG6389vi/extDbK+zk9IF0ddp3MsNWQnmUi2qBzQnfzVXUBBqGbQz5OhWZkb3kxPfdVpuWUqrkh7rE6qAt+ekEvupLN4ecUO/NXdw/+HOk9VjhEU+PZTIJoxKdGL33aRw+t3nMcDz3+EKdDG9Bw7U3Js3Ffq7FWnFKvK0nDxIdveN+HzpCrRgOVY6pTnNNEeMGiIWPhCG8+txUEuddbx+vY23CFjQOpkVhXaUkexvN3V72tEf+s0Vy3njHw7Fe1htrWr/TpPDaZMNlLABP34Xvd61mlKto1fNo3BQYjHSmpxmBU+2++lyitO6LZ3rOeprzpNFVWx74RjqdPNoxXyndGh3r6+c7sShX/44YcnTqLwgSKE4Morr6S1tZUvv/wS6E44Xl1dTX5+fmzfO+64g4qKCj766CMA3G43eXl5rFy5kqlTp7Jp0yZmz55NbW0tycl9LxCZyNEGY4nKf7DjnSi8zRfk430eajxhDBG9O4oYglA4QkfYQEEh12lC0zQ0VUEROnaTSppNQ1GgukOwozGANxhiuMtCqk1DIGgJKui6gUUV0TsWQ5DlMJHe2YtU1R7gwz1earxhRqZZOb84mbXVHaTZFHY1BRmbaWXmMCcum4mWjiDnFTrJcJjY1xpkyb4Ovq7xI3Sd1oBOSBd8daCD/zk/nxynmTv+URGr5+3T01l84TCSzCq6rvPTj6p5bnMrBclmMpMsfKvYxU/PSOOAJ4w7YFCUakYzmdhY6+OH71RQlGrhtmlp+CMwLS+JfKdGrTtEXUeYsNGZ1kXVCIZ1MuzRXgJNgYgAdxgUYRAMG9R7wzy8qhEDhXGZdm6dkkrYiB5Lp1VjmMtCst2MoUdwmFSCusGOpiB+XeGa8alMfmp7bPhs24/GcvnrFZS1hOJ6VoYnmzm/OJkfTEnn5S1N/GVzKwA/Pj2dSblOlu338rdt3b0TU3JsnDHMxb0zM3slAdY0jbU1HWyr91HtCfNumZu9rWHcYVCFQVGKifvOymL+6GSsJg2zFj2+m+p81HVEeGeXG09YcG6RizGpGnOLnLhDBl9Uenlzl5cl+7xYFT2WemhEqoU/XVbIuYVOAqEIe1uDmFQFp0XFHYb1tX4qW/0YAq4cm8KMZ8tivRNW1WB6roO1ncOWXT0rZkXQcyRu5a1jeXNHK6urOshN0hifaeOH0zLY3Rrh4pf3xN3JGyg03juZX62s45erGuK2d/VOPHv5cE7PdTAq3UpAV/j3ZXX4giFqPRHGZ1k5v8jJ33d5WbrPQ1NHtKfk3rMyuXpcKtPykvjpkmoq24I8dlEen1d4+elHNbE69TyvH98wklkFyTy7sYmvq72cP8LJnuYgH5V7qfIYzBuZxA8mpnBukZNqT5gtDQE+Lvfx2tZmbpuexvlFToa5zDT6DRp8BiZ0xmXYiBjRobgVB3x8UeVn/kgHY9OttAd13t/jwR0STMt1cO04J1eOSUFTFUK6QZ1PsL0xQHV7ALOmoBuCTIeJHS1hxmXYeH5TEx91DsXfMjWNoNCwqvDtUUlcPNLF9P/bzb7WELqiccuUFJ66ZBivbW/l1n8ciDt/KoLF5+di1RRcNhNjMx1UtwfY3xZkeUUH03Ns2C0mdBS21HZg0eCfxkVzSjosJvwRWHPATa03zI6mIIGIgapqGCjsavRh1RRGpJpxmlWGpdroCAne3N5CyBAUuMw8Ni8fTdO44MW9lLcGSDKr3HdWFisP+Hjg3DzOf2FP3HkCuGFqJhPSLZw93M7SfR4uK0kmyaLyy69b+GyfmxpPiPmjXPzb7GxOz09CKCorKtwsWl6HN2ywsynAsGQrF41KYVqWmUyHhtOsUtEe5qNyL2cXusi1KxhCMMxlwWFWWFUTZGKWjUtfifai5iSZKE61YDWbuGpsCt8qsvOPMncsKbiOyjkFSSy9fgQQ/R56an0zL25zMyHTyshkjQZfhDS7xqa6AD5dJcUa7TU0aQreoMHkHDsj0uy0+MJk2VVaAzopVo0cpxkUFcPQ41KGdESgLSTQRPR6vb7Wx7bGIC0Bg8k5Dr4z1sllJcnUd0S46OV97GmLcG6hk1SLoCMkmJRtZVKWjTFZDtJsGt5AmEZfhHyXmfqOCIqqEdYFJsVAiOii2IGIQUhoBCI6Hn+YiBD8enV03t+EnCRevnI4JWkW2gM6u5qj7cNpt3CgLYg3FJ1iENQNFEXFaTOjCp0WX4QWfwSHWSXNYebHS2rRhM5zlxfEsquckj1jd911F++//z4rVqxg+PBoupOuYKympoa8vLzYvrfffjtVVVUsWbIEgKeffponn3yS0tLu5NOTJ09mwYIF3HHHHf0qR6Jg7Msvv2T+/Pmxn//4xz9yww03HLb80rH7p7+V816Zh0cuyONfZmbGNeaIEX3CqTjVMujlKvzddmq9EdbfVsKUfj6dl/f4Npo6UyDtXzCePS1Brv77ftxBg2EuM/82O5vbpqUfNq9bW0DnjZ1tTM+19zuLgSEE2xuDZDo0cp3mfv3uoexsCjAyzRLr5j8Sc1/Yw1cHuueMHfjpeC5/fT8bO9ermj3cwVPfHs6UP3X3KveVdPrLSi8XvLSv13bfA5MRCE7/vzJ2NndP4l9wZiaPXZTfa/9DEUIc8qIqRDRp8zu73VxU7OK6CSn8v2V13H1mJuMzT/y8qz11PXUIEPq3yb3qPfmPu2LH87Zp6Tz17ei17z+W1fHwyvinKQc7UXgiNZ4wT69v5vIxyXGLTl/+WjlL9kaDTqdF5Y1ririguP85iwdKV+L1/5qTw7+fE79yQLMvQtHvdxDsvDtJtM+p4G/b23i3zM1vLsonw3HsC0J8780K3tjZzuMX5XP3mZkDUMKjM6RLWyxYsIB3332XL774Ii6Qyc2NzqGpq6uLC8YaGhrilrZ49tln2bZtGyZTdzUMw+CZZ57pdzCWyBlnnBHLgQm9l9Xoq/zSsXvzOyMwBAkDE5OqDEkgBrDhtjHUeMP9DsQgvi6qAucVOdl251iqPWGm59qPeImLVJvGrdOOblFHVVGYlD3wgcG4owg2/vf8POa+GB16+N7EVHKcZtb8c0mst7g/Swkkaiea0rUQpkLpnWP5tNyDqijMHObAcRTLUByuPIqi8IMp6fxgSnd+vkPl0zyR9WyLierdczmInv+elHViBp35LjP/PTe31/bXri7ivTI35xYmkWRWST5BkogHEzyYkeEw8d0JqbxYGu0t729S8W+KY80PfLALi52k2TQmZFoPv/NxNCTBmBCCBQsW8NZbb7Fs2TKKi4vjXi8uLiY3N5elS5fG5oyFQiGWL1/OI488AkBpaSnr1q1j2bJlpKd3X/za2tqYM2cOW7duTTh/qz/sdjujR4/ud/mlY6coCifiIt6ZDhOZR3k31rM+Xf/MdZoHtIfqZDK7IInW+yaioJBk6Q6ODv7yPyPPzrpa/yEDcC1BwHDw4/0XDmGPx8nmcNmMeq723vPf4QF6QnuwOMwq3x3AL/ZjZVYVwobgghHOhK//+lt50eE1m8YZecdn3bxTze3TM2D64fc73oYkGLvrrrt45ZVXeOedd3C5XNTVRcfBU1JSsNvtKIrCwoULWbx4MSUlJZSUlLB48WIcDgfXX389AM888wwzZsxI+PTirFmzeOaZZ3j88ccPW5auni+v10tjYyObNm3CYrEwYcKEoy6/JCXSs/fmBIwzh4TTcvieiL9dU8TjXzfxk0OkeEm0rJLNJI/y0TrcjVDP1d57HvuBWi7nVLXv7nHsaQlxTmHi3JJpdhNPXDJskEslDYYhCcaeeuopIDpPq6fnnnsulqT7/vvvx+/385Of/ITW1lZmzpzJxx9/jMvlIhQK8dJLL8WWvTjYNddcw0MPPcQjjzyCxXLo4ayeT2uuX7+eV155haKiIvbv339M5Zekg/X8gjvVVt0/FsOTLfz6MPO7Eh1PufDl0Ttc+zT3MUx5cCw2zHVq9voerVO5p/xUN2TDlIejKAqLFi1i0aJFvV6zWCw0NfVe0bzLPffcwz333DNgZRmI35Gk+Hk4Q1iQb6BEw2rf0OxEg6LnJPdEegZj5rhgrPvaePW4ZP5wyck5Z06SBpu8XEnSIFHiesaGrhzfRInmjCWaBC0dmeJUCxtvG0PlT8cnfN3cY3S5Z89YzyOeajMNyNNu0uGtr/Ux4emdPPRV/VAXRTpK3+hgbOLEiTidzoR/Xn755aEunnSKURNM4JcGRqLgNhCRwdixmJRtI6+PITNnj2is52hwz2HKFl/8WkzS4f1mTSPnPr+nV+qlw3n860bKWkL85/J6OXJzkupXMHYkCbKFECxatIj8/Hzsdjtz585l27ZtCd/veCb4DofDXHzxxaSnpxMOhxk+fDi/+93v2LRpE5s2beKKK65I+DsPPPAAkydPJikpifz8fH7wgx9QUxOfTDYYDLJgwQIyMzNJSkriiiuu4MCBA/2qg9Q/h8ulN1gihmBH09HlAu0ZL8g5Y0cuGInmj/yiwtvnPomCsZ6TyQMRg/9cVsew32znq6rBzSH7TZRs6/7q6GuYsrZDBmP99a+f1LK62sevVzcefuceWvzdwVtXsnHp5NKvYOxkSvD9//7f/+O1117j6aefZseOHfzsZz/jrrvuwuPxMHr06ITpCXw+Hxs2bOA//uM/2LBhA2+++Sa7d+/uFbgtXLiQt956i1dffZUVK1bg9Xq57LLLeq2+Kw2MX65qIO1XW/nVqobD73yc3bWkmil/2s1LW9v6/buHmjO2orKDD/e4T5ig80ThDuo4H93Kk+uaufDlfbFEyQdLFNxGDMEbO9owL96C69GtPLSygQZfhGvf2H+cS/3N8NT6JmwPbeHfPquNJT3vktJjPa6up4RXVHbw04+6b1zreiQYlw6v52e/wt2/gKqivXv/NTW+Q+wpnaiOaQX+EznBd35+Pr/4xS+46667YtuuuuoqnE4nL7300hG//9q1a5kxYwYVFRUUFhbS3t5OVlYWL774Itdddx0ANTU1FBQU8MEHH3DxxRf3uw5HSwjBE+uauXJMMq0BnUZfhJJ0K5l2U9y6TT21+CNsrIsmbF2y18O6Wh9XjklhcraN8ZlWzh4eXfxQVaLzP1QlmojXYVZi6z91NZlARKAq0X00te/enoghomlMlGgKkLbO9EfukIECeEIGeU5TbEjEYY6mXmr167QEIkz6Y/cK7O9+dwTzR8enujKEQAHqOiJk2LVYeh6AA+4wWxsDTM62sbneT0V7iGk5dsZn2ugIG6gKBCMCq0lBAWo8EVJtGk6LSmGKGSGivS5dde9aIRtg421jmJBl7Twm0SEaQwgMAf6IQUfYwBc2WHXAR0GymZ99XMOuzlXLW++biNOi4Q3pLPqint+uiT6QclqunQfn5HDJKFfseEYMQZMvQqbDhElVEELwXpkbAUzItJGTFD3fqqIQMaLnRCE6Z8qqKXHrdgkh2NcWiqaiybWTnWTCpil8daCDjrBBcaoFh1nFYVLJ7UwE7wsb2Exq3HpSQkSzIOxuCeINGbQGdMZmWJmeY8feOXM+YgjaAzodYQNPyOD17W2k2jQ21/uZmGXj3rOyErYZIQQC2NYY4NJXy6n1xgdgV4xJ5pnLCki1aVS0h9jZFGREqjmunQCxPIyJvHXtCC4r6TtlWntA59P9XpZVeClINqMpCslWNVa34S4zo9IsOC0a7UGdLIcJq6b0WnxWNwTlbSGqPeFYO893mcl2mGL7hnXBF5VetjUGmTXcwWm5djrCBm2BaIJl7aCepwPuMJvr/dz7SS1FKWauHpfC/FHJDE+Ofn7e3e0m065xdkFS3HwuiAa3SeboOa31RnCHdEanWUmxqnHtZHmFl2+93J3R4MIRTp67oiD2Gf3PZXU81LnSftdK8GP/sJN9PXplzKqC5/5JaGq0XXpDBi6Lyt7WEK7O9Go5SSbManwb1Q1BUBfc+f4Bmv0Rzi1MYlyGjSSLijdkUJRiZky6FYdZRev8PHSEDZLM3XXQO9NEPbmuiYJkCxOzbFw8yhV7urPeG+aJdc00+SLkJJn4p3EpTMqyxY51xBC9jl0inqBOjTfM1oYAo9KtjEq14A0btAd0xmRY+XCPh0nZNopSLPjDBjubg+xrDZLrNHNGnh1r5xivEIKb3qnkte3dyeIXzckh1aZx4QgnRSkWgrpge1OADHs0EB6bYYu1n+Rflsaue3efkcHj86LLXwQjBiFd4AsbJFs17GYVvTODiUVTyO/xtOuLpa0sq/CycEYmkzsXtTaEYNUBH6UNASZmWUmyqBS4LJS3h1hR2cEZeXZKMqwEItFr0j1Lo8F4vtPE5zeNojjVEnduazxhNtRFr8OzhjuYkm2PHWd/OJrw3KIpqEr0HHS1Dd0QRAzBrpYgEUOQZjORYu1K6RdtAwcvEt7qjxAxoje+XddEVYm+98Y6P4u+qOfbo1386PSMI1pi53g7pmDsRE7wnZGRwaOPPsqtt94a2/b973+fVatWHXLZioN98sknzJs3j7a2NpKTk/nss8+48MILaWlpIS0tLbbf1KlTueqqq/iv//qvXu9xvHJTLq/0ccmr+9FEfI+cjkqqTcMXDDMu00azL0J7UCeCSiAieuViS5RLr2t7V345kwpJZhWHWaU1pOALRVB7TNcVKBiKihkjtoSDLgQoCmGh9ipjz/yAB5c9w2GizRfqtR0g3Qp/vHQ4l5WksK81yMOrmnmxtPWo6nS47V11UoWB0xwNON1Bo8+yH6pOKErc9lunpZGZZOX/NrbQnKCuI1MtzMyzsq0pyLbGQKyMDhMEwwe9f2fZM2wq7UE9FoDoihatvxAMc5kpSDazszlEc1CgCqNXHscjrVOKNZprMiKUhHW1aAouM3hD3Xkru85fovMxt9BBriP6xTCn0Mk1f6847HlymCDNplHrjSBQUFQVYfRdpztPS+dHp2Wy8OMaPq/swG7R+PKmYoY5zayp8VHa4OeJ9a1cNCqZ/c1+VlV3dB/Hvsp+0HanRaUw2YxQTUR0g45gmNaAjr9z7lrPOjktKpeVuGjs0Pmk0o8wuusazYsabXsuEyR1fl+aVYX2kMAd5ojbXkGKleEpVsKRMFXtYeo7hw4T1WlchhW7xcS6Wn/C85RqVTkrz0ZZa5Aad4iQcfjP07+elcHfd7RT0R6O+zwpPeqKomI2aWBEiBgi1maO5PPUfa2Jbrd2tr1AxOg+7p11tamC4lRL7IbAZ6hx14gsh4bTotEUhHZ/OJqT16JhiGjezv1ug4iuU5hsQgjwhQ1aAkavOvVVdrXzvHZtt5kUvj3KRWGqhce+bkEoiT9PB5+nru2zhzuYlGXhla2t+MLdbQwhuGiEg5AeDUh7no+Dz9Pk3CRCYZ1dzd0JvgUKuS4LdZ7QUV8jDj5Po9Is7G0N9aqTArEgO1FdVQUMRUM3juxablJBM5mIRAz0Ht+5idpez7JfMsLBy/9UGMvMMRS5KY/6URchBPfccw/nnHNObKX7rsVPD04blJOTQ0VFd+Jnt9vNG2+8wcqVKwG48cYbmT17Nr///e/7neC7LxdffDGPPfYYc+bMYdSoUXz66ae88847/RpKDAQC/PznP+f666+Plauurg6LxRIXiEG0jl31P1hZWRm7d3fftRcWFjJ16lS2bt1KZWVlbPuYMWMYO3Ys69ato7Gxe85AVwb5FStWxA33mgunMDbdSlHjWkzoOEwq/ojBcnUcnoCFi40tUA9dD5d/pE7BSYgL2YUCpNs1hKrhGzELd0sTrobteMPRBuzFxhfaeIaLFiaLKjCACDT6XRzQRlMi6ikR3fWtUjIoVQoZZxygQDR3113JpUzN4zSjnCy6y75dK6TJksWM4A5cRO92BLBGHUWTP5l5xjZMRM9VbpKJC8+fy8Nr2iloWMtzf9/EcwfVaY6xM/beETQ+1qaQiYcZxt7Y9l516tSIi7XaaMbSwEQ1OgE2pAsqOus0URygIHhQnZTedSpVCqhSMplt7MZJ9OJmUmElo/CaUpgT7K7TgQ3wijoOPxauNW3ljHwHeU4Tm+sD/Nk7joY2N+0tOxlO9Px11ckRdjO3s04WTcEtrHxGZ518ves00ug8T+1AO+QrGXjMRUzUD5Cn967TbK2CDMMdexIxUZ3wd54nJZkLjW2kmKO9cYGI4FPG4tctzAx39yCqCnyoTMHex3naWlGHw9iLG9i5Gmb3OE+nqwfISTJR5Q6TnpHJS20FjBb1lITqIARTutqeKGSySND2lDw+vSBAS9MW9qyBO1yCPTipDGfyL39+v7tOQFgdxQtbdObpW7io8zxZNYXW3GkkJyWRX/c13pBBSyD6WXtXTMIietQpAJFAZ9sT7l5tryF7GmZPPQX+cghAaym04sLQRjNFa2CCUo87FP38dX2eRoQqe7U9d4/PU2GymUp3OPF5Ata0j2KFO5l5+hYy6L72faGOI6JauZSt+Luin8bEn6dLRqfy0/JiTIE21L17GQuM5fCfp9Ginq0rNzMOGNejThMTnSeRx5n6vl6fp0ZzFt+z7yfo9+ILCxQFVoiRNBFte6aD6uTXLczo0fZSrCramNnsrHOT3bgZOldEOgeNpmEzuTQvQt3OjVR7w+CN1mmPNp4C0cLkSBV0fuc2+l2Eu657bfHXvX2WEYwMVsbVaY+Sy+4E14j9thE4MvPJrN+IGvLTsQN2ABnqqLg6JXcGKMs6rxEXG911guh52nyghZTKnZzbuS3ZZmF/9pnsOVCHed8mzMDFhztP9aMpMWq5+OBruTf+82RWFXaSwy4Ofd1L14KEOq8da3rWqVmnK5fN15bxpCQ5GN+6KRoWBbrr1Nc1outablGjvc+thqX7utezToaLtWI0JUZdwu+ng9veHjWX3eTRvHcLr75dSp4zGhL19Z07c+ZMsrOzY9O0usydOxe73c6HH34Yd57mz5+P3+9POC3qYEfdM3YiJ/iG6BDq7bffzj/+8Q8URWHUqFF861vf4rnnnsPn8/Hyyy/HDZt++OGHnHvuubGfw+Ew1157LZWVlSxbtiwWjL3yyiv88Ic/JBgMxv1/F110EaNGjeLpp5/uVcbj1TOmadEhuXZ/CJdFjQ0H+CKwsznIhhovOUkmgrrAHzZIspmZV+wi1RofpZtMJoQQRCIR2gI6NZ4ItR1hhqXYaPKGyUlSOeAJoykKKTYNi9mEhsBpVnCaVXQhMES0dyIc0YkYBroR7eK2WUwkWTQ0YSA670ismopJi94Nd9VJCMGu5iC7WiO0BHRM6MwpdBLWBaPSLJhMJrwhnYdW1PKbr5tivRbfGpnCOYVJtPiC/MuMbOo7wmQ6TKQ6LNHEzsLAokWPi0VTo8fdMPCH9NgK7boATTOhYsTORzBisLc1TKrDDIZOaYMfp0Xj4lf2YaDwxPwCbpzooj1gxLrBNVXFpGnoegRNUWJDu113R9P+uCM2TFmcamZPm86PT8/gobnZseEKgICu8M7udqraAozPtFKcaiXfZSYkVJp8YTqCEXKdJgqSo3WMoFHeGqDeE2JkupVmXwSrSSEv2UZ7IMK2Bh8f7nGT7TBx3ggXZxe60BDsbQnE8vHZLRomrft8BCMG7qBBSIDTYiIYClPjjdCVB1woGhOybGhCjxu+9oSh0afT5g+R5YgOPZs1BVWNDiF13QxtqvNT6Q6xpTHMxjofH+3pHp4Zl2HlF3PyQRhcNjp6EdtQ5+OMPAdWi5kXNjdzx3vRm5hfXpjHnadn8tcdbu74R2Wvu979P51Itj2+ve9tC/P9t6vYXt8919VpUWkPwcKZWQxLUvj26GRGplljnzPovus1hEBVFMIiOoRv16LDavtaQ7QHddrDClYNsmwKKVaNfJcZm0nBbDZjGAb+UIT3ytzsag6iCxib5eA745JRiQ7F7GsNkm43k+ows6fJT0g3cAd1bCYVq1ljUrYDYURiQ7zBiEFAhw31QcKRMLOGRVdv31zvx2w2sbslhEM1SLFpjEix4LKoJFnNuKzR3sT2gM4/ytpZus+DjsYtU9P5zt/2xnqovA9MxhOGv+1o4/N97QxLNuMJ6jy/pQ1d0bhpUjLbGvx4Qgb7uno/Duq1uGSUi7vPzMRuMXNmrpWQbmBWFfa0BBGKSltQ4A2G8IUN7v+kFotJ4Z3rRlKSYe913UNR8UcEvmCYkCEIhA2cFo1KbzRI9gTCJJlVxmZaMandn7+le9t4ubSVM/MdnJbrYGaBC1WJntdAxGBTnR93SCc9yUqRy0QgolPnjeAJ6YR1gcNqAcPApEaH/20mlYIUC6l2c+wa3xE20BQFi0mjyhOh1h2gzhvGGza4cISLYckWNE0jHA6zZK+H365pYkVVBzoqc4qcfFXhBmDLHWMYmWbtvMYLKtsCNPsiTMq2ETFgZ0uY696ooNbT/T104+RUnvh2EZf+dR9fVUaHRx86P5dRaVZGpNtp90eocQdRFYXiNAvugM7LOzz8amUdLovKvJFO7j0rG1/YYGNDCH8oglmFq8elYDNFv4MCOgRCYRxmFZOqEOhsewYqqZbo58IXNthc72d6npPfr2si1Qwj0yzkJpmxmhTGZkXXsAuFI5S1BClrCdLki3Dp2DScZpWmjmgbsptUwobApytsbfCTaVOYXZAUu95EUGnzRzAMgwPuEFlJJlTAUE0Ewzp2E7HgChQUVSMciaB33vhbNAWzpjL1z3vY0+zj1asLuawkBRianrGjCsYWLFjA22+/zRdffBGXl/FIhylnzJjBunXrUNXuLyDDMDjzzDP5+uuv+1WWvoKxLoFAgObmZvLz8/n5z3/Oe++9x7Zt2/B4PNTXd6/JMmzYsFgqo3A4zHe/+1327dvHZ599RkZGdxqWoxmmlAZWtSfMzqYAI1ItjEob3OSuXXPGHr8on7vPzOzX757xzG4210dvAz3/OhFFUeKCsFNZqz/Cy1vbCBuC26enH3YOx46mACNSLLE5XNWeMCN+vyNuHwUI/fuUPt/DHYzOsyxOtcinWw/yxNom/mVpDclWleZ7e+f4ffzrRu7/tBaAv1xRwA2T0jjgDlH8RLRX44ZJqdx9ZiYZdtMhc4r2pSvgPZV0hAxSf7UVgO0/GktJ+qGvbSHdYPGKBv73q+jcvd/Oy+cnZ/TvmiTBt/+6j6Xl3lg7Hir9GqY8WRJ892Sz2Rg2bBjhcJg33niD7373uwC4XK6EXYddgVhZWRmff/55XCAGcPrpp2M2m1m6dGnsvWpra9m6dSuPPvrogJVb6tswl3nI06wUpfT//+/51aKp8RPiT3VpdlO/gtvxmba4n3vOtS5wmajyRHjuioJDvkeyVSPZeuig71T1o9MzSLdrnFOQOEdiz8ntps6gqec2VVE4I+/Qq/gfyqkWiAHYzd11TjmCdmnRVH4+OzsWjFllLtaj4uq88XMHh3Y1hH4FYydTgu+vv/6a6upqpk2bRnV1NYsWLcIwDO6///4+3zMSifCd73yHDRs28N5776HreqyO6enpWCwWUlJSuPXWW7n33nvJyMggPT2d++67j8mTJ/Otb32rP4dTOgl99P1i1tb6D/kkXl9kOqTjp2f/4gOzc7huQiqpNhloHS2TqnD9IXoJenbodv37SJ4+lPqmKgrvf6+YjpBBdtKRfTXbTCpXjElmV1OQfxqbcpxL+M00JcdGa0AnJ2mIc4KKfiC62kGvP88991xsH8MwxIMPPihyc3OF1WoVc+bMEaWlpUIIIYLBoMjIyBCPPvpowvf/9a9/LTIzM0UwGDyqshQVFcVeX7ZsmRg/frywWq0iIyND3HTTTaK6uvqQ71leXt5nHT///PPYfn6/X9x9990iPT1d2O12cdlll4nKysrDllk6tc18drcw/e9mYfrfzUI3jKEuzjdKgzccO7Z/XN801MX5xvvzhqbY8X57Z5sQQohWfyS27eZ3Koa4hKcWQ15PTnrHtLSFJElH7uy/lLG2xg9A6N8mH9GkTunItPgj5Dy+HYAnLxnGHadlHOY3pGPxl80t3P5+NOvIO98dwbdHJ+MN6aT9Kppt5XsTU3nxysKhLKIknVTk7GFJGiTxw5QyEBtIcgh4cMXNGVN7zxmT9/iS1D8nZDAmE3xL30QyRjh+5HSlwWWOm8Df+XdcpoDBLpEkndyOetHX4+mDDz4gHE6c1+zgBWUl6WQhA4bjRx7bwdVzAn/XU8E9Hw7WDSRJ6ocTMhgrKioa6iJI0oCT8cLxcyouhTCUevaCdeUD7Dn0LhPeS1L/nJDDlJL0TSQDhuNH9owNrp5r5CVa0kJ2jElS/8hgTJIGiYzFjh9NHtxB1TMAMycIxnQ5aUyS+kUGY5I0SGTvzfEjj+3gipvAn+BbRMZiktQ/MhiTpEEihymPH1VOHh9U8SvwJximlMGYJPWLDMYkaZDI3pvjp+fk8YiMBI477XDDlHICvyT1iwzGJGmQyFhscIRlMHbcmRMs+tqTPAWS1D8yGJOkQSJHKQeH7Bk7/nq2ZYe599eIXNpCkvpHBmOSJH2jyGDs+PMGuyfmpdu1Xq/LeXuS1D8yGJOkQaLIgcpBEdZlMHa8pfUIwBIPU8pzIEn9cUKuwC9JknS0ClIsQ12Eb7ypOXZ+d3E+xamJj3WiAE2SpL7JYEySBomcM3Z8Lfl+McsrOvjB5LShLsop4cenZ/b5mgzGJKl/ZDAmSYNEfj0dXxcWu7iw2DXUxZCIT5ckSdLhyTljkiRJ0oBKtPaYJEl9k8GYJEmSNKASpUiSJKlv8iMjSZIkDYjvT0wF4L5Z2UNbEEk6ycg5Y5I0SOQEfumb7vkrCvjdxcNItfVee0ySpL7JnjFJkiRpQCiKIgMxSToKMhiTpEEiO8YkSZKkRGQwJkmDRA5TSpIkSYnIYEySBolMmShJkiQlIoMxSRokMhiTJEmSEpHBmCQNEpk8WZIkSUpEBmOSNEhkz5gkSZKUiAzGJGmQyGBMkiRJSkQGY5I0SOQwpSRJkpSIDMYkaZDInjFJkiQpERmMSdIgkcGYJEmSlIgMxiRpkMhhSkmSJCkRGYxJ0iCRPWOSJElSIjIYk6RBIoMxSZIkKREZjEnSILGZZHJKSZIkqTcZjEnSIHnykmGUpFv4v8uGD3VRJEmSpBOIIoScVSxJkiRJkjRUZM+YJEmSJEnSEDINdQG+6YQQeDyeoS6GJEmSJElDxOVyoSh9zxuWwdhx5vF4SElJGepiSJIkSZI0RNrb20lOTu7zdTln7DiTPWOSJEmSdGo7XM+YDMYkSZIkSZKGkJzAL0mSJEmSNIRkMCZJkiRJkjSEZDAmSZIkSZI0hGQwJkmSJEmSNIRkMHYS+8Mf/kBxcTE2m43TTz+dL7/8cqiLdNJatGgRiqLE/cnNzY29LoRg0aJF5OfnY7fbmTt3Ltu2bYt7j2AwyIIFC8jMzCQpKYkrrriCAwcODHZVTlhffPEFl19+Ofn5+SiKwttvvx33+kAd49bWVm666SZSUlJISUnhpptuoq2t7TjX7sR0uGN+yy239Gr3Z511Vtw+8pj3z0MPPcSZZ56Jy+UiOzubq666il27dsXtI9v6wDqSY36it3UZjJ2kXnvtNRYuXMgvfvELNm7cyLnnnsv8+fOprKwc6qKdtCZOnEhtbW3sT2lpaey1Rx99lMcee4wnnniCtWvXkpuby0UXXRS3bMnChQt56623ePXVV1mxYgVer5fLLrsMXdeHojonnI6ODqZOncoTTzyR8PWBOsbXX389mzZtYsmSJSxZsoRNmzZx0003Hff6nYgOd8wBLrnkkrh2/8EHH8S9Lo95/yxfvpy77rqL1atXs3TpUiKRCPPmzaOjoyO2j2zrA+tIjjmc4G1dSCelGTNmiB/96Edx28aNGyd+/vOfD1GJTm4PPvigmDp1asLXDMMQubm54uGHH45tCwQCIiUlRTz99NNCCCHa2tqE2WwWr776amyf6upqoaqqWLJkyXEt+8kIEG+99Vbs54E6xtu3bxeAWL16dWyfVatWCUDs3LnzONfqxHbwMRdCiJtvvllceeWVff6OPObHrqGhQQBi+fLlQgjZ1gfDwcdciBO/rcuesZNQKBRi/fr1zJs3L277vHnzWLly5RCV6uRXVlZGfn4+xcXFfO9732Pfvn0AlJeXU1dXF3e8rVYr5513Xux4r1+/nnA4HLdPfn4+kyZNkufkCAzUMV61ahUpKSnMnDkzts9ZZ51FSkqKPA99WLZsGdnZ2YwZM4bbb7+dhoaG2GvymB+79vZ2ANLT0wHZ1gfDwce8y4nc1mUwdhJqampC13VycnLitufk5FBXVzdEpTq5zZw5kxdeeIGPPvqIP//5z9TV1XH22WfT3NwcO6aHOt51dXVYLBbS0tL63Efq20Ad47q6OrKzs3u9f3Z2tjwPCcyfP5+XX36Zzz77jF//+tesXbuWCy64gGAwCMhjfqyEENxzzz2cc845TJo0CZBt/XhLdMzhxG/rMjflSezg1ApCiEOmW5D6Nn/+/Ni/J0+ezKxZsxg1ahTPP/98bJLn0RxveU76ZyCOcaL95XlI7Lrrrov9e9KkSZxxxhkUFRXx/vvvc/XVV/f5e/KYH5m7776bLVu2sGLFil6vybZ+fPR1zE/0ti57xk5CmZmZaJrWKxJvaGjodbclHZ2kpCQmT55MWVlZ7KnKQx3v3NxcQqEQra2tfe4j9W2gjnFubi719fW93r+xsVGehyOQl5dHUVERZWVlgDzmx2LBggW8++67fP755wwfPjy2Xbb146evY57IidbWZTB2ErJYLJx++uksXbo0bvvSpUs5++yzh6hU3yzBYJAdO3aQl5dHcXExubm5ccc7FAqxfPny2PE+/fTTMZvNcfvU1taydetWeU6OwEAd41mzZtHe3s6aNWti+3z99de0t7fL83AEmpubqaqqIi8vD5DH/GgIIbj77rt58803+eyzzyguLo57Xbb1gXe4Y57ICdfWj2n6vzRkXn31VWE2m8Uzzzwjtm/fLhYuXCiSkpLE/v37h7poJ6V7771XLFu2TOzbt0+sXr1aXHbZZcLlcsWO58MPPyxSUlLEm2++KUpLS8X3v/99kZeXJ9xud+w9fvSjH4nhw4eLTz75RGzYsEFccMEFYurUqSISiQxVtU4oHo9HbNy4UWzcuFEA4rHHHhMbN24UFRUVQoiBO8aXXHKJmDJlili1apVYtWqVmDx5srjssssGvb4ngkMdc4/HI+69916xcuVKUV5eLj7//HMxa9YsMWzYMHnMj8GPf/xjkZKSIpYtWyZqa2tjf3w+X2wf2dYH1uGO+cnQ1mUwdhJ78sknRVFRkbBYLOK0006Le4xX6p/rrrtO5OXlCbPZLPLz88XVV18ttm3bFnvdMAzx4IMPitzcXGG1WsWcOXNEaWlp3Hv4/X5x9913i/T0dGG328Vll10mKisrB7sqJ6zPP/9cAL3+3HzzzUKIgTvGzc3N4oYbbhAul0u4XC5xww03iNbW1kGq5YnlUMfc5/OJefPmiaysLGE2m0VhYaG4+eabex1Pecz7J9HxBsRzzz0X20e29YF1uGN+MrR1pbMikiRJkiRJ0hCQc8YkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShtD/D17NLmLrkmFUAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "Scene(background_color='#4c4c4c', camera={'position': [71.80763645292058, -4.5938635470794225, 216.89163645292…"
+       "<Figure size 600x120 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -330,26 +442,84 @@
     }
    ],
    "source": [
-    "mesh.plot()"
+    "egm_figure, egm_axes = openep.draw.plot_electrograms(\n",
+    "    times=case.electric.times,\n",
+    "    electrograms=case.electric.bipolar_egm.egm[:3],  # plot the first 3 electrograms\n",
+    "    names=case.electric.bipolar_egm.names[:3],  # pass the first 3 electrode names\n",
+    ")  # creates a matplotlib.pyplot.Figure and matplotlib.pyplot.Axes\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/Caskroom/miniconda/base/envs/openep-tutorials/lib/python3.9/site-packages/traittypes/traittypes.py:97: UserWarning: Given trait value dtype \"float64\" does not match required type \"float64\". A coerced copy has been created.\n",
-      "  warnings.warn(\n"
-     ]
-    },
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAACDCAYAAADBExzWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAA9hAAAPYQGoP6dpAABUJ0lEQVR4nO3deXxU9b34/9c5Z/bMZN8hCQHCvrqAiCJqRanr1Vpbl2qvW1ul5apXe2+/98q993dxaatdtNr2qnWt2rrWBcUFFAHZIewBQhKy7zOT2c/5/P6YZJIhEyAQEpDP8/HgATlzMnw+53zmzPt8Pp/zeStCCIEkSZIkSZI0JNShLoAkSZIkSdKpTAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSZIkSUNIBmOSJEmSJElDSAZjkiRJkiRJQ0gGY5IkSdJx8bftbWyu9w91MSTphKfIROGSJEnSQFtR2cH5L+0FIPzvU4a4NJJ0YpM9Y5I0iF4sbaXod9tZX+sb6qJI0nG1uUH2iEnSkZLBmCQNon/+RxU13gg/fLdqqIvyjSSE4NlNLXxS7hnqokg9GHIARpIOyTTUBZCkU5EvYgx1Eb5RXtvWxoulrdw0OY07PziARVNoumcidrO83xwqSo9/e4IGKTZtyMoiSSc6GYxJ0hAwZEfBgLrxnUoAPtoX7REL6YIVVR1cNNI1lMU6pQX17kbeFtRlMHacCSHwhAySrfI4n4zkbaMkDQE5anP8bW8KDHURTmltAT3hv6Xj42cf15Dx622sk/NRT0oyGJOkIRCRXWPHXVlLaKiLcEp7c2d77N/tMhg77p5a3wzA/3xZP8QlkY6GDMYkaQjIOWMDxx9OfCzLWoKDXBKpp53N3ce/LSiDscGytSHA3UuqafVHhrooUj/IYEw6LiKGkE9QHUJHSAZjA6XBl/hLZ0Odn1e3tQ5yaaRE5DDl8dVzudBKd5g/bmjmzg8ODGGJpP6SwZg04Fr8EcY9tZNZz+1Bl8NxMT0DMF0elgFT1R5OuL0toHPTO1XypuAE0BaQNx/HU0eC3uG3drmHoCTS0ZLBmDTglu7zUtEeZkOdn9JGOYm6y11L5J3q8VDh7j03rOeyCl7ZCznoDk7s0i6HKY+rZn/i4ysT7Jw8ZDAmDbhdzd0BWFW7nETd5eWtbUNdhJPW/rYQIT1xUFXe2ruNjcu0xv7dKofIBt3BHeJymPL48gQTfzb299FrLJ14+hWMPfTQQ5x55pm4XC6ys7O56qqr2LVrV9w+QggWLVpEfn4+druduXPnsm3btoTvt3jxYjRN4+GHH+5XoWtra7n++usZO3YsqqqycOHCXvvMnTsXRVF6/bn00ksP+d5vvvkmF198MZmZmSiKwqZNm3rtU1dXx0033URubi5JSUmcdtpp/P3vf+9XHb7JNvZIDPzVgcF9zPr17W2c98IeqhL0lgyEZl+Et3a29/tpSHmHevS+quqg5A87ueSV8oSvb0yQiHpMencwJntljo47qNPcx3y8w9EPau8NHcd/MnkwYuANnZrn2tNHvd/d3Z5wu3Ti6Vcwtnz5cu666y5Wr17N0qVLiUQizJs3j46Ojtg+jz76KI899hhPPPEEa9euJTc3l4suugiPp3d6kueee47777+fZ599tl+FDgaDZGVl8Ytf/IKpU6cm3OfNN9+ktrY29mfr1q1omsa11157yPfu6Ohg9uzZhwwQb7rpJnbt2sW7775LaWkpV199Nddddx0bN27sVz0Gwom4RMKOpu6nqL6qiraNWm+Yz3qkqPnF57WYF2/h/bLueQ3VnjA//EcVzkdKMS/ewtl/KSPQz6cOb3i7kpUHfPzrJ7XHWIvEvvtmBd99s4KHv2ro1+81+XpfLOVcpiPz/JYWAL6s6uj1WkfI4MvK+O02k0JxqiX280AOUwYjBtsaA7ScAk+qzf7LHgp+t6PPgGzVgQ5WHehI2I4P/tjubD626QpCCP6yuYUHl9clvOaFdcHw3+0g7VfbsD20hW2d0yMaOyKsru7dbo6lHG0Bnb9ua2XZfu9h9//Nmkbm/3Ufv17dQLDzoBzqxuzVba1c8OJeShPk9XxrZzvX/n0/td7evV19tfG3dh59MLa2xseHe+LnnX1a7uHLSi/727pvdoUQvLWzHfvDW1iwpDq2PRgxaPZFCOkG7qDeZ73bAzpPr2/mopf3cu3f9x/xNV83BIuW1/FC5/XhZKeIY7hlb2xsJDs7m+XLlzNnzhyEEOTn57Nw4UIeeOABIBo45eTk8Mgjj3DnnXfGfnf58uXccMMNlJeXM2LECP76178yZ86cfpdh7ty5TJs2jd/85jeH3O83v/kN//mf/0ltbS1JSUmHfd/9+/dTXFzMxo0bmTZtWtxrTqeTp556iptuuim2LSMjg0cffZRbb72133U4Ws2+CNP+vJvvTkhl/mgXhoiuPO6yqNR6w7QFDKo9YarcIXxhg7KW6N9Tc2xkJ5nJtGu4rCrPbmohJ8lMfUeYM/IdnJHnwKRCjSdCilUl12kmxarismj4Igab6/28V+ahxR/BEDDMZea0PDuZdhPtQZ1frW6MK+d9Z2XFts0tSuLv14wg87Fob+kwl5n9C8bzj93tXP33il51nJJt4+EL8rCbVOo7wqyp8bG+1k9a52reG+r8JJlVpuTYyHWa+e2aptjv+h6YTI03jE1TyEoysaHOz+oDPv6+o43ythBOi8p1E1I5a3gSmQ6N3c1BLJqKzaTgNKtUuMN8tt+LN6iTbNOwm1T+uKE59v6/v3gYigJ2k4LDrNLQEaEjbKAqoBvgDulUtIUJRAwq3dE5dD39bEYmz21uoSTdynmFSZw/wklxqoUvKjv4VrGLWm+Y0oYADrOKP2xgUhUOuEPYTCqaGh2aeHlrK6k2jUBEYDerdIR0zKpCrtPMuYVJnJZrp8mvs6Kqg2FOE2l2E7oQfFXZQb0vwvlFTiZk2jBrCq2BCC1+HZOqcKQihiCsC7KSTGQ5TFg0hRpPmNaAji9sEIgI/BGDNTU+hIDxmTam5tgYlWbFG9LZ2xqizhsh1aaRZFaxmhQ0RUFTwaQqBCOCez+pif1//3NeLhcWO1my18Pu5iCf7vfQeFCgm2bT+MvlBVz5t/0APHf5cG6cnB57vaEjwivbWnmptJVaT4TpuXbMGtx5WgY1nghra3w4zCpmTSHNphHWBXvbQizd56G+s4fHYVa4eUo6cwqTcFk09rYGURWFPa1Brh2fyrQcG56QQWlDgGpPGEMIdBE9XhFDoBvRz2qzP0JQF1g0BVUBq6aSnWRiYqaNVJtGUDf4orKD8rYQFk2hoi1EyBC0B3SGJ5sJRAS6EBSlWBjuMqN1njt3MHr8S9KtuCwaI1It5DpN7GoOsrbGx7paH2XNIcyawph0KxOzrNjNKmFdENIFvojB419HP0v3npXFHdPTaQno7GwKoijw9PpmVld393pfPNLFvrYg5xQk8dt5w3hlWys/+qD7i9lmUmj4l+70VPvbQpQ2+KnxRmLXmv2dUxrynWYafBF8YYOx6VZCuuDNne3s6lyqZGy6lV+cm82141NRFZj5bBmb6uODvbOGOfjsxlE4HikFop/Rl68qZNbwJE7/v93UeCNMy7ExuyCJB87Oxhsy+NXqRr6s9BKMCPJcZhbNyeHB5fWsqYnWc0Kmle1N8culXDraxcY6P4UpFi4Y4aQoxcLcoiTcIYPfrmnipdLeT/PaTQo/nJrO7IIkluz1oCjR4/ePMjevbmuL7bfqh6NZUdWBpiicU5DEjGfLALBqCovPz6PBF2Zsho3zi5KY+ufduBMMVSrA2ltLmJpjp84bZn97CENAZXuo8xqo0dgRIaAbOEwqVZ4wFW0hFAWWVUSD2MnZNuaNdLGiqoOve5zza8en8OzlBdz3SW3cdXHnj8cS0gXnvbA3borA+Awr105I5fpJqYxKi/Zc72gKcMYzZYQOeqKpINlMcaqFjrDBeYVJnJnvwKQq/KPMTW6SiXS7xiflXj4pjwbEt01L58E5OezvrFdYF+xqDhLSBQIYmWoh2aqhKLC7Ocj/bWwhzaZxxdhkfGGDZIvGg3NyYp+foXBMwdiePXsoKSmhtLSUSZMmsW/fPkaNGsWGDRuYPn16bL8rr7yS1NRUnn/++di2H/zgB+Tk5PDLX/6S++67j8bGxrjXj9SRBmOTJ09m1qxZ/OlPfzqi9z1UMHbJJZdgMpl44YUXSE1N5fXXX+e2225j8+bNjBo1qtd7GYaBYXR/UBRFQdM0dD3+bkFVVVRVJRKJvxPta/vTG1v5l6W1aCL+y0jv7PDUMI5su6KBEAm3K8JARRx2u0DBUFRUYaD02G6gIBQ1roz/Pjub/++rRoSiYhI6628r4fLX9lPtCaOjUpRq4UBb/MX1RK/TobbrqKAoJ915OlnqZNFUTstPYlWVFwVBvtPEG9eOYOZzexGKSqpZ8If5w/i6xsfr29qp8+knfJ2+Secp32mixhthfkkyNpOJPS1+SnsMLR+vOhWmmKlsD8dtH5VmYW/nHMNv+nm6oiSZdztHHgazTv8+O5vFXzUcsk52k0IocoR1HaTztPSGkcwaHu2o6es7V9M0FEVJuB1A1/WE2xXl8EHeUeemFEJwzz33cM455zBp0iQgOpcKICcnJ27fnJwcKiq6ez3cbjdvvPEGK1euBODGG29k9uzZ/P73vyc5Ofloi9SnNWvWsHXrVp555pkBeb/XXnuN6667joyMDEwmEw6Hg7feeithIAZQVlbG7t27Yz8XFhYydepUtm7dSmVlZWz7mDFjGDt2LOvWraOxsbt3aerUqRQWFrJixYq44d7vzJhB5pUFLPvkY1p9QQIRgQLsTZmMbrIyo2Mj2UkmVEXBooJjwrnsa/QwvHkzjb4IAjCbTFRkz8DT2sj0yF72t4XITTLjwUpZ6hT8TTXM1A7gDup4QgatajIF409jjKjF0laF06zijwhqtAz+Up/FyGAlBaKZcRlWar1h1oWyKVPyOM0oJ4to2dd/CcOVAqqUTM42drP4L1uZFDKYBDx800WMH5HPhx9+iNsfYuUBH/vbQ6y1jKcwM5lZvo24rCpdc7mHnXYebq+f+m2rsWgKmXYTpc1h/hqaSCYeZhh7Y8fLp9hoyp7OOFMLZ6gHqPGEafLplAUdlFpLuDi5nXTfAUK6IBARhJzZjJs0hbS2vQSbawkbgk31fsqUXMqUPL6TUoMt2EYwYiAAb/pozGl5DG/ejCniR1HAZdFoSBvH07sEFxrbMNH9Yf1CHcel4zKZ6tlIrTdMky9Ce9DgI3UKdkLMFTtJtmhEDIFmMrHMMhWTv5UrHJVEDEGVO4wXGzPPmcNYrYWm8h20BXQiBuj2VPY6x1K2ezeT1HqKUy2EDYHblkWdcyQjAvvJDDVR6w3TETZocQxDZI6g2LMTU6AtVkZv2mgCzhzSajeiRbrvitszJxC2p5JWtRoMnaBu0B4wKE+dTE6qk5KWdZhUhYghUBUYd9YFWEWIPRtW0uzX8YYMFFWjYdhM6hsamKOWYxjRu1jdZKchZzomTy1GbVnssf1GXKzVRjNRbWC2o4k8pxmnWeWM8cWsMVJwV+6kQDSTHFDZtGIPo4WDMiWPksBeXnprEwDTgVKlgHpTFvPVvYx0RD8Hu1uCrFFH0aIk8z3rTjKsxMofGH4aDoed1KqvyU0ykWbXqHaH+dI6jX2NHsZ7t5Jmj15KazoM3hGTY20vyazitKhgcVCfPY1kfwPp7ftQlc4nPpPSsBVPxV9bjq09ugxHR9hgZySN5cFhTOEAM51uUm0a/rBBcn4xeSNKCO7fjKe1GU2Fak+E1pSRGMm5ZNZvQov40I3ovK0q1zh2BBxMaV9PuPMLJNNhInXcDPJTnVj2rcQTMmgL6BiAt+gsrEaIA6WrY8OBiqqx3DKNPNycrZRjUsFhUglodsyjzqSl7gBjwxU0+XXK20Kx8zRa1FMi6jg/zcnnbi8VuzMoVQuZbFRysWhGU6KBNBmFOPNHktKwjYC7BbtZxWVR0fLGUKmkkV67ESXsJ8thIifJxJeimGfK6PV5unDuXK6bmsODz7xBrTcCrTAeaBo2k+217cwxdkIzjAZyXVamnfst/nvJztg1Is9poigrlc+V8ewp389kURV77551Ot/ZzOyCJDwhg22hFFZGhjM2VIG3qbsHt+sacWNGLfNzI4QNwbpaP43OYiyZ+VRsXIldBGJtbI06iiaSE14j/Fi42NhCklnltFw7+9tDvKlPYkSSQVbDlti+ETQ+1qaQiYdZYi9Xm1LRaafNsPKFNp7hooWZWjUCsGgKblMy+51jmWZqoCBcQ9gAb0gnmJRD9qgJJDXvQXXXUd8RYV9biDIll3OnT2RiYDf7q+vZ3x5CF7DXUsRN507g408/x0mA9V/CxcAadRSv3ziNbSs/JdUC+1pDbGsK8EFkDP5ItE4AmXYTs4Y7uPmay1i9v5U3l3xKeVuIiVk2zCYTpamn425uJKlhO4LoaAoWB8vUcZg99ZSEKgh3ttWu83Rpehs5gWocJhVVVWizZrGBAor85YxUWgjpAqtJRaQX8rtyJ6cZ5Wz5qpy2ZPMhv3NnzpxJdnZ2bJpWl7lz52K32/nwww/paf78+fj9flyuw+fIPeqesbvuuov333+fFStWMHz4cABWrlzJ7NmzqampIS8vL7bv7bffTlVVFUuWLAHg6aef5sknn6S0tDS2z+TJk1mwYAF33HFHv8pxJD1jd955JytXroz7/15++eW4YdMPP/yQc889N/bzoXrGFixYwJo1a1i8eDGZmZm8/fbbPP7443z55ZdMnjy51/9/vHrGDo7ShRCx94a+o/SDt5tMJoQQCbcfXPa+tieqk24IHvyygS+qfPxpfh5/2tDMnzZEx/cT3WUtODODRy8q6HXnoRsCi9nUrzpVdxg0doQpcmlsbQigqQpn5juwW829yr6tMUBxuh2nWTlsnZyPlGKg8Ot5w/nx9NS4//NQ5+l/vqznze0tlLeFYgmUhaKy7+7x5Di6p24GIwYOq5mOkIFZMeK6zY/mPB3cxo5X2+u5HQ59np5Y28jPP6vj1asLuWp8xmHr5Hyk+3P79W3jGJFsIsncfVwUReHJ9a3869IDKAgmZtl48pJhzHlxH0JRybEDIvpU5ag0KzdPzWDhWdkII/p/hnXBVa/vR9VU3v/+SIwjbGOH2t7si2BSDJyW7qTN/f08KapKIBTBonXX9VjOU0V7iGEuMyb18NeIDTVeZv9lDwDeByb32fZu/aCGv5a28NuL8rj9tAwWr6iP9or06J3wPjCZj/e5eaG0naABp+dYuXVqOllJpqOu07paP3d/UEFJmoV/npbBzGEOHNboF+m9H1fxh3XRYbOzhjn45KYS/m9TCwuXRIOrf56Wxu8uHo7JZGJPS4APd7cxLdfOWcMcKIqCyWSi0RvixS3NTM2xc16RE0MILObe146en6eIbrC1McDjqxuYNzqVG6ek92pLXXXa3uDFHTA4I99BY0eEuz6q5Z+nZ/Cd16OB4fYfjaUg2Rz9DBuCqvYAw13mWA9L13l6fFUd//55Xez9u3qR8pNU9t49nhWVXpZVdDCzwMWYdAtFyfH9L0d6Le+5vet8lLcG2dUS5JxCF6l2M7b/7Z4znWHXeOd7ozgjP6nX+dvcGOQ/Pq/js3I335+Ywp8uLTjk91ZX26v3BHFZVKwmNWHZ9c4pAEk2S7++c+e/up/l5e08c/lwrpuQFneeBrNn7KiCsQULFvD222/zxRdfUFxcHNt+pMOUM2bMYN26dahq95eQYRiceeaZfP311/0qy+GCMZ/PR15eHv/93//Nz372s9h2j8dDfX13Dq9hw4Zht9tjP/cVjO3du5fRo0ezdetWJk6cGNv+rW99i9GjR/P000/3q/ynkrAuYnM4AL4/MZVPyrvn/Gy9cwxjM2xDVbwjYl4cvZt76cpCrpuY2u/fH/abbTR01vfVfyrkmvH9f4+TXdcxtJsU3Pf3vnnpa3+A8L9PSbjPk+uaWPhxtGfizHw7j12Uz7nPR7/YHr4gl3vPyj7WYp9yvqz0kp1kOuRnsuvcZNo1av9lIutqfcx6bk/cPn2ds+Ol2hPmf1fU809jU7hoZLRH4u1d7Vz7RnR0puXeibis2qHeYsgs3efBFza4cmzKEe2vG4IXS1u5/f34NQxL0i1s/9G441HEPp37/B5WV/tQleh83aGcf9Uf3/n7ft7Z7eaJS4Zx52kZQ1aOfg1TCiFYsGABb731FsuWLYsLxACKi4vJzc1l6dKlsWAsFAqxfPlyHnnkEQBKS0tZt24dy5YtIz29e1JtW1sbc+bMYevWrbFhz4Hw+uuvEwwGufHGG+O2u1yuI+o6PJjPFx2q6RlIQjQCPviOV4pn1hRK0i2xBM4RQ/DU/OH895f13Dcr64QPxABeuaqQFVUdfGf8kV0sD9bzzifRqtmnEn9k4J4m7fnQgd2kxj3NJ1NPHZ1zC52HfD3cY9J1V67VyVk2Uqwq7X2sezUYhrnM/GH+8Lht5xc5yXaYmDHMfsIGYkAseDxSmqpwy9T0XsGYyzL4dXz16iI+3ufhxklpJ00gBuC0RB/aGuqVCfoVjN1111288sorvPPOO7hcrtgcsZSUFOx2O4qisHDhQhYvXkxJSQklJSUsXrwYh8PB9ddfD8AzzzzDjBkzEj45OWvWLJ555hkef/zxw5ala/0vr9dLY2MjmzZtwmKxMGHChLj9nnnmGa666ioyMo4s4m1paaGyspKamuhddtc6arm5ueTm5jJu3DhGjx7NnXfeya9+9SsyMjJ4++23Wbp0Ke+9994R/R+nsv8+L5fvvxWdJ3ffrCxOy3Uc8V3gieDaCalcOyH1qH+/Zz90X6tmS/E+vn4kt7xbyZMHfcH21GMkD7tJxehxYW0bwsDgm6zn+m2+cPQJzxSbxqc3juKMZ8qGsGS9pdg0yheMw3wSBQn98fH1I7n01fLY3KnytsFfbHuYy8wPp6YffscTzLOXF/CXKwqHuhj9W2fsqaeeor29nblz55KXlxf789prr8X2uf/++1m4cCE/+clPOOOMM6iurubjjz/G5XIRCoV46aWXuOaaaxK+/zXXXMNLL71EKHT4hjR9+nSmT5/O+vXreeWVV5g+fTrf/va34/bZvXs3K1as6NdyE++++y7Tp0+PLQ77ve99j+nTp8eGH81mMx988AFZWVlcfvnlTJkyhRdeeIHnn3++1/8v9XbNuBRW3jKa8rvHcVquY6iLM+h63ns1HuWCmqea80c4qfjpBC4r6fvhnvieMYUNPZ7Wk1kgjg/3QYvpbu1c22tqjp0sx4nX+2TR1COau3MyOn+Ek39cNyL2s8w6ceTUE6RN9HuY8nAURWHRokUsWrSo12sWi4Wmpqbev9Tpnnvu4Z577hmwsowZM6bfK5/fcsst3HLLLYfcp6SkhDfeeKNf7ytFKUp0Iv2pqmdPeNMpGozZTAqBARyiBOKGRWxmNW7R3/0yGBtwn5Z7eq0NtbHOz+yC6NIA39QeqBNZzwc9zik4/Fqa0onlqJe2kCSp/3p+fSValf9UkO0wUeke2Jx5ph59/GZVYXSahT2d60kN9P91qqj1hvGFjdgCnV2+qurgkr/2Tk3Vc1FjsyaDscHW85jffcbQTUSXjs4JmSh84sSJOJ3OhH9efvnloS6eJPWbJ6jz8FcNcQmTK49T/swTXdeSBhBd12htjY9//aTmmPIKaj2GGlQF5o/uHtJs8eu9htSkwyv83Q7GPbWrVzqkN/tIsbOh1ocQggeX1xEc4J7PgXTAHTphU5Htbwvxy1UNtB/FMGPPnrGuDCXSyeOE7Bn74IMPCIcT380evKCsJJ0MHlnVwCMr49NElbUEMYQ4YeYsDBZbjy+Nak+Y+X/dR3vQoNYb5qWrio7qPXvOGVMV8B/0pGpFe4jJ2faDf21ACCFi6ai+ibY3BeKerNzdEp8SaEy6hd0tIXY0B/lgj4fF/czbOpie39LCbe8d4OqxKVw5NpnvTkg9ZPovIaKLKxckmwdlvtm8V/ZR3hZiS0OAF6889KRyQwjeK3MzNcdOUYoFS48n/FNkMHbSGZKrx0MPPcSZZ56Jy+UiOzubq666KvbUIkBRURGjRo3ipZdeYs6cOUyePJnbbruNYDCYcDmKxYsXo2naIZN7J1JbW8v111/P2LFjUVWVhQsXDkj5JaknQwh+v7b3XElfWFDtGdghNCEErSd4EuuecdLe1lBsGYTXtved1NgfNg45/7PnMKWmKPgPSja846CcggPpln9UUfC77WxJkNz5ZNWz56hnEmpPMJrntKeSdCvFqRYMQSyP44nqd525a9/c1c7N71bxLx/XHHL/36xpYtSTO3lqffMh9xsoXU9Bvrv78Am+//uLeq75ewWjn9zJnpYgw1zdfSs20zfzxuCbbEjO2PLly7nrrrtYvXp1LK3AvHnz6Ojo/pA/+uijPPbYYzzxxBOsXbuW3NxcLrroorjUBF2ee+457r//fp599tl+lSMYDJKVlcUvfvELpk6dOqDlHwy6IXhsdSNbGwL9flABGLB1VdxBnbuXVPPhHnef++iGYGOdnz+sa2JHU6DP/YQQfFYeTULe9bMQgiZfhD0tQTbX++OG+gDaAjr7WoOxY9AW0I/b2lJbGvzMeq6Mpft6t8O+fLzPgy8cf6ytnb1D2xr7Phb9sbHOz2vb2rj01XKyH9/OdW9U8Pu1TUcUmAkhMEQ04bc/bCRsF7oh2N8WIqQf+ri2+iPsbAqwoc5HWI+eO3/YiBsmDPd4/3UHfXlXJphsv7s5SMavt5H6q6386IMDccNmQgh2NgX4tLz7fIQNEXuazGmJXuKWlic+X/6wwcKPqxn+2+385MMDfFnp7VWfsN77eJS1BFld3cHWhgCvbG2jPWhwxWv7EULQ0BFhyV43emc9gxGDr6t9lLUEE75Xl/aAzsf7PLywpaVX+w3rAs9BQ62BiHHI9zv499fW+HiptJWtDYHDDtP1bAM13u4bhpe2tsYFZxBdSuSSUdGb5E31xx6Q6oZgQ52PP21oZsle91Fd2yDaNlZUdfDkuiY8QR3dEGxpiP+8Pbu5pdf1pEtYF9z/afRBkJ99XNNr6HB3c5CXSlspbfD361rqCxsEO28W2gI6H+5xx37u3qf7/UK6we/XNvFfX9TFrovlbSH+t0cP5PT/202tN8J5hUmMTbdSkm4hpBu9eoiPpz0tQVZUdfRqp4dzDOmx8QR1vq72sbVhYK6jQ+mYEoUPlMbGRrKzs1m+fDlz5sxBCEF+fj4LFy7kgQceAKKBU05ODo888khcGqPly5dzww03UF5ezogRI/jrX/+acA2zwznShONHUv6DHa90SMsrfVzy6v5YSqEJWTZMKqTZLZhVBasq8IUNWoM6TrOKjoohBMIwaPJH2Nc5wXlCThLpVpXCZI16bzSPGgpUuA0KXBqGblDf+QVoN6s0BcCEQb7ThN2ksrzSG5eI9ZapqYxMsbCrJcjWxiAbG0K9ksWeNTyJ0/OdpFshJ0njV6ub2N8WQigqBgouk8EvZufwq9WNtAb0Xklkx6Rb+edpaby2w8O6Wj8aBul2jVa/jgAUTWNkiplaT5DhLgvFqRY+2udBVzTSrArZDpV0mwmzqhAwDDKTrHgCEVQEhiEwAE9YYKBS4NIIhHWa/DrbGwOxVE7/NDoJp1XFHzao8UQoaw0RFAroOooSDbgy7Cb2tEUIC+KOwflFTj6p8HHnaRn85qJcIPrF//r2Nv6208P6Oj92TeAOGkzItDIxy8qedoOiZDPJFsH/zs1jXa2fP25oZnNjmGp3sM+EuRMzLeQ5zTjMKrdMS+eC4hSq2gI8ua6Rd3e5qeuIxKWnSrdrTM6yU+kOIVA4u9DFqko35W0hzKrCyDQL25vDoCh8Z0wSEzJtVHvDrKzysaMlHHeeNAV0EU0CXJBsxqaJWLsDOLswmS8rvbH9/2tODvfOyo6lcvr79lZufrcqrk65DpWFZ2ZwwBPijR1u6n16XBLgSdk2DAFbG4MsPCub362uJ8OusfPH47Cbo5+l/1nRwENf1tJTz8TG5xQk0RbU2doQQEfl26Nd2FVBjTdCjTfMAXc4YWLjH52eTrVX8PaudjQMVv9wNGd1rkivKxopFpiZZ6c5oOPQFAwFZg53sbclwHs9ekMECucUuajzBKn3hmMBUJrdxLgsB75giC31AawmhRn5DsZk2slwmDF0nYr2IGZNoTjFQkmmgw11fv68viHuC15HZWKWjVQLOMwqJlXhgCdMaWMIp0XFH+q+1qRYVe4/J49NtX7+tr2lVxv73vhkfjgllW+/Wo7DrOALi7h0SFeNSWZdrZ/ajgghoVKcrDEpy0pHSLC3LciwZAvFaTYmZZqp84Z5a6ebak84rk1OyLIRiBjMzLcTMlSSbSYcmoFZU+gIGRxwh/FGok8rp1oUXFaFdbV+9rSE0FEZk27hO2NdPLKqMa7sCMGTF+fyz9OiE96X7HXzwlY3a6s7qPXE3xgUptlZfF429d4QH+718Gm5F6PzumdXBecUODgtL9r2mgMCl9XEjvoODnii5y/TobGxPhirU26SibqOSOx8DE+2UOvuDioKU8yoqsbe1lDc5+nAzyaw4ONaXtveTooluqhx15nNcVm5eXIqX1Z4WFXtI82mcdeZmZRkOPAEw1S3B9nVHOTdMjfnFDiJoLK3JYAwDOo6IoxMs6B2poRSDkqqrSoKWU4L4UiEYERgNymk2zQK06w0+AxeLY3vPbSZTfz4jEzM6AxzmdlY72dLQ4BdLWF0A9Ks0R68Gk+YsCEYmWbHaVWJ6Dq+sMFwl5lkq4bFbMKiAkKnqj0SnRNaksw7ZV5WVXnjrntOi4rTZmG4UyPFomDRon8iKPgj0e9imwbJVpUWv84BTwSL2cTYNBN//PawaK5UTqJ0SANtz549lJSUUFpayqRJk444rRLAD37wA3JycvjlL3/JfffdR2NjY9zrR+pYgrGDy3+wXbt2JUwUvnnz5oSJwlevXp0wUfiyZcviegbNRVN4rFTHvG9ln8lle+pKQD3H2BnbFksuK9xxSbW92PhCG0+B0ZQwYW6JUUuJ6M6JVqV0JwEuEN0fyjIllzI1jzP1PbFE4RBN1lylZjJH34GT7gvQGnUUTUoy8/QtCes039hCz3u9k6VOKemZjGpaF6vTOQVJLK4uwG6389vi/extDbK+zk9IF0ddp3MsNWQnmUi2qBzQnfzVXUBBqGbQz5OhWZkb3kxPfdVpuWUqrkh7rE6qAt+ekEvupLN4ecUO/NXdw/+HOk9VjhEU+PZTIJoxKdGL33aRw+t3nMcDz3+EKdDG9Bw7U3Js3Ffq7FWnFKvK0nDxIdveN+HzpCrRgOVY6pTnNNEeMGiIWPhCG8+txUEuddbx+vY23CFjQOpkVhXaUkexvN3V72tEf+s0Vy3njHw7Fe1htrWr/TpPDaZMNlLABP34Xvd61mlKto1fNo3BQYjHSmpxmBU+2++lyitO6LZ3rOeprzpNFVWx74RjqdPNoxXyndGh3r6+c7sShX/44YcnTqLwgSKE4Morr6S1tZUvv/wS6E44Xl1dTX5+fmzfO+64g4qKCj766CMA3G43eXl5rFy5kqlTp7Jp0yZmz55NbW0tycl9LxCZyNEGY4nKf7DjnSi8zRfk430eajxhDBG9O4oYglA4QkfYQEEh12lC0zQ0VUEROnaTSppNQ1GgukOwozGANxhiuMtCqk1DIGgJKui6gUUV0TsWQ5DlMJHe2YtU1R7gwz1earxhRqZZOb84mbXVHaTZFHY1BRmbaWXmMCcum4mWjiDnFTrJcJjY1xpkyb4Ovq7xI3Sd1oBOSBd8daCD/zk/nxynmTv+URGr5+3T01l84TCSzCq6rvPTj6p5bnMrBclmMpMsfKvYxU/PSOOAJ4w7YFCUakYzmdhY6+OH71RQlGrhtmlp+CMwLS+JfKdGrTtEXUeYsNGZ1kXVCIZ1MuzRXgJNgYgAdxgUYRAMG9R7wzy8qhEDhXGZdm6dkkrYiB5Lp1VjmMtCst2MoUdwmFSCusGOpiB+XeGa8alMfmp7bPhs24/GcvnrFZS1hOJ6VoYnmzm/OJkfTEnn5S1N/GVzKwA/Pj2dSblOlu338rdt3b0TU3JsnDHMxb0zM3slAdY0jbU1HWyr91HtCfNumZu9rWHcYVCFQVGKifvOymL+6GSsJg2zFj2+m+p81HVEeGeXG09YcG6RizGpGnOLnLhDBl9Uenlzl5cl+7xYFT2WemhEqoU/XVbIuYVOAqEIe1uDmFQFp0XFHYb1tX4qW/0YAq4cm8KMZ8tivRNW1WB6roO1ncOWXT0rZkXQcyRu5a1jeXNHK6urOshN0hifaeOH0zLY3Rrh4pf3xN3JGyg03juZX62s45erGuK2d/VOPHv5cE7PdTAq3UpAV/j3ZXX4giFqPRHGZ1k5v8jJ33d5WbrPQ1NHtKfk3rMyuXpcKtPykvjpkmoq24I8dlEen1d4+elHNbE69TyvH98wklkFyTy7sYmvq72cP8LJnuYgH5V7qfIYzBuZxA8mpnBukZNqT5gtDQE+Lvfx2tZmbpuexvlFToa5zDT6DRp8BiZ0xmXYiBjRobgVB3x8UeVn/kgHY9OttAd13t/jwR0STMt1cO04J1eOSUFTFUK6QZ1PsL0xQHV7ALOmoBuCTIeJHS1hxmXYeH5TEx91DsXfMjWNoNCwqvDtUUlcPNLF9P/bzb7WELqiccuUFJ66ZBivbW/l1n8ciDt/KoLF5+di1RRcNhNjMx1UtwfY3xZkeUUH03Ns2C0mdBS21HZg0eCfxkVzSjosJvwRWHPATa03zI6mIIGIgapqGCjsavRh1RRGpJpxmlWGpdroCAne3N5CyBAUuMw8Ni8fTdO44MW9lLcGSDKr3HdWFisP+Hjg3DzOf2FP3HkCuGFqJhPSLZw93M7SfR4uK0kmyaLyy69b+GyfmxpPiPmjXPzb7GxOz09CKCorKtwsWl6HN2ywsynAsGQrF41KYVqWmUyHhtOsUtEe5qNyL2cXusi1KxhCMMxlwWFWWFUTZGKWjUtfifai5iSZKE61YDWbuGpsCt8qsvOPMncsKbiOyjkFSSy9fgQQ/R56an0zL25zMyHTyshkjQZfhDS7xqa6AD5dJcUa7TU0aQreoMHkHDsj0uy0+MJk2VVaAzopVo0cpxkUFcPQ41KGdESgLSTQRPR6vb7Wx7bGIC0Bg8k5Dr4z1sllJcnUd0S46OV97GmLcG6hk1SLoCMkmJRtZVKWjTFZDtJsGt5AmEZfhHyXmfqOCIqqEdYFJsVAiOii2IGIQUhoBCI6Hn+YiBD8enV03t+EnCRevnI4JWkW2gM6u5qj7cNpt3CgLYg3FJ1iENQNFEXFaTOjCp0WX4QWfwSHWSXNYebHS2rRhM5zlxfEsquckj1jd911F++//z4rVqxg+PBoupOuYKympoa8vLzYvrfffjtVVVUsWbIEgKeffponn3yS0tLu5NOTJ09mwYIF3HHHHf0qR6Jg7Msvv2T+/Pmxn//4xz9yww03HLb80rH7p7+V816Zh0cuyONfZmbGNeaIEX3CqTjVMujlKvzddmq9EdbfVsKUfj6dl/f4Npo6UyDtXzCePS1Brv77ftxBg2EuM/82O5vbpqUfNq9bW0DnjZ1tTM+19zuLgSEE2xuDZDo0cp3mfv3uoexsCjAyzRLr5j8Sc1/Yw1cHuueMHfjpeC5/fT8bO9ermj3cwVPfHs6UP3X3KveVdPrLSi8XvLSv13bfA5MRCE7/vzJ2NndP4l9wZiaPXZTfa/9DEUIc8qIqRDRp8zu73VxU7OK6CSn8v2V13H1mJuMzT/y8qz11PXUIEPq3yb3qPfmPu2LH87Zp6Tz17ei17z+W1fHwyvinKQc7UXgiNZ4wT69v5vIxyXGLTl/+WjlL9kaDTqdF5Y1ririguP85iwdKV+L1/5qTw7+fE79yQLMvQtHvdxDsvDtJtM+p4G/b23i3zM1vLsonw3HsC0J8780K3tjZzuMX5XP3mZkDUMKjM6RLWyxYsIB3332XL774Ii6Qyc2NzqGpq6uLC8YaGhrilrZ49tln2bZtGyZTdzUMw+CZZ57pdzCWyBlnnBHLgQm9l9Xoq/zSsXvzOyMwBAkDE5OqDEkgBrDhtjHUeMP9DsQgvi6qAucVOdl251iqPWGm59qPeImLVJvGrdOOblFHVVGYlD3wgcG4owg2/vf8POa+GB16+N7EVHKcZtb8c0mst7g/Swkkaiea0rUQpkLpnWP5tNyDqijMHObAcRTLUByuPIqi8IMp6fxgSnd+vkPl0zyR9WyLierdczmInv+elHViBp35LjP/PTe31/bXri7ivTI35xYmkWRWST5BkogHEzyYkeEw8d0JqbxYGu0t729S8W+KY80PfLALi52k2TQmZFoPv/NxNCTBmBCCBQsW8NZbb7Fs2TKKi4vjXi8uLiY3N5elS5fG5oyFQiGWL1/OI488AkBpaSnr1q1j2bJlpKd3X/za2tqYM2cOW7duTTh/qz/sdjujR4/ud/mlY6coCifiIt6ZDhOZR3k31rM+Xf/MdZoHtIfqZDK7IInW+yaioJBk6Q6ODv7yPyPPzrpa/yEDcC1BwHDw4/0XDmGPx8nmcNmMeq723vPf4QF6QnuwOMwq3x3AL/ZjZVYVwobgghHOhK//+lt50eE1m8YZecdn3bxTze3TM2D64fc73oYkGLvrrrt45ZVXeOedd3C5XNTVRcfBU1JSsNvtKIrCwoULWbx4MSUlJZSUlLB48WIcDgfXX389AM888wwzZsxI+PTirFmzeOaZZ3j88ccPW5auni+v10tjYyObNm3CYrEwYcKEoy6/JCXSs/fmBIwzh4TTcvieiL9dU8TjXzfxk0OkeEm0rJLNJI/y0TrcjVDP1d57HvuBWi7nVLXv7nHsaQlxTmHi3JJpdhNPXDJskEslDYYhCcaeeuopIDpPq6fnnnsulqT7/vvvx+/385Of/ITW1lZmzpzJxx9/jMvlIhQK8dJLL8WWvTjYNddcw0MPPcQjjzyCxXLo4ayeT2uuX7+eV155haKiIvbv339M5Zekg/X8gjvVVt0/FsOTLfz6MPO7Eh1PufDl0Ttc+zT3MUx5cCw2zHVq9voerVO5p/xUN2TDlIejKAqLFi1i0aJFvV6zWCw0NfVe0bzLPffcwz333DNgZRmI35Gk+Hk4Q1iQb6BEw2rf0OxEg6LnJPdEegZj5rhgrPvaePW4ZP5wyck5Z06SBpu8XEnSIFHiesaGrhzfRInmjCWaBC0dmeJUCxtvG0PlT8cnfN3cY3S5Z89YzyOeajMNyNNu0uGtr/Ux4emdPPRV/VAXRTpK3+hgbOLEiTidzoR/Xn755aEunnSKURNM4JcGRqLgNhCRwdixmJRtI6+PITNnj2is52hwz2HKFl/8WkzS4f1mTSPnPr+nV+qlw3n860bKWkL85/J6OXJzkupXMHYkCbKFECxatIj8/Hzsdjtz585l27ZtCd/veCb4DofDXHzxxaSnpxMOhxk+fDi/+93v2LRpE5s2beKKK65I+DsPPPAAkydPJikpifz8fH7wgx9QUxOfTDYYDLJgwQIyMzNJSkriiiuu4MCBA/2qg9Q/h8ulN1gihmBH09HlAu0ZL8g5Y0cuGInmj/yiwtvnPomCsZ6TyQMRg/9cVsew32znq6rBzSH7TZRs6/7q6GuYsrZDBmP99a+f1LK62sevVzcefuceWvzdwVtXsnHp5NKvYOxkSvD9//7f/+O1117j6aefZseOHfzsZz/jrrvuwuPxMHr06ITpCXw+Hxs2bOA//uM/2LBhA2+++Sa7d+/uFbgtXLiQt956i1dffZUVK1bg9Xq57LLLeq2+Kw2MX65qIO1XW/nVqobD73yc3bWkmil/2s1LW9v6/buHmjO2orKDD/e4T5ig80ThDuo4H93Kk+uaufDlfbFEyQdLFNxGDMEbO9owL96C69GtPLSygQZfhGvf2H+cS/3N8NT6JmwPbeHfPquNJT3vktJjPa6up4RXVHbw04+6b1zreiQYlw6v52e/wt2/gKqivXv/NTW+Q+wpnaiOaQX+EznBd35+Pr/4xS+46667YtuuuuoqnE4nL7300hG//9q1a5kxYwYVFRUUFhbS3t5OVlYWL774Itdddx0ANTU1FBQU8MEHH3DxxRf3uw5HSwjBE+uauXJMMq0BnUZfhJJ0K5l2U9y6TT21+CNsrIsmbF2y18O6Wh9XjklhcraN8ZlWzh4eXfxQVaLzP1QlmojXYVZi6z91NZlARKAq0X00te/enoghomlMlGgKkLbO9EfukIECeEIGeU5TbEjEYY6mXmr167QEIkz6Y/cK7O9+dwTzR8enujKEQAHqOiJk2LVYeh6AA+4wWxsDTM62sbneT0V7iGk5dsZn2ugIG6gKBCMCq0lBAWo8EVJtGk6LSmGKGSGivS5dde9aIRtg421jmJBl7Twm0SEaQwgMAf6IQUfYwBc2WHXAR0GymZ99XMOuzlXLW++biNOi4Q3pLPqint+uiT6QclqunQfn5HDJKFfseEYMQZMvQqbDhElVEELwXpkbAUzItJGTFD3fqqIQMaLnRCE6Z8qqKXHrdgkh2NcWiqaiybWTnWTCpil8daCDjrBBcaoFh1nFYVLJ7UwE7wsb2Exq3HpSQkSzIOxuCeINGbQGdMZmWJmeY8feOXM+YgjaAzodYQNPyOD17W2k2jQ21/uZmGXj3rOyErYZIQQC2NYY4NJXy6n1xgdgV4xJ5pnLCki1aVS0h9jZFGREqjmunQCxPIyJvHXtCC4r6TtlWntA59P9XpZVeClINqMpCslWNVa34S4zo9IsOC0a7UGdLIcJq6b0WnxWNwTlbSGqPeFYO893mcl2mGL7hnXBF5VetjUGmTXcwWm5djrCBm2BaIJl7aCepwPuMJvr/dz7SS1FKWauHpfC/FHJDE+Ofn7e3e0m065xdkFS3HwuiAa3SeboOa31RnCHdEanWUmxqnHtZHmFl2+93J3R4MIRTp67oiD2Gf3PZXU81LnSftdK8GP/sJN9PXplzKqC5/5JaGq0XXpDBi6Lyt7WEK7O9Go5SSbManwb1Q1BUBfc+f4Bmv0Rzi1MYlyGjSSLijdkUJRiZky6FYdZRev8PHSEDZLM3XXQO9NEPbmuiYJkCxOzbFw8yhV7urPeG+aJdc00+SLkJJn4p3EpTMqyxY51xBC9jl0inqBOjTfM1oYAo9KtjEq14A0btAd0xmRY+XCPh0nZNopSLPjDBjubg+xrDZLrNHNGnh1r5xivEIKb3qnkte3dyeIXzckh1aZx4QgnRSkWgrpge1OADHs0EB6bYYu1n+Rflsaue3efkcHj86LLXwQjBiFd4AsbJFs17GYVvTODiUVTyO/xtOuLpa0sq/CycEYmkzsXtTaEYNUBH6UNASZmWUmyqBS4LJS3h1hR2cEZeXZKMqwEItFr0j1Lo8F4vtPE5zeNojjVEnduazxhNtRFr8OzhjuYkm2PHWd/OJrw3KIpqEr0HHS1Dd0QRAzBrpYgEUOQZjORYu1K6RdtAwcvEt7qjxAxoje+XddEVYm+98Y6P4u+qOfbo1386PSMI1pi53g7pmDsRE7wnZGRwaOPPsqtt94a2/b973+fVatWHXLZioN98sknzJs3j7a2NpKTk/nss8+48MILaWlpIS0tLbbf1KlTueqqq/iv//qvXu9xvHJTLq/0ccmr+9FEfI+cjkqqTcMXDDMu00azL0J7UCeCSiAieuViS5RLr2t7V345kwpJZhWHWaU1pOALRVB7TNcVKBiKihkjtoSDLgQoCmGh9ipjz/yAB5c9w2GizRfqtR0g3Qp/vHQ4l5WksK81yMOrmnmxtPWo6nS47V11UoWB0xwNON1Bo8+yH6pOKErc9lunpZGZZOX/NrbQnKCuI1MtzMyzsq0pyLbGQKyMDhMEwwe9f2fZM2wq7UE9FoDoihatvxAMc5kpSDazszlEc1CgCqNXHscjrVOKNZprMiKUhHW1aAouM3hD3Xkru85fovMxt9BBriP6xTCn0Mk1f6847HlymCDNplHrjSBQUFQVYfRdpztPS+dHp2Wy8OMaPq/swG7R+PKmYoY5zayp8VHa4OeJ9a1cNCqZ/c1+VlV3dB/Hvsp+0HanRaUw2YxQTUR0g45gmNaAjr9z7lrPOjktKpeVuGjs0Pmk0o8wuusazYsabXsuEyR1fl+aVYX2kMAd5ojbXkGKleEpVsKRMFXtYeo7hw4T1WlchhW7xcS6Wn/C85RqVTkrz0ZZa5Aad4iQcfjP07+elcHfd7RT0R6O+zwpPeqKomI2aWBEiBgi1maO5PPUfa2Jbrd2tr1AxOg+7p11tamC4lRL7IbAZ6hx14gsh4bTotEUhHZ/OJqT16JhiGjezv1ug4iuU5hsQgjwhQ1aAkavOvVVdrXzvHZtt5kUvj3KRWGqhce+bkEoiT9PB5+nru2zhzuYlGXhla2t+MLdbQwhuGiEg5AeDUh7no+Dz9Pk3CRCYZ1dzd0JvgUKuS4LdZ7QUV8jDj5Po9Is7G0N9aqTArEgO1FdVQUMRUM3juxablJBM5mIRAz0Ht+5idpez7JfMsLBy/9UGMvMMRS5KY/6URchBPfccw/nnHNObKX7rsVPD04blJOTQ0VFd+Jnt9vNG2+8wcqVKwG48cYbmT17Nr///e/7neC7LxdffDGPPfYYc+bMYdSoUXz66ae88847/RpKDAQC/PznP+f666+Plauurg6LxRIXiEG0jl31P1hZWRm7d3fftRcWFjJ16lS2bt1KZWVlbPuYMWMYO3Ys69ato7Gxe85AVwb5FStWxA33mgunMDbdSlHjWkzoOEwq/ojBcnUcnoCFi40tUA9dD5d/pE7BSYgL2YUCpNs1hKrhGzELd0sTrobteMPRBuzFxhfaeIaLFiaLKjCACDT6XRzQRlMi6ikR3fWtUjIoVQoZZxygQDR3113JpUzN4zSjnCy6y75dK6TJksWM4A5cRO92BLBGHUWTP5l5xjZMRM9VbpKJC8+fy8Nr2iloWMtzf9/EcwfVaY6xM/beETQ+1qaQiYcZxt7Y9l516tSIi7XaaMbSwEQ1OgE2pAsqOus0URygIHhQnZTedSpVCqhSMplt7MZJ9OJmUmElo/CaUpgT7K7TgQ3wijoOPxauNW3ljHwHeU4Tm+sD/Nk7joY2N+0tOxlO9Px11ckRdjO3s04WTcEtrHxGZ518ves00ug8T+1AO+QrGXjMRUzUD5Cn967TbK2CDMMdexIxUZ3wd54nJZkLjW2kmKO9cYGI4FPG4tctzAx39yCqCnyoTMHex3naWlGHw9iLG9i5Gmb3OE+nqwfISTJR5Q6TnpHJS20FjBb1lITqIARTutqeKGSySND2lDw+vSBAS9MW9qyBO1yCPTipDGfyL39+v7tOQFgdxQtbdObpW7io8zxZNYXW3GkkJyWRX/c13pBBSyD6WXtXTMIietQpAJFAZ9sT7l5tryF7GmZPPQX+cghAaym04sLQRjNFa2CCUo87FP38dX2eRoQqe7U9d4/PU2GymUp3OPF5Ata0j2KFO5l5+hYy6L72faGOI6JauZSt+Luin8bEn6dLRqfy0/JiTIE21L17GQuM5fCfp9Ginq0rNzMOGNejThMTnSeRx5n6vl6fp0ZzFt+z7yfo9+ILCxQFVoiRNBFte6aD6uTXLczo0fZSrCramNnsrHOT3bgZOldEOgeNpmEzuTQvQt3OjVR7w+CN1mmPNp4C0cLkSBV0fuc2+l2Eu657bfHXvX2WEYwMVsbVaY+Sy+4E14j9thE4MvPJrN+IGvLTsQN2ABnqqLg6JXcGKMs6rxEXG911guh52nyghZTKnZzbuS3ZZmF/9pnsOVCHed8mzMDFhztP9aMpMWq5+OBruTf+82RWFXaSwy4Ofd1L14KEOq8da3rWqVmnK5fN15bxpCQ5GN+6KRoWBbrr1Nc1outablGjvc+thqX7utezToaLtWI0JUZdwu+ng9veHjWX3eTRvHcLr75dSp4zGhL19Z07c+ZMsrOzY9O0usydOxe73c6HH34Yd57mz5+P3+9POC3qYEfdM3YiJ/iG6BDq7bffzj/+8Q8URWHUqFF861vf4rnnnsPn8/Hyyy/HDZt++OGHnHvuubGfw+Ew1157LZWVlSxbtiwWjL3yyiv88Ic/JBgMxv1/F110EaNGjeLpp5/uVcbj1TOmadEhuXZ/CJdFjQ0H+CKwsznIhhovOUkmgrrAHzZIspmZV+wi1RofpZtMJoQQRCIR2gI6NZ4ItR1hhqXYaPKGyUlSOeAJoykKKTYNi9mEhsBpVnCaVXQhMES0dyIc0YkYBroR7eK2WUwkWTQ0YSA670ismopJi94Nd9VJCMGu5iC7WiO0BHRM6MwpdBLWBaPSLJhMJrwhnYdW1PKbr5tivRbfGpnCOYVJtPiC/MuMbOo7wmQ6TKQ6LNHEzsLAokWPi0VTo8fdMPCH9NgK7boATTOhYsTORzBisLc1TKrDDIZOaYMfp0Xj4lf2YaDwxPwCbpzooj1gxLrBNVXFpGnoegRNUWJDu113R9P+uCM2TFmcamZPm86PT8/gobnZseEKgICu8M7udqraAozPtFKcaiXfZSYkVJp8YTqCEXKdJgqSo3WMoFHeGqDeE2JkupVmXwSrSSEv2UZ7IMK2Bh8f7nGT7TBx3ggXZxe60BDsbQnE8vHZLRomrft8BCMG7qBBSIDTYiIYClPjjdCVB1woGhOybGhCjxu+9oSh0afT5g+R5YgOPZs1BVWNDiF13QxtqvNT6Q6xpTHMxjofH+3pHp4Zl2HlF3PyQRhcNjp6EdtQ5+OMPAdWi5kXNjdzx3vRm5hfXpjHnadn8tcdbu74R2Wvu979P51Itj2+ve9tC/P9t6vYXt8919VpUWkPwcKZWQxLUvj26GRGplljnzPovus1hEBVFMIiOoRv16LDavtaQ7QHddrDClYNsmwKKVaNfJcZm0nBbDZjGAb+UIT3ytzsag6iCxib5eA745JRiQ7F7GsNkm43k+ows6fJT0g3cAd1bCYVq1ljUrYDYURiQ7zBiEFAhw31QcKRMLOGRVdv31zvx2w2sbslhEM1SLFpjEix4LKoJFnNuKzR3sT2gM4/ytpZus+DjsYtU9P5zt/2xnqovA9MxhOGv+1o4/N97QxLNuMJ6jy/pQ1d0bhpUjLbGvx4Qgb7uno/Duq1uGSUi7vPzMRuMXNmrpWQbmBWFfa0BBGKSltQ4A2G8IUN7v+kFotJ4Z3rRlKSYe913UNR8UcEvmCYkCEIhA2cFo1KbzRI9gTCJJlVxmZaMandn7+le9t4ubSVM/MdnJbrYGaBC1WJntdAxGBTnR93SCc9yUqRy0QgolPnjeAJ6YR1gcNqAcPApEaH/20mlYIUC6l2c+wa3xE20BQFi0mjyhOh1h2gzhvGGza4cISLYckWNE0jHA6zZK+H365pYkVVBzoqc4qcfFXhBmDLHWMYmWbtvMYLKtsCNPsiTMq2ETFgZ0uY696ooNbT/T104+RUnvh2EZf+dR9fVUaHRx86P5dRaVZGpNtp90eocQdRFYXiNAvugM7LOzz8amUdLovKvJFO7j0rG1/YYGNDCH8oglmFq8elYDNFv4MCOgRCYRxmFZOqEOhsewYqqZbo58IXNthc72d6npPfr2si1Qwj0yzkJpmxmhTGZkXXsAuFI5S1BClrCdLki3Dp2DScZpWmjmgbsptUwobApytsbfCTaVOYXZAUu95EUGnzRzAMgwPuEFlJJlTAUE0Ewzp2E7HgChQUVSMciaB33vhbNAWzpjL1z3vY0+zj1asLuawkBRianrGjCsYWLFjA22+/zRdffBGXl/FIhylnzJjBunXrUNXuLyDDMDjzzDP5+uuv+1WWvoKxLoFAgObmZvLz8/n5z3/Oe++9x7Zt2/B4PNTXd6/JMmzYsFgqo3A4zHe/+1327dvHZ599RkZGdxqWoxmmlAZWtSfMzqYAI1ItjEob3OSuXXPGHr8on7vPzOzX757xzG4210dvAz3/OhFFUeKCsFNZqz/Cy1vbCBuC26enH3YOx46mACNSLLE5XNWeMCN+vyNuHwUI/fuUPt/DHYzOsyxOtcinWw/yxNom/mVpDclWleZ7e+f4ffzrRu7/tBaAv1xRwA2T0jjgDlH8RLRX44ZJqdx9ZiYZdtMhc4r2pSvgPZV0hAxSf7UVgO0/GktJ+qGvbSHdYPGKBv73q+jcvd/Oy+cnZ/TvmiTBt/+6j6Xl3lg7Hir9GqY8WRJ892Sz2Rg2bBjhcJg33niD7373uwC4XK6EXYddgVhZWRmff/55XCAGcPrpp2M2m1m6dGnsvWpra9m6dSuPPvrogJVb6tswl3nI06wUpfT//+/51aKp8RPiT3VpdlO/gtvxmba4n3vOtS5wmajyRHjuioJDvkeyVSPZeuig71T1o9MzSLdrnFOQOEdiz8ntps6gqec2VVE4I+/Qq/gfyqkWiAHYzd11TjmCdmnRVH4+OzsWjFllLtaj4uq88XMHh3Y1hH4FYydTgu+vv/6a6upqpk2bRnV1NYsWLcIwDO6///4+3zMSifCd73yHDRs28N5776HreqyO6enpWCwWUlJSuPXWW7n33nvJyMggPT2d++67j8mTJ/Otb32rP4dTOgl99P1i1tb6D/kkXl9kOqTjp2f/4gOzc7huQiqpNhloHS2TqnD9IXoJenbodv37SJ4+lPqmKgrvf6+YjpBBdtKRfTXbTCpXjElmV1OQfxqbcpxL+M00JcdGa0AnJ2mIc4KKfiC62kGvP88991xsH8MwxIMPPihyc3OF1WoVc+bMEaWlpUIIIYLBoMjIyBCPPvpowvf/9a9/LTIzM0UwGDyqshQVFcVeX7ZsmRg/frywWq0iIyND3HTTTaK6uvqQ71leXt5nHT///PPYfn6/X9x9990iPT1d2O12cdlll4nKysrDllk6tc18drcw/e9mYfrfzUI3jKEuzjdKgzccO7Z/XN801MX5xvvzhqbY8X57Z5sQQohWfyS27eZ3Koa4hKcWQ15PTnrHtLSFJElH7uy/lLG2xg9A6N8mH9GkTunItPgj5Dy+HYAnLxnGHadlHOY3pGPxl80t3P5+NOvIO98dwbdHJ+MN6aT9Kppt5XsTU3nxysKhLKIknVTk7GFJGiTxw5QyEBtIcgh4cMXNGVN7zxmT9/iS1D8nZDAmE3xL30QyRjh+5HSlwWWOm8Df+XdcpoDBLpEkndyOetHX4+mDDz4gHE6c1+zgBWUl6WQhA4bjRx7bwdVzAn/XU8E9Hw7WDSRJ6ocTMhgrKioa6iJI0oCT8cLxcyouhTCUevaCdeUD7Dn0LhPeS1L/nJDDlJL0TSQDhuNH9owNrp5r5CVa0kJ2jElS/8hgTJIGiYzFjh9NHtxB1TMAMycIxnQ5aUyS+kUGY5I0SGTvzfEjj+3gipvAn+BbRMZiktQ/MhiTpEEihymPH1VOHh9U8SvwJximlMGYJPWLDMYkaZDI3pvjp+fk8YiMBI477XDDlHICvyT1iwzGJGmQyFhscIRlMHbcmRMs+tqTPAWS1D8yGJOkQSJHKQeH7Bk7/nq2ZYe599eIXNpCkvpHBmOSJH2jyGDs+PMGuyfmpdu1Xq/LeXuS1D8yGJOkQaLIgcpBEdZlMHa8pfUIwBIPU8pzIEn9cUKuwC9JknS0ClIsQ12Eb7ypOXZ+d3E+xamJj3WiAE2SpL7JYEySBomcM3Z8Lfl+McsrOvjB5LShLsop4cenZ/b5mgzGJKl/ZDAmSYNEfj0dXxcWu7iw2DXUxZCIT5ckSdLhyTljkiRJ0oBKtPaYJEl9k8GYJEmSNKASpUiSJKlv8iMjSZIkDYjvT0wF4L5Z2UNbEEk6ycg5Y5I0SOQEfumb7vkrCvjdxcNItfVee0ySpL7JnjFJkiRpQCiKIgMxSToKMhiTpEEiO8YkSZKkRGQwJkmDRA5TSpIkSYnIYEySBolMmShJkiQlIoMxSRokMhiTJEmSEpHBmCQNEpk8WZIkSUpEBmOSNEhkz5gkSZKUiAzGJGmQyGBMkiRJSkQGY5I0SOQwpSRJkpSIDMYkaZDInjFJkiQpERmMSdIgkcGYJEmSlIgMxiRpkMhhSkmSJCkRGYxJ0iCRPWOSJElSIjIYk6RBIoMxSZIkKREZjEnSILGZZHJKSZIkqTcZjEnSIHnykmGUpFv4v8uGD3VRJEmSpBOIIoScVSxJkiRJkjRUZM+YJEmSJEnSEDINdQG+6YQQeDyeoS6GJEmSJElDxOVyoSh9zxuWwdhx5vF4SElJGepiSJIkSZI0RNrb20lOTu7zdTln7DiTPWOSJEmSdGo7XM+YDMYkSZIkSZKGkJzAL0mSJEmSNIRkMCZJkiRJkjSEZDAmSZIkSZI0hGQwJkmSJEmSNIRkMHYS+8Mf/kBxcTE2m43TTz+dL7/8cqiLdNJatGgRiqLE/cnNzY29LoRg0aJF5OfnY7fbmTt3Ltu2bYt7j2AwyIIFC8jMzCQpKYkrrriCAwcODHZVTlhffPEFl19+Ofn5+SiKwttvvx33+kAd49bWVm666SZSUlJISUnhpptuoq2t7TjX7sR0uGN+yy239Gr3Z511Vtw+8pj3z0MPPcSZZ56Jy+UiOzubq666il27dsXtI9v6wDqSY36it3UZjJ2kXnvtNRYuXMgvfvELNm7cyLnnnsv8+fOprKwc6qKdtCZOnEhtbW3sT2lpaey1Rx99lMcee4wnnniCtWvXkpuby0UXXRS3bMnChQt56623ePXVV1mxYgVer5fLLrsMXdeHojonnI6ODqZOncoTTzyR8PWBOsbXX389mzZtYsmSJSxZsoRNmzZx0003Hff6nYgOd8wBLrnkkrh2/8EHH8S9Lo95/yxfvpy77rqL1atXs3TpUiKRCPPmzaOjoyO2j2zrA+tIjjmc4G1dSCelGTNmiB/96Edx28aNGyd+/vOfD1GJTm4PPvigmDp1asLXDMMQubm54uGHH45tCwQCIiUlRTz99NNCCCHa2tqE2WwWr776amyf6upqoaqqWLJkyXEt+8kIEG+99Vbs54E6xtu3bxeAWL16dWyfVatWCUDs3LnzONfqxHbwMRdCiJtvvllceeWVff6OPObHrqGhQQBi+fLlQgjZ1gfDwcdciBO/rcuesZNQKBRi/fr1zJs3L277vHnzWLly5RCV6uRXVlZGfn4+xcXFfO9732Pfvn0AlJeXU1dXF3e8rVYr5513Xux4r1+/nnA4HLdPfn4+kyZNkufkCAzUMV61ahUpKSnMnDkzts9ZZ51FSkqKPA99WLZsGdnZ2YwZM4bbb7+dhoaG2GvymB+79vZ2ANLT0wHZ1gfDwce8y4nc1mUwdhJqampC13VycnLitufk5FBXVzdEpTq5zZw5kxdeeIGPPvqIP//5z9TV1XH22WfT3NwcO6aHOt51dXVYLBbS0tL63Efq20Ad47q6OrKzs3u9f3Z2tjwPCcyfP5+XX36Zzz77jF//+tesXbuWCy64gGAwCMhjfqyEENxzzz2cc845TJo0CZBt/XhLdMzhxG/rMjflSezg1ApCiEOmW5D6Nn/+/Ni/J0+ezKxZsxg1ahTPP/98bJLn0RxveU76ZyCOcaL95XlI7Lrrrov9e9KkSZxxxhkUFRXx/vvvc/XVV/f5e/KYH5m7776bLVu2sGLFil6vybZ+fPR1zE/0ti57xk5CmZmZaJrWKxJvaGjodbclHZ2kpCQmT55MWVlZ7KnKQx3v3NxcQqEQra2tfe4j9W2gjnFubi719fW93r+xsVGehyOQl5dHUVERZWVlgDzmx2LBggW8++67fP755wwfPjy2Xbb146evY57IidbWZTB2ErJYLJx++uksXbo0bvvSpUs5++yzh6hU3yzBYJAdO3aQl5dHcXExubm5ccc7FAqxfPny2PE+/fTTMZvNcfvU1taydetWeU6OwEAd41mzZtHe3s6aNWti+3z99de0t7fL83AEmpubqaqqIi8vD5DH/GgIIbj77rt58803+eyzzyguLo57Xbb1gXe4Y57ICdfWj2n6vzRkXn31VWE2m8Uzzzwjtm/fLhYuXCiSkpLE/v37h7poJ6V7771XLFu2TOzbt0+sXr1aXHbZZcLlcsWO58MPPyxSUlLEm2++KUpLS8X3v/99kZeXJ9xud+w9fvSjH4nhw4eLTz75RGzYsEFccMEFYurUqSISiQxVtU4oHo9HbNy4UWzcuFEA4rHHHhMbN24UFRUVQoiBO8aXXHKJmDJlili1apVYtWqVmDx5srjssssGvb4ngkMdc4/HI+69916xcuVKUV5eLj7//HMxa9YsMWzYMHnMj8GPf/xjkZKSIpYtWyZqa2tjf3w+X2wf2dYH1uGO+cnQ1mUwdhJ78sknRVFRkbBYLOK0006Le4xX6p/rrrtO5OXlCbPZLPLz88XVV18ttm3bFnvdMAzx4IMPitzcXGG1WsWcOXNEaWlp3Hv4/X5x9913i/T0dGG328Vll10mKisrB7sqJ6zPP/9cAL3+3HzzzUKIgTvGzc3N4oYbbhAul0u4XC5xww03iNbW1kGq5YnlUMfc5/OJefPmiaysLGE2m0VhYaG4+eabex1Pecz7J9HxBsRzzz0X20e29YF1uGN+MrR1pbMikiRJkiRJ0hCQc8YkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShpAMxiRJkiRJkoaQDMYkSZIkSZKGkAzGJEmSJEmShtD/D17NLmLrkmFUAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 600x120 with 1 Axes>"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "egm_figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:>"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "egm_axes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpolate electrical data onto the surface mesh\n",
+    "The bipolar voltage we visualised above (`case.fields.bipolar_voltage`) was calculated by CARTO and then exported from the mapping system.\n",
+    "\n",
+    "However, it is not known what interpolation method is used by CARTO (or other system vendors) nor the interpolation parameters.\n",
+    "\n",
+    "We can use OpenEP to re-interpolate electrical data onto the surface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bipolar_voltage = openep.case.interpolate_voltage_onto_surface(case=case)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "98b1a90f7977464c911da87f6c059a66",
+       "model_id": "dfc1159d056949eab33bfd8f940474cf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -362,7 +532,42 @@
     }
    ],
    "source": [
-    "plotter = openep.draw.draw_map(mesh, field=case.fields.bipolar_voltage, add_mesh_kws={'cmap': 'Plasma'})\n",
+    "plotter = openep.draw.draw_map(\n",
+    "    mesh=mesh,\n",
+    "    field=case.fields.bipolar_voltage,\n",
+    "    add_mesh_kws=dict(cmap='Turbo'),\n",
+    "    plotter=plotter,\n",
+    ")\n",
+    "plotter.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "90beb7dc2a914d37aec9d01015ecef1d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(VBox(children=(HTML(value='<h3></h3>'), Dropdown(description='Colormap:', options={'BrBG':…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plotter = openep.draw.draw_map(\n",
+    "    mesh=mesh,\n",
+    "    field=bipolar_voltage,\n",
+    "    add_mesh_kws=dict(cmap='Turbo'),\n",
+    "    plotter=plotter,\n",
+    ")\n",
     "plotter.show()\n"
    ]
   },
@@ -376,7 +581,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('openep-tutorials')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/getting_started.py
+++ b/notebooks/getting_started.py
@@ -1,0 +1,8 @@
+import pyvista
+import openep
+from openep._datasets.openep_datasets import DATASET_2
+
+case = openep.load_openep_mat(DATASET_2)
+mesh = case.create_mesh()
+plotter = openep.draw.draw_map(mesh, field=case.fields.bipolar_voltage)
+plotter.show()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import glob
 from setuptools import setup, find_packages
 from pkg_resources import parse_requirements
 
@@ -20,6 +21,7 @@ setup(
     author="Steven Williams",
     author_email="steven.williams@ed.ac.uk",
     packages=find_packages(),
+    py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob.glob('openep/*.py')],
     install_requires=requirements,
     url='https://github.com/openep/openep-gui',
     project_urls={
@@ -27,4 +29,8 @@ setup(
         'Issue Tracker': 'https://github.com/openep/openep-py/issues',
     },
     python_requires='>=3.8',
+    include_package_data=True,
+    package_data={
+        'openep/_datasets/OpenEP-MATLAB': ['_datasets/OpenEP-MATLAB/*.mat']
+    }
 )


### PR DESCRIPTION
Changes made:
* Added a top-level `notebooks` folder for tutorial-style notebooks
* Added a `environment.yml` file for creating a conda environment in which to run the tutorial notebooks
* Added a notebook on getting started with openep-py (loading datasets, interpolating voltage onto surface, voxelising a surface mesh, visualising meshes)

Note, if the `notebook` folder and it's contents is moved to its own repository (e.g. `openep-tutorials`), then a mybinder could be created (https://mybinder.org/) that will allow the notebooks to be launched and run in a browser with needing to install openep-py.